### PR TITLE
feat(lib): mkManifest + projectRoot + types + manifest.json v1（1a）

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,7 +2,9 @@
   "nodes": {
     "flake-parts": {
       "inputs": {
-        "nixpkgs-lib": "nixpkgs-lib"
+        "nixpkgs-lib": [
+          "nixpkgs"
+        ]
       },
       "locked": {
         "lastModified": 1778716662,
@@ -15,6 +17,92 @@
       "original": {
         "owner": "hercules-ci",
         "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "haumea": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781356213,
+        "narHash": "sha256-Fz4MPqynn8ZfBYNOAsbnG/BIeU0rEs9ANz563+qkELU=",
+        "owner": "nix-community",
+        "repo": "haumea",
+        "rev": "fc881eb4603312ce8624a65ab7294cbc7d3e08ff",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "haumea",
+        "type": "github"
+      }
+    },
+    "namaka": {
+      "inputs": {
+        "haumea": [
+          "haumea"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781052900,
+        "narHash": "sha256-LKLdSa+ZLvpnZRuo2uoUCYARGS6YhqlbF2yRyiCmDs4=",
+        "owner": "nix-community",
+        "repo": "namaka",
+        "rev": "82b8062497f786f40ca6b5c107d0bc1d911aea2f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "namaka",
+        "type": "github"
+      }
+    },
+    "nix-github-actions": {
+      "inputs": {
+        "nixpkgs": [
+          "nix-unit",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1737420293,
+        "narHash": "sha256-F1G5ifvqTpJq7fdkT34e/Jy9VCyzd5XfJ9TO8fHhJWE=",
+        "owner": "nix-community",
+        "repo": "nix-github-actions",
+        "rev": "f4158fa080ef4503c8f4c820967d946c2af31ec9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nix-github-actions",
+        "type": "github"
+      }
+    },
+    "nix-unit": {
+      "inputs": {
+        "nix-github-actions": "nix-github-actions",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "treefmt-nix": "treefmt-nix"
+      },
+      "locked": {
+        "lastModified": 1779338171,
+        "narHash": "sha256-affUbv/bwE8SLGhuWKniDr7SVO+Lo1XEPjCZdyU5kgQ=",
+        "owner": "nix-community",
+        "repo": "nix-unit",
+        "rev": "6ab1f232562a01d18b40d5ed6a58718c4f3a74bc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nix-unit",
         "type": "github"
       }
     },
@@ -34,29 +122,38 @@
         "type": "github"
       }
     },
-    "nixpkgs-lib": {
-      "locked": {
-        "lastModified": 1777168982,
-        "narHash": "sha256-GOkGPcboWE9BmGCRMLX3worL4EMnsnG8MyKmXNeYuhQ=",
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "rev": "f5901329dade4a6ea039af1433fb087bd9c1fe14",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
         "flake-parts": "flake-parts",
+        "haumea": "haumea",
+        "namaka": "namaka",
+        "nix-unit": "nix-unit",
         "nixpkgs": "nixpkgs",
-        "treefmt-nix": "treefmt-nix"
+        "treefmt-nix": "treefmt-nix_2"
       }
     },
     "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nix-unit",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775636079,
+        "narHash": "sha256-pc20NRoMdiar8oPQceQT47UUZMBTiMdUuWrYu2obUP0=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "790751ff7fd3801feeaf96d7dc416a8d581265ba",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "treefmt-nix_2": {
       "inputs": {
         "nixpkgs": [
           "nixpkgs"

--- a/flake.nix
+++ b/flake.nix
@@ -3,18 +3,42 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-    flake-parts.url = "github:hercules-ci/flake-parts";
+    flake-parts = {
+      url = "github:hercules-ci/flake-parts";
+      # nix-unit の flake-parts モジュールは nixpkgs-lib follows を要求する。
+      inputs.nixpkgs-lib.follows = "nixpkgs";
+    };
     treefmt-nix = {
       url = "github:numtide/treefmt-nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    # lib 評価テスト（→ ADR-0006, ADR-0012）。
+    nix-unit = {
+      url = "github:nix-community/nix-unit";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    haumea = {
+      url = "github:nix-community/haumea";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    namaka = {
+      url = "github:nix-community/namaka";
+      inputs.haumea.follows = "haumea";
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };
 
   outputs =
     inputs@{ flake-parts, ... }:
+    let
+      # flake output（lib）とテスト入力で同一実体を共有する（self 参照を避ける）。
+      nputLib = import ./lib;
+    in
     flake-parts.lib.mkFlake { inherit inputs; } {
       imports = [
         inputs.treefmt-nix.flakeModule
+        inputs.nix-unit.modules.flake.default
       ];
       systems = [
         "x86_64-linux"
@@ -32,9 +56,39 @@
               package = pkgs.nixfmt;
             };
           };
+
+          # nix-unit: デフォルト適用・manifest 構造の不変条件をアサート（→ ADR-0006, ADR-0010）。
+          # flake-parts モジュールが checks 派生を組み `nix flake check` に載せる。
+          # check は sandbox 内で `nix-unit --flake ${self}#tests.systems.<system>` を回し flake を
+          # 再 import するため、全 direct input を override-input でローカルに渡しオフライン評価する。
+          nix-unit.inputs = {
+            inherit (inputs)
+              nixpkgs
+              flake-parts
+              treefmt-nix
+              nix-unit
+              haumea
+              namaka
+              ;
+          };
+          nix-unit.tests = import ./tests/nix-unit.nix {
+            inherit (pkgs) lib;
+            nput = nputLib;
+          };
+
+          # namaka: manifest.json 全体（= normalizeManifest 出力）のスナップショット回帰（→ ADR-0006）。
+          # namaka.lib.load は不一致で throw・成功で {} を返す純評価。seq で評価を強制し
+          # check 派生に紐付けて `nix flake check` に載せる。
+          checks.namaka = builtins.seq (inputs.namaka.lib.load {
+            src = ./tests/namaka;
+            inputs = {
+              inherit (pkgs) lib;
+              nput = nputLib;
+            };
+          }) (pkgs.runCommandLocal "nput-namaka-snapshots" { } "touch \"$out\"");
         };
       flake = {
-        lib = import ./lib;
+        lib = nputLib;
         homeManagerModules.default = ./modules/home-manager.nix;
         nixosModules.default = ./modules/nixos.nix;
         darwinModules.default = ./modules/nix-darwin.nix;

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -1,1 +1,26 @@
-{ }
+# nput lib 公開 API のまとめ（→ docs/design.md「flake.nix outputs 設計」）。
+#
+# nixpkgs.lib のみ依存（home-manager / NixOS / nix-darwin は引かない・→ ADR-0006）。
+# マーカー群は純 attrset 構築子で依存なし。mkManifest は引数 attrset の `pkgs` から
+# linkFarm 相当（runCommandLocal）と `pkgs.lib` を得て derivation を組む。
+let
+  markers = import ./out-of-store.nix;
+  manifest = import ./manifest.nix;
+in
+{
+  # lib.mkManifest { pkgs, root, entries } -> derivation（manifest.json + symlink farm・→ ADR-0006, ADR-0023）
+  inherit (manifest) mkManifest;
+
+  # 検査・正規化の純データ関数。nix-unit / namaka の単体対象 + 将来 modules から再利用（→ ADR-0010）。
+  # normalizeManifest { lib, root, entries } -> attrset
+  inherit (manifest) normalizeManifest;
+
+  # lib.mkOutOfStoreSymlink "/abs/path" -> marker（src に渡す・→ ADR-0001）
+  # lib.projectRoot / homeRoot / systemRoot -> marker（root に渡す・→ ADR-0004, ADR-0005, ADR-0007）
+  inherit (markers)
+    mkOutOfStoreSymlink
+    projectRoot
+    homeRoot
+    systemRoot
+    ;
+}

--- a/lib/manifest.nix
+++ b/lib/manifest.nix
@@ -1,0 +1,184 @@
+# normalizeManifest（純データ・検査ゲート）+ mkManifest（derivation 生成）（→ ADR-0006, ADR-0010, ADR-0016, ADR-0019, ADR-0023）。
+#
+# 2 段に分ける（→ ADR-0010）:
+#   - normalizeManifest { lib, root, entries } -> attrset
+#       evalModules 検査・デフォルト適用・パス安全性 / クロスフィールド throwIf・marker タグ → clean enum 変換。
+#       derivation の外に出すことで nix-unit / namaka の単体対象にする。
+#   - mkManifest { pkgs, root, entries } -> derivation
+#       normalizeManifest の出力を manifest.json に書き、store src への symlink farm を組む。
+#
+# 本スライスの最小スコープ: root = projectRoot のみ / src = path・set の store-backed symlink entry のみ
+# （→ Issue #5）。型・throwIf は将来スライス（home / copy / out-of-store）も見据えて完全形で定義する。
+let
+  # ---- パス安全性（→ ADR-0019）----------------------------------------------
+  # target は root 相対・subpath は src 内相対。絶対パス（`/` 始まり）と
+  # `..` で外へ出るパスを eval 時に拒否する。root の実体値（実行時解決）に依らず静的に判定可能。
+  pathChecks =
+    lib:
+    let
+      isAbsolute = lib.hasPrefix "/";
+      # `..` を辿って深さが負になる（base の外へ出る）かを判定する。
+      escapesBase =
+        p:
+        let
+          comps = lib.filter (c: c != "" && c != ".") (lib.splitString "/" p);
+          step =
+            acc: c:
+            if acc.bad then
+              acc
+            else if c == ".." then
+              {
+                bad = acc.depth == 0;
+                depth = if acc.depth == 0 then 0 else acc.depth - 1;
+              }
+            else
+              {
+                bad = false;
+                depth = acc.depth + 1;
+              };
+        in
+        (lib.foldl' step {
+          bad = false;
+          depth = 0;
+        } comps).bad;
+    in
+    {
+      isUnsafe = p: isAbsolute p || escapesBase p;
+    };
+
+  normalizeManifest =
+    {
+      lib,
+      root,
+      entries ? { },
+    }:
+    let
+      t = import ./types.nix lib;
+      checks = pathChecks lib;
+
+      # 両経路（CLI 直呼び / モジュール）で検査を効かせるため mkManifest 自身が evalModules を回す（→ ADR-0010）。
+      evaluated = lib.evalModules {
+        modules = [
+          {
+            options = {
+              root = lib.mkOption { type = t.rootType; };
+              entries = lib.mkOption {
+                type = t.entriesType;
+                default = { };
+              };
+            };
+            config = { inherit root entries; };
+          }
+        ];
+      };
+      cfg = evaluated.config;
+
+      # root の marker タグ → clean enum（→ ADR-0010）。
+      rootInfo =
+        if t.isRootMarker cfg.root then
+          { rootKind = cfg.root.kind; }
+        else
+          {
+            rootKind = "fixed";
+            root = cfg.root;
+          };
+
+      # entry の marker タグ → clean enum + 解決済み src 文字列（→ ADR-0010）。
+      # 属性キー = target なので attrNames の辞書順で決定的に配列化する（Go は配列を読む・→ ADR-0014）。
+      resolveEntry =
+        e:
+        let
+          srcInfo =
+            if t.isOutOfStoreMarker e.src then
+              {
+                srcKind = "outOfStore";
+                src = e.src.path;
+              }
+            else
+              {
+                srcKind = "store";
+                src = toString e.src;
+              };
+        in
+        {
+          inherit (srcInfo) srcKind src;
+          inherit (e) subpath target method;
+        };
+
+      normEntries = map (key: resolveEntry cfg.entries.${key}) (lib.attrNames cfg.entries);
+
+      targets = map (e: e.target) normEntries;
+
+      # ---- クロスフィールド / パス検査（→ ADR-0013, ADR-0019, ADR-0024）-------
+      assertions = lib.concatLists [
+        # systemRoot は未実装（→ ADR-0013）。
+        (lib.optional (
+          rootInfo.rootKind == "system"
+        ) "nput: root = systemRoot (system mode) は未実装です（→ ADR-0013）")
+        # method = "copy" かつ out-of-store marker は意図矛盾（→ ADR-0013）。
+        (map (
+          e: "nput: method = \"copy\" と out-of-store marker は同時指定できません（target: ${e.target}・→ ADR-0013）"
+        ) (lib.filter (e: e.method == "copy" && e.srcKind == "outOfStore") normEntries))
+        # 別キーで target を同値に明示上書きした衝突（→ ADR-0024）。
+        (lib.optional (
+          lib.length targets != lib.length (lib.unique targets)
+        ) "nput: 複数 entry が同一 target に解決されました（→ ADR-0024）")
+        # target / subpath の絶対パス・`..` エスケープ拒否（→ ADR-0019）。
+        (map (e: "nput: target が不正です（絶対パスまたは `..` で root の外）: ${e.target}（→ ADR-0019）") (
+          lib.filter (e: checks.isUnsafe e.target) normEntries
+        ))
+        (map (
+          e: "nput: subpath が不正です（絶対パスまたは `..` で src の外）: ${e.subpath}（target: ${e.target}・→ ADR-0019）"
+        ) (lib.filter (e: checks.isUnsafe e.subpath) normEntries))
+      ];
+
+      result = {
+        schemaVersion = 1;
+        root = rootInfo;
+        entries = normEntries;
+      };
+    in
+    # 全 assertion を throwIf で評価ゲートに通す。
+    lib.foldl' (acc: msg: lib.throwIf true msg acc) result assertions;
+
+  # symlink farm の GC アンカー名 = target の sha256 短縮 hex（固定長・FS 安全・衝突不可能・→ ADR-0016）。
+  anchorName = lib: target: lib.substring 0 32 (builtins.hashString "sha256" target);
+
+  mkManifest =
+    {
+      pkgs,
+      root,
+      entries ? { },
+    }:
+    let
+      lib = pkgs.lib;
+      norm = normalizeManifest { inherit lib root entries; };
+
+      manifestJson = pkgs.writeText "manifest.json" (builtins.toJSON norm);
+
+      # farm アンカーは「store-backed かつ method = symlink」の entry 限定（→ ADR-0016, ADR-0019）。
+      # out-of-store / copy は farm アンカーを持たない（copy は世代外・place-once で store から独立）。
+      farmEntries = lib.filter (e: e.srcKind == "store" && e.method == "symlink") norm.entries;
+
+      anchorLines = lib.concatMapStringsSep "\n" (
+        e: "ln -s ${lib.escapeShellArg e.src} \"$out/${anchorName lib e.target}\""
+      ) farmEntries;
+    in
+    # derivation は manifest.json（engine の入力契約）+ store src への symlink farm（GC アンカー）を含む（→ ADR-0006）。
+    pkgs.runCommandLocal "nput-manifest"
+      {
+        # CLI が build 前に `nix eval … .rootKind` で読む（→ ADR-0023）。
+        passthru = {
+          inherit (norm.root) rootKind;
+        }
+        // lib.optionalAttrs (norm.root ? root) { inherit (norm.root) root; };
+      }
+      ''
+        mkdir -p "$out"
+        cp ${manifestJson} "$out/manifest.json"
+        ${anchorLines}
+      '';
+in
+{
+  inherit normalizeManifest mkManifest;
+}

--- a/lib/out-of-store.nix
+++ b/lib/out-of-store.nix
@@ -1,0 +1,30 @@
+# マーカー構築子（→ ADR-0001, ADR-0004, ADR-0005, ADR-0007, ADR-0010）。
+#
+# マーカーは「実行時解決の種別を運ぶ入れ物」であり、パス文字列を返す糖衣ではない。
+# `src`（derivation）も marker もどちらも attrset で構造判別できないため、marker には
+# `_nputMarker` 判別タグを持たせ、`lib/types.nix` の custom optionType の `check` が判別する。
+# `_nputMarker` は Nix 評価内で完結させ `manifest.json` には漏らさない（Go 契約は clean enum・→ ADR-0010）。
+#
+# 依存なし（nixpkgs.lib すら要らない純 attrset 構築子）。
+{
+  # ローカルパスへの out-of-store symlink を表すマーカー（→ ADR-0001）。
+  # 引数は Nix 評価時に確定する絶対パスの文字列。実際の link 生成は engine の実行時責務。
+  mkOutOfStoreSymlink = path: {
+    _nputMarker = "outOfStore";
+    inherit path;
+  };
+
+  # root マーカー（→ ADR-0004 改訂, ADR-0005, ADR-0007）。kind を運ぶだけで、実体パス解決は engine の実行時責務。
+  projectRoot = {
+    _nputMarker = "root";
+    kind = "project";
+  };
+  homeRoot = {
+    _nputMarker = "root";
+    kind = "home";
+  };
+  systemRoot = {
+    _nputMarker = "root";
+    kind = "system";
+  };
+}

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -1,0 +1,85 @@
+# entry submodule + srcType / rootType / marker custom type（→ ADR-0010, ADR-0014）。
+#
+# `mkManifest` の `evalModules` と `modules/common.nix` の `attrsOf (submodule …)` で
+# 共有できるよう、nixpkgs.lib を受け取り型定義一式を返す純関数として書く。
+# `lib.types` / `mkOption` / `evalModules` は nixpkgs.lib のコアなので
+# 「lib は nixpkgs.lib のみ依存」を満たす（home-manager / NixOS / nix-darwin は引かない）。
+lib:
+let
+  inherit (lib) types mkOption mkDefault;
+  inherit (lib.options) mergeEqualOption;
+  inherit (builtins) isAttrs isString;
+
+  # marker 判別（`out-of-store.nix` が付ける `_nputMarker` タグで見分ける）。
+  isOutOfStoreMarker = x: isAttrs x && (x._nputMarker or null) == "outOfStore";
+  isRootMarker = x: isAttrs x && (x._nputMarker or null) == "root";
+
+  # store-backed src: path / derivation / flake input（`{ outPath = …; }`）を 1 ブランチに集約。
+  # 素の文字列は拒否し out-of-store の暗黙分岐を型で禁ずる（→ ADR-0001）。
+  # path と set は挙動が同一（ともに store link）なので型レベルで分けない（→ ADR-0010）。
+  isStoreBacked =
+    x:
+    lib.isPath x || lib.isDerivation x || (isAttrs x && x ? outPath && (x._nputMarker or null) == null);
+
+  # srcType = either storeBacked outOfStoreMarker（→ ADR-0010）。
+  srcType = types.mkOptionType {
+    name = "nputSrc";
+    description = "store-backed source (path / derivation / flake input) or out-of-store marker";
+    check = x: isStoreBacked x || isOutOfStoreMarker x;
+    merge = mergeEqualOption;
+  };
+
+  # rootType = either str rootMarker（→ ADR-0010）。`mkManifest` 専用で modules は共有しない
+  # （modules は root を pin する・→ ADR-0003）。
+  rootType = types.mkOptionType {
+    name = "nputRoot";
+    description = "absolute path string or root marker (projectRoot / homeRoot / systemRoot)";
+    check = x: isString x || isRootMarker x;
+    merge = mergeEqualOption;
+  };
+
+  # entry submodule（→ ADR-0014）。属性キー = target が識別子。strict（未知キー拒否）。
+  entryModule =
+    { name, ... }:
+    {
+      options = {
+        src = mkOption {
+          type = srcType;
+          description = "配置元。store-backed（path / set）または out-of-store marker。";
+        };
+        subpath = mkOption {
+          type = types.str;
+          default = ".";
+          description = "src 内の相対パス。省略 = リポジトリ全体（→ ADR-0008）。";
+        };
+        target = mkOption {
+          type = types.str;
+          # 既定 = 属性キー（→ ADR-0014）。
+          default = name;
+          defaultText = "属性キー";
+          description = "root 相対の配置先。省略時は属性キー。";
+        };
+        method = mkOption {
+          type = types.enum [
+            "symlink"
+            "copy"
+          ];
+          default = "symlink";
+          description = "配置方法（旧名 mode・→ ADR-0015）。";
+        };
+      };
+    };
+
+  entriesType = types.attrsOf (types.submodule entryModule);
+in
+{
+  inherit
+    isOutOfStoreMarker
+    isRootMarker
+    isStoreBacked
+    srcType
+    rootType
+    entryModule
+    entriesType
+    ;
+}

--- a/tests/namaka/_snapshots/manifest-project
+++ b/tests/namaka/_snapshots/manifest-project
@@ -1,0 +1,2 @@
+#json
+{"entries":[{"method":"symlink","src":"/nix/store/00000000000000000000000000000000-fake-src","srcKind":"store","subpath":"skills/nix","target":".claude/skills/nix"},{"method":"symlink","src":"/nix/store/11111111111111111111111111111111-other","srcKind":"store","subpath":".","target":".config/foo"}],"root":{"rootKind":"project"},"schemaVersion":1}

--- a/tests/namaka/manifest-project/expr.nix
+++ b/tests/namaka/manifest-project/expr.nix
@@ -1,0 +1,22 @@
+# namaka: manifest.json 全体（= normalizeManifest 出力）のスナップショット回帰（→ ADR-0006）。
+# src は toString が安定する fake な flake-input 相当（`{ outPath = …; }`）を使い、
+# store hash 揺れでスナップショットが壊れないようにする。
+{ lib, nput }:
+nput.normalizeManifest {
+  inherit lib;
+  root = nput.projectRoot;
+  entries = {
+    ".claude/skills/nix" = {
+      src = {
+        outPath = "/nix/store/00000000000000000000000000000000-fake-src";
+      };
+      subpath = "skills/nix";
+    };
+    # subpath / target / method 省略 → デフォルト適用
+    ".config/foo" = {
+      src = {
+        outPath = "/nix/store/11111111111111111111111111111111-other";
+      };
+    };
+  };
+}

--- a/tests/nix-unit.nix
+++ b/tests/nix-unit.nix
@@ -1,0 +1,214 @@
+# nix-unit: normalizeManifest のデフォルト適用・manifest 構造の不変条件・検査ゲートを
+# アサートする（→ ADR-0006, ADR-0010, ADR-0013, ADR-0019, ADR-0024）。
+#
+# store パスの hash 揺れを避けるため src には toString が安定する fake な flake-input 相当
+# （`{ outPath = …; }`）を使う。これは srcType の store-backed 判定（`? outPath`）を通る正当な test double。
+{ lib, nput }:
+let
+  fakeSrc = {
+    outPath = "/nix/store/00000000000000000000000000000000-fake-src";
+  };
+  norm = root: entries: nput.normalizeManifest { inherit lib root entries; };
+
+  basic = norm nput.projectRoot {
+    ".claude/skills/nix" = {
+      src = fakeSrc;
+      subpath = "skills/nix";
+    };
+  };
+in
+{
+  # ---- manifest 構造の不変条件 ----------------------------------------------
+  testSchemaVersion = {
+    expr = basic.schemaVersion;
+    expected = 1;
+  };
+
+  testRootKindProject = {
+    expr = basic.root.rootKind;
+    expected = "project";
+  };
+
+  # project は実行時解決なので固定 root パスを持たない（→ ADR-0010）。
+  testProjectHasNoFixedRoot = {
+    expr = basic.root ? root;
+    expected = false;
+  };
+
+  testStoreEntry = {
+    expr = builtins.head basic.entries;
+    expected = {
+      srcKind = "store";
+      src = "/nix/store/00000000000000000000000000000000-fake-src";
+      subpath = "skills/nix";
+      target = ".claude/skills/nix";
+      method = "symlink";
+    };
+  };
+
+  # ---- デフォルト適用（subpath="." / target=属性キー / method="symlink"）-----
+  testDefaultsApplied = {
+    expr =
+      builtins.head
+        (norm nput.projectRoot {
+          ".config/foo" = {
+            src = fakeSrc;
+          };
+        }).entries;
+    expected = {
+      srcKind = "store";
+      src = "/nix/store/00000000000000000000000000000000-fake-src";
+      subpath = ".";
+      target = ".config/foo";
+      method = "symlink";
+    };
+  };
+
+  # 明示上書きが反映される
+  testExplicitOverrides = {
+    expr =
+      builtins.head
+        (norm nput.projectRoot {
+          "label" = {
+            src = fakeSrc;
+            target = ".config/bar";
+            subpath = "sub/dir";
+            method = "copy";
+          };
+        }).entries;
+    expected = {
+      srcKind = "store";
+      src = "/nix/store/00000000000000000000000000000000-fake-src";
+      subpath = "sub/dir";
+      target = ".config/bar";
+      method = "copy";
+    };
+  };
+
+  # entries は target（属性キー）の辞書順で決定的に配列化される（→ ADR-0014, ADR-0016）。
+  testEntriesSortedByTarget = {
+    expr =
+      map (e: e.target)
+        (norm nput.projectRoot {
+          "b" = {
+            src = fakeSrc;
+          };
+          "a" = {
+            src = fakeSrc;
+          };
+          "c" = {
+            src = fakeSrc;
+          };
+        }).entries;
+    expected = [
+      "a"
+      "b"
+      "c"
+    ];
+  };
+
+  # ---- 検査ゲート（eval 時に throw する不変条件）----------------------------
+  # systemRoot は未実装（→ ADR-0013）。
+  testSystemRootUnimplemented = {
+    expr =
+      (norm nput.systemRoot {
+        "x" = {
+          src = fakeSrc;
+        };
+      }).entries;
+    expectedError.type = "ThrownError";
+    expectedError.msg = "system mode";
+  };
+
+  # method = "copy" かつ out-of-store marker は意図矛盾（→ ADR-0013）。
+  testCopyOutOfStoreRejected = {
+    expr =
+      (norm nput.projectRoot {
+        ".config/x" = {
+          src = nput.mkOutOfStoreSymlink "/home/me/dots";
+          method = "copy";
+        };
+      }).entries;
+    expectedError.type = "ThrownError";
+    expectedError.msg = "out-of-store";
+  };
+
+  # target が絶対パス（→ ADR-0019）。
+  testAbsoluteTargetRejected = {
+    expr =
+      (norm nput.projectRoot {
+        "/etc/x" = {
+          src = fakeSrc;
+        };
+      }).entries;
+    expectedError.type = "ThrownError";
+    expectedError.msg = "target";
+  };
+
+  # target が `..` で root の外（→ ADR-0019）。
+  testEscapingTargetRejected = {
+    expr =
+      (norm nput.projectRoot {
+        "../../etc/x" = {
+          src = fakeSrc;
+        };
+      }).entries;
+    expectedError.type = "ThrownError";
+    expectedError.msg = "target";
+  };
+
+  # subpath が `..` で src の外（→ ADR-0019）。
+  testEscapingSubpathRejected = {
+    expr =
+      (norm nput.projectRoot {
+        ".config/x" = {
+          src = fakeSrc;
+          subpath = "../escape";
+        };
+      }).entries;
+    expectedError.type = "ThrownError";
+    expectedError.msg = "subpath";
+  };
+
+  # 別キーで target を同値に明示上書きした衝突（→ ADR-0024）。
+  testDuplicateTargetRejected = {
+    expr =
+      (norm nput.projectRoot {
+        "a" = {
+          src = fakeSrc;
+          target = ".config/same";
+        };
+        "b" = {
+          src = fakeSrc;
+          target = ".config/same";
+        };
+      }).entries;
+    expectedError.type = "ThrownError";
+    expectedError.msg = "同一 target";
+  };
+
+  # 未知キー（タイポ / 旧名）は submodule strict で弾く（→ ADR-0008, ADR-0010）。
+  testUnknownKeyRejected = {
+    expr =
+      (norm nput.projectRoot {
+        ".config/x" = {
+          src = fakeSrc;
+          source = "skills/nix"; # 旧名（正しくは subpath）
+        };
+      }).entries;
+    expectedError.type = "ThrownError";
+    expectedError.msg = "source";
+  };
+
+  # 素の文字列 src は拒否（out-of-store は marker で opt-in・→ ADR-0001）。
+  testStringSrcRejected = {
+    expr =
+      (norm nput.projectRoot {
+        ".config/x" = {
+          src = "/home/me/dots";
+        };
+      }).entries;
+    expectedError.type = "ThrownError";
+    expectedError.msg = "src";
+  };
+}


### PR DESCRIPTION
## 概要

lib データ生成層の最小スライス（垂直トレーサー弾 Slice1・ADR-0023）。`nput.lib.mkManifest { pkgs, root, entries }` が manifest.json（schemaVersion=1）+ store src への symlink farm を含む derivation を返す。

- **lib/out-of-store.nix**: `mkOutOfStoreSymlink` / `projectRoot`・`homeRoot`・`systemRoot` マーカー（`_nputMarker` タグ方式）
- **lib/types.nix**: `srcType`（either storeBacked outOfStoreMarker）・`rootType`（either str rootMarker）・entry submodule（src/subpath/target/method・strict）。nixpkgs.lib を受け取り modules と共有可能な形
- **lib/manifest.nix**: `normalizeManifest`（evalModules 検査・デフォルト適用・marker タグ→clean enum 変換・パス安全性/copy+marker/systemRoot/重複 target の throwIf）と `mkManifest`（symlink farm アンカー名=target の sha256 短縮 hex・`passthru.rootKind` 露出）
- **flake.nix**: nix-unit/namaka/haumea を `nix flake check` に配線
- **tests/**: nix-unit でデフォルト適用・manifest 構造の不変条件・検査ゲート（15 件）、namaka で manifest.json 全体のスナップショット回帰（1 件）

最小スコープは **root=projectRoot のみ・src=path/set の store-backed symlink entry のみ**。home / copy / out-of-store は後続スライス。型・throwIf は将来も見据えて完全形で定義済み。

### 設計判断（要確認）

- `mkManifest` の引数に **`pkgs` を追加**した（`{ pkgs, root, entries }`）。symlink farm derivation のビルドに linkFarm 相当（runCommandLocal）が要るが、`lib = import ./lib`（フラット）+ pure eval では builder を得る術がないため。spec の `{ entries, root }` 表記は pkgs を省略した概念形だった。docs 反映は別途必要なら対応する。

## 関連 issue

Closes #5

## docs / ADR 影響

なし（実装が docs/spec.md・ADR-0006/0007/0010/0013/0014/0016/0019/0023 の確定仕様に追随。ただし上記 `pkgs` 引数の追加は spec の `mkManifest` シグネチャ表記と差異があり、必要なら docs 追補を検討）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)