### PR TITLE
feat(engine): project mode の store-symlink 配置エンジンと flake パッケージング

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -47,15 +47,85 @@
         "x86_64-darwin"
       ];
       perSystem =
-        { pkgs, ... }:
         {
+          config,
+          pkgs,
+          lib,
+          ...
+        }:
+        let
+          # Go ビルド・lint の入力（go.mod + internal/。docs 変更で再ビルドしないよう絞る）。
+          # CLI（cmd/）と go.sum（外部依存）は後続スライスで追加される（→ ADR-0011）。
+          goSrc = lib.fileset.toSource {
+            root = ./.;
+            fileset = lib.fileset.unions [
+              ./go.mod
+              ./internal
+            ];
+          };
+          # nix sandbox（ネットワーク遮断）で go ツールを回すための環境。
+          # stdlib-only なので GOPROXY=off で十分（外部 fetch ゼロ・→ ADR-0011）。
+          # build dir 直下は Go が temp root とみなし go.mod を無視するため、サブディレクトリで作業する。
+          goToolEnv = ''
+            export HOME="$TMPDIR"
+            export GOCACHE="$TMPDIR/go-cache"
+            export GOTOOLCHAIN=local
+            export GOFLAGS=-mod=mod
+            export GOPROXY=off
+            mkdir -p build && cd build
+            cp -r --no-preserve=mode ${goSrc}/. .
+          '';
+        in
+        {
+          # 配置エンジン（internal/）を含む Go モジュール（→ ADR-0006, ADR-0011）。
+          # stdlib-only ゆえ vendorHash = null（外部依存ゼロ）。cobra / fatih-color を足す
+          # CLI スライス（1c・cmd/）で vendorHash 文字列に切り替わる。本スライスは CLI を
+          # まだ持たないため internal/ をライブラリとしてビルドし doCheck で go test を回す。
+          packages.nput = pkgs.buildGoModule {
+            pname = "nput";
+            version = "0.0.0";
+            src = goSrc;
+            vendorHash = null;
+            doCheck = true;
+            env.GOTOOLCHAIN = "local";
+            meta = {
+              description = "Place fetched git repositories at arbitrary paths via symlink or copy (engine).";
+              mainProgram = "nput";
+            };
+          };
+
           treefmt = {
             projectRootFile = "flake.nix";
             programs.nixfmt = {
               enable = true;
               package = pkgs.nixfmt;
             };
+            # Go 整形（→ ADR-0025）。
+            programs.gofmt.enable = true;
           };
+
+          # 静的解析を flake check に載せる（→ ADR-0025）。stdlib-only ゆえ依存検出は軽い。
+          checks.go-vet = pkgs.runCommandLocal "nput-go-vet" { nativeBuildInputs = [ pkgs.go ]; } ''
+            ${goToolEnv}
+            go vet ./...
+            touch "$out"
+          '';
+          checks.golangci-lint =
+            pkgs.runCommandLocal "nput-golangci-lint"
+              {
+                nativeBuildInputs = [
+                  pkgs.go
+                  pkgs.golangci-lint
+                ];
+              }
+              ''
+                ${goToolEnv}
+                export GOLANGCI_LINT_CACHE="$TMPDIR/golangci-cache"
+                golangci-lint run ./...
+                touch "$out"
+              '';
+          # go test（unit + tmpdir 統合テスト）も flake check で回す。
+          checks.nput = config.packages.nput;
 
           # nix-unit: デフォルト適用・manifest 構造の不変条件をアサート（→ ADR-0006, ADR-0010）。
           # flake-parts モジュールが checks 派生を組み `nix flake check` に載せる。

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/yasunori0418/nput
+
+go 1.26

--- a/internal/engine/commit.go
+++ b/internal/engine/commit.go
@@ -1,0 +1,20 @@
+package engine
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+// nixEnvCommit は既定のコミット点。`nix-env --profile <profileLink> --set <linkFarm>`
+// で 1 世代 = 1 link-farm の atomic 置換を行う（→ ADR-0002, ADR-0006, ADR-0015）。
+// stdout は機械可読出力を専有するため nix の出力は stderr に流す（→ docs/spec.md ストリーム規律）。
+func nixEnvCommit(profileLink, linkFarm string) error {
+	if _, err := exec.LookPath("nix-env"); err != nil {
+		return fmt.Errorf("nix-env が PATH にありません: %w", err)
+	}
+	cmd := exec.Command("nix-env", "--profile", profileLink, "--set", linkFarm)
+	cmd.Stdout = os.Stderr
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -1,0 +1,233 @@
+// Package engine is the placement core: it resolves root, fixes the profileDir
+// layout, takes a flock, places store-symlinks via native FS ops, removes stale
+// links conservatively, and commits a generation with `nix-env --set`
+// (→ ADR-0002, ADR-0005, ADR-0006, ADR-0011, ADR-0013, ADR-0015, ADR-0025).
+//
+// 本スライス（#6）の最小核は project mode の store-symlink 配置に絞る。配置〜
+// stale 除去（ネイティブ FS）は nix 不使用でユニット/統合テスト可能にし、commit
+// （nix-env --set）は注入可能にして tmpdir テストでは nix を呼ばない（→ ADR-0006）。
+package engine
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/yasunori0418/nput/internal/gitutil"
+	"github.com/yasunori0418/nput/internal/lock"
+	"github.com/yasunori0418/nput/internal/manifest"
+	"github.com/yasunori0418/nput/internal/paths"
+)
+
+// CommitFunc は配置成功後に世代を積むコミット点（→ ADR-0006, docs/spec.md 実行フロー f）。
+// 既定は nix-env --profile <profileLink> --set <linkFarm>。tmpdir テストはこれを
+// 差し替えて nix を呼ばずに検証する（commit の e2e は 1c・→ Issue #6）。
+type CommitFunc func(profileLink, linkFarm string) error
+
+// GitFunc は project mode の git toplevel 解決（→ ADR-0005）。既定は gitutil.Toplevel。
+type GitFunc func(dir string) (string, error)
+
+// Options は Apply の入力。
+type Options struct {
+	// LinkFarm は manifest.json と GC アンカー symlink farm を含む link-farm ディレクトリ。
+	// 実運用では CLI が `nix build --out-link <profileDir>/.pending` で得る（→ ADR-0011）。
+	LinkFarm string
+	// Name は config 名（profile を一意特定する。entrypoint の nput.<name> 由来）。
+	Name string
+	// RootOverride は --root 上書き（空 = なし）。明示時は全モードで roothash キー（→ ADR-0023）。
+	RootOverride string
+	// WorkDir は project mode の git toplevel 解決の起点（空 = os.Getwd）。
+	WorkDir string
+	// StateDir は profile 基底 <state> の上書き（空 = paths.StateDir で解決・主にテスト用）。
+	StateDir string
+	// NoWait は flock を try-lock にする（shellHook 経路・保持中なら ErrSkipped・→ ADR-0013）。
+	NoWait bool
+
+	// Git は git toplevel 解決の差し替え（nil = gitutil.Toplevel）。
+	Git GitFunc
+	// Commit は世代コミットの差し替え（nil = nix-env --set）。
+	Commit CommitFunc
+	// Warnf は warning の出力先（nil = stderr）。foreign symlink 等の可視化に使う（→ ADR-0015）。
+	Warnf func(format string, args ...any)
+}
+
+// Result は Apply の結果レポート（dryrun / レポート表示・テスト検証用）。
+type Result struct {
+	Root       string   // 解決後の絶対 root パス
+	ProfileDir string   // 確定した profileDir
+	Placed     []string // 新規配置した target
+	Replaced   []string // 既存 symlink を張り替えた target
+	Removed    []string // stale 除去した target
+	Skipped    bool     // try-lock 競合で skip した（NoWait 経路）
+}
+
+// ErrSkipped は NoWait 経路で他の apply が進行中のため skip したことを表す。
+var ErrSkipped = lock.ErrLocked
+
+// Apply は manifest.json を入力に project mode の store-symlink 配置を行い、
+// 成功後に世代をコミットする。docs/spec.md「実行フロー」の engine 駆動部に対応する
+// （eval 先行・build は CLI 責務でここでは LinkFarm を受け取る）。
+func Apply(opts Options) (*Result, error) {
+	m, err := manifest.Load(opts.LinkFarm)
+	if err != nil {
+		return nil, err
+	}
+
+	a := &applier{opts: opts, manifest: m, result: &Result{}}
+	if a.opts.Warnf == nil {
+		a.opts.Warnf = func(format string, args ...any) {
+			fmt.Fprintf(os.Stderr, format+"\n", args...)
+		}
+	}
+
+	// 1. root 解決 → profileDir 確定（→ docs/spec.md「root の解決」）。
+	root, err := a.resolveRoot()
+	if err != nil {
+		return nil, err
+	}
+	a.root = root
+	a.result.Root = root
+
+	stateDir := opts.StateDir
+	if stateDir == "" {
+		stateDir, err = paths.StateDir()
+		if err != nil {
+			return nil, err
+		}
+	}
+	a.profile = paths.Resolve(stateDir, opts.Name, m.Root.RootKind, root, opts.RootOverride != "")
+	a.result.ProfileDir = a.profile.Dir
+
+	// 2. profileDir / backref を用意（flock は profileDir を開くため先に作る）。
+	if err := a.ensureProfileDir(); err != nil {
+		return nil, err
+	}
+
+	// 3. 解決後 profileDir 単位で flock を取得し直列化する（→ ADR-0013）。
+	l, err := lock.Acquire(a.profile.Dir, !opts.NoWait)
+	if err != nil {
+		if opts.NoWait && err == lock.ErrLocked {
+			a.result.Skipped = true
+			return a.result, ErrSkipped
+		}
+		return nil, fmt.Errorf("nput: flock の取得に失敗しました (%s): %w", a.profile.Dir, err)
+	}
+	defer func() { _ = l.Release() }()
+
+	// 4. 前世代 manifest を読む（無ければ初回 = stale 除去ゼロ）。
+	prev := a.loadPrevManifest()
+
+	// 5. 配置 → stale 除去（新規 / 張替を先に、stale 除去を最後に・→ ADR-0006）。
+	if err := a.place(prev); err != nil {
+		return nil, err
+	}
+	if err := a.removeStale(prev); err != nil {
+		return nil, err
+	}
+
+	// 6. 世代コミット（commit の e2e は 1c・→ Issue #6）。
+	commit := opts.Commit
+	if commit == nil {
+		commit = nixEnvCommit
+	}
+	if err := commit(a.profile.Profile, opts.LinkFarm); err != nil {
+		return nil, fmt.Errorf("nput: 世代コミット（nix-env --set）に失敗しました: %w", err)
+	}
+
+	return a.result, nil
+}
+
+type applier struct {
+	opts     Options
+	manifest *manifest.Manifest
+	profile  paths.Profile
+	root     string
+	result   *Result
+}
+
+func (a *applier) resolveRoot() (string, error) {
+	if a.opts.RootOverride != "" {
+		return filepath.Abs(a.opts.RootOverride)
+	}
+	switch a.manifest.Root.RootKind {
+	case manifest.RootKindProject:
+		dir := a.opts.WorkDir
+		if dir == "" {
+			cwd, err := os.Getwd()
+			if err != nil {
+				return "", fmt.Errorf("nput: cwd を取得できません: %w", err)
+			}
+			dir = cwd
+		}
+		git := a.opts.Git
+		if git == nil {
+			git = gitutil.Toplevel
+		}
+		return git(dir)
+	case manifest.RootKindHome:
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("nput: $HOME を解決できません: %w", err)
+		}
+		return home, nil
+	case manifest.RootKindFixed:
+		if a.manifest.Root.Root == "" {
+			return "", fmt.Errorf("nput: rootKind=fixed なのに root パスがありません")
+		}
+		return filepath.Abs(a.manifest.Root.Root)
+	case manifest.RootKindSystem:
+		return "", fmt.Errorf("nput: root = systemRoot (system mode) は未実装です（→ ADR-0013）")
+	default:
+		return "", fmt.Errorf("nput: 未知の rootKind: %q", a.manifest.Root.RootKind)
+	}
+}
+
+func (a *applier) ensureProfileDir() error {
+	if err := os.MkdirAll(a.profile.Dir, 0o755); err != nil {
+		return fmt.Errorf("nput: profileDir を作成できません (%s): %w", a.profile.Dir, err)
+	}
+	// backref .root を <roothash> 階層に置く（孤児 profile の逆引き seam・→ ADR-0013）。
+	if a.profile.Backref != "" {
+		if err := os.MkdirAll(a.profile.BackrefDir, 0o755); err != nil {
+			return fmt.Errorf("nput: backref ディレクトリを作成できません (%s): %w", a.profile.BackrefDir, err)
+		}
+		if err := os.WriteFile(a.profile.Backref, []byte(a.root+"\n"), 0o644); err != nil {
+			return fmt.Errorf("nput: backref を書けません (%s): %w", a.profile.Backref, err)
+		}
+	}
+	return nil
+}
+
+// loadPrevManifest は profileDir/profile（前世代 link-farm への symlink）が指す
+// manifest.json を読む。初回（profile 不在）は nil を返す（削除対象ゼロ・→ ADR-0006）。
+func (a *applier) loadPrevManifest() *manifest.Manifest {
+	if _, err := os.Stat(a.profile.Profile); err != nil {
+		return nil
+	}
+	m, err := manifest.Load(a.profile.Profile)
+	if err != nil {
+		// 前世代が読めなくても新規配置は妨げない（stale 除去だけ諦める）。
+		a.opts.Warnf("nput: 前世代 manifest を読めませんでした。stale 除去をスキップします: %v", err)
+		return nil
+	}
+	return m
+}
+
+func byTarget(m *manifest.Manifest) map[string]manifest.Entry {
+	if m == nil {
+		return nil
+	}
+	out := make(map[string]manifest.Entry, len(m.Entries))
+	for _, e := range m.Entries {
+		out[e.Target] = e
+	}
+	return out
+}
+
+// linkDest は entry の symlink が指すべき先（<src>/<subpath>）を返す。
+func linkDest(e manifest.Entry) string {
+	if e.Subpath == "" || e.Subpath == "." {
+		return e.Src
+	}
+	return filepath.Join(e.Src, e.Subpath)
+}

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -1,0 +1,442 @@
+package engine
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/yasunori0418/nput/internal/lock"
+	"github.com/yasunori0418/nput/internal/manifest"
+	"github.com/yasunori0418/nput/internal/paths"
+)
+
+// profileDirFor は --root 上書き（roothash キー）時の profileDir を返す。
+func profileDirFor(t *testing.T, state, root, name string) string {
+	t.Helper()
+	return paths.Resolve(state, name, manifest.RootKindProject, root, true).Dir
+}
+
+// --- test helpers ----------------------------------------------------------
+
+// realTempDir は EvalSymlinks 済みの tmpdir を返す（macOS の /var → /private/var 対策）。
+func realTempDir(t *testing.T) string {
+	t.Helper()
+	d, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return d
+}
+
+// writeLinkFarm は手書き manifest.json を持つ link-farm ディレクトリを作って返す。
+func writeLinkFarm(t *testing.T, m manifest.Manifest) string {
+	t.Helper()
+	dir := realTempDir(t)
+	data, err := json.Marshal(m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, manifest.FileName), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+// makeSrc は store src 相当の tmpdir に <subpath> のファイルを作って src dir を返す。
+func makeSrc(t *testing.T, subpath string) string {
+	t.Helper()
+	src := realTempDir(t)
+	full := filepath.Join(src, subpath)
+	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(full, []byte("content"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return src
+}
+
+// fakeCommit は nix-env --set を模し、profile リンクを link-farm へ張る
+// （前世代 manifest の読み取りを後続 apply で成立させる）。
+func fakeCommit(captured *[][2]string) CommitFunc {
+	return func(profileLink, linkFarm string) error {
+		if captured != nil {
+			*captured = append(*captured, [2]string{profileLink, linkFarm})
+		}
+		_ = os.Remove(profileLink)
+		return os.Symlink(linkFarm, profileLink)
+	}
+}
+
+func collectWarnings(buf *[]string) func(string, ...any) {
+	return func(format string, args ...any) {
+		*buf = append(*buf, format)
+	}
+}
+
+func projectManifest(entries ...manifest.Entry) manifest.Manifest {
+	return manifest.Manifest{
+		SchemaVersion: 1,
+		Root:          manifest.Root{RootKind: manifest.RootKindProject},
+		Entries:       entries,
+	}
+}
+
+func storeEntry(src, subpath, target string) manifest.Entry {
+	return manifest.Entry{
+		SrcKind: manifest.SrcKindStore,
+		Src:     src,
+		Subpath: subpath,
+		Target:  target,
+		Method:  manifest.MethodSymlink,
+	}
+}
+
+// --- tests -----------------------------------------------------------------
+
+func TestApplyFirstPlacementProjectMode(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	root := realTempDir(t)
+	if out, err := exec.Command("git", "init", root).CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v: %s", err, out)
+	}
+	src := makeSrc(t, "skills/nix/init.lua")
+	state := realTempDir(t)
+	lf := writeLinkFarm(t, projectManifest(storeEntry(src, "skills/nix", ".claude/skills/nix")))
+
+	var commits [][2]string
+	res, err := Apply(Options{
+		LinkFarm: lf,
+		Name:     "skills",
+		WorkDir:  root, // project mode: git toplevel = root
+		StateDir: state,
+		Commit:   fakeCommit(&commits),
+	})
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	// symlink が <root>/<target> -> <src>/<subpath> で張られる。
+	target := filepath.Join(root, ".claude", "skills", "nix")
+	dest, err := os.Readlink(target)
+	if err != nil {
+		t.Fatalf("Readlink target: %v", err)
+	}
+	if want := filepath.Join(src, "skills/nix"); dest != want {
+		t.Errorf("symlink dest = %q, want %q", dest, want)
+	}
+
+	// profileDir レイアウトが <state>/nix/profiles/nput/<roothash>/<name> に作られる。
+	if !strings.HasPrefix(res.ProfileDir, filepath.Join(state, "nix", "profiles", "nput")) {
+		t.Errorf("ProfileDir = %q, not under state base", res.ProfileDir)
+	}
+	if fi, err := os.Stat(res.ProfileDir); err != nil || !fi.IsDir() {
+		t.Errorf("profileDir not created: %v", err)
+	}
+
+	// backref .root が <roothash> 階層に root の絶対パスを記録する。
+	backref := filepath.Join(filepath.Dir(res.ProfileDir), ".root")
+	data, err := os.ReadFile(backref)
+	if err != nil {
+		t.Fatalf("read backref: %v", err)
+	}
+	if strings.TrimSpace(string(data)) != root {
+		t.Errorf("backref = %q, want %q", strings.TrimSpace(string(data)), root)
+	}
+
+	// commit が profileDir/profile と link-farm で 1 回呼ばれる。
+	if len(commits) != 1 {
+		t.Fatalf("commit calls = %d, want 1", len(commits))
+	}
+	if commits[0][0] != filepath.Join(res.ProfileDir, "profile") || commits[0][1] != lf {
+		t.Errorf("commit args = %v", commits[0])
+	}
+	if len(res.Placed) != 1 || res.Placed[0] != ".claude/skills/nix" {
+		t.Errorf("Placed = %v", res.Placed)
+	}
+}
+
+func TestApplySubpathDot(t *testing.T) {
+	root := realTempDir(t)
+	src := makeSrc(t, "file.txt")
+	state := realTempDir(t)
+	lf := writeLinkFarm(t, projectManifest(storeEntry(src, ".", ".config/whole")))
+
+	_, err := Apply(Options{
+		LinkFarm: lf, Name: "c", RootOverride: root, StateDir: state, Commit: fakeCommit(nil),
+	})
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	dest, err := os.Readlink(filepath.Join(root, ".config", "whole"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dest != src { // subpath="." → src そのもの
+		t.Errorf("dest = %q, want %q", dest, src)
+	}
+}
+
+func TestApplyAncestorSymlinkError(t *testing.T) {
+	root := realTempDir(t)
+	src := makeSrc(t, "x")
+	state := realTempDir(t)
+
+	// <root>/.claude を symlink 配置済みにする → 配下に nix をネストできない。
+	if err := os.Symlink(realTempDir(t), filepath.Join(root, ".claude")); err != nil {
+		t.Fatal(err)
+	}
+	lf := writeLinkFarm(t, projectManifest(storeEntry(src, ".", ".claude/skills/nix")))
+
+	_, err := Apply(Options{
+		LinkFarm: lf, Name: "c", RootOverride: root, StateDir: state, Commit: fakeCommit(nil),
+	})
+	if err == nil || !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("expected ancestor symlink error, got %v", err)
+	}
+}
+
+func TestApplyExistingRegularFileError(t *testing.T) {
+	root := realTempDir(t)
+	src := makeSrc(t, "x")
+	state := realTempDir(t)
+
+	if err := os.MkdirAll(filepath.Join(root, ".config"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".config", "foo"), []byte("user"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	lf := writeLinkFarm(t, projectManifest(storeEntry(src, ".", ".config/foo")))
+
+	_, err := Apply(Options{
+		LinkFarm: lf, Name: "c", RootOverride: root, StateDir: state, Commit: fakeCommit(nil),
+	})
+	if err == nil {
+		t.Fatal("expected error for existing regular file, got nil")
+	}
+}
+
+func TestApplyForeignSymlinkWarns(t *testing.T) {
+	root := realTempDir(t)
+	src := makeSrc(t, "x")
+	state := realTempDir(t)
+
+	// 記録の無い foreign symlink を target に置く。
+	foreign := realTempDir(t)
+	if err := os.MkdirAll(filepath.Join(root, ".config"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(foreign, filepath.Join(root, ".config", "foo")); err != nil {
+		t.Fatal(err)
+	}
+	lf := writeLinkFarm(t, projectManifest(storeEntry(src, ".", ".config/foo")))
+
+	var warns []string
+	res, err := Apply(Options{
+		LinkFarm: lf, Name: "c", RootOverride: root, StateDir: state,
+		Commit: fakeCommit(nil), Warnf: collectWarnings(&warns),
+	})
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if len(warns) == 0 {
+		t.Error("expected a foreign symlink warning")
+	}
+	if len(res.Replaced) != 1 {
+		t.Errorf("Replaced = %v, want 1", res.Replaced)
+	}
+	dest, _ := os.Readlink(filepath.Join(root, ".config", "foo"))
+	if dest != src {
+		t.Errorf("dest = %q, want %q (last-wins)", dest, src)
+	}
+}
+
+func TestApplyRecordedSymlinkReplacedSilently(t *testing.T) {
+	root := realTempDir(t)
+	state := realTempDir(t)
+	src1 := makeSrc(t, "x")
+
+	lf1 := writeLinkFarm(t, projectManifest(storeEntry(src1, ".", ".config/foo")))
+	var commits [][2]string
+	if _, err := Apply(Options{
+		LinkFarm: lf1, Name: "c", RootOverride: root, StateDir: state, Commit: fakeCommit(&commits),
+	}); err != nil {
+		t.Fatalf("first Apply: %v", err)
+	}
+
+	// 2 回目: 同 target・別 src。前世代記録と一致するので foreign 警告を出さず張替。
+	src2 := makeSrc(t, "x")
+	lf2 := writeLinkFarm(t, projectManifest(storeEntry(src2, ".", ".config/foo")))
+	var warns []string
+	res, err := Apply(Options{
+		LinkFarm: lf2, Name: "c", RootOverride: root, StateDir: state,
+		Commit: fakeCommit(&commits), Warnf: collectWarnings(&warns),
+	})
+	if err != nil {
+		t.Fatalf("second Apply: %v", err)
+	}
+	for _, w := range warns {
+		if strings.Contains(w, "foreign") {
+			t.Errorf("unexpected foreign warning on recorded replace: %q", w)
+		}
+	}
+	if len(res.Replaced) != 1 {
+		t.Errorf("Replaced = %v, want 1", res.Replaced)
+	}
+	dest, _ := os.Readlink(filepath.Join(root, ".config", "foo"))
+	if dest != src2 {
+		t.Errorf("dest = %q, want %q", dest, src2)
+	}
+}
+
+func TestApplyStaleRemoval(t *testing.T) {
+	root := realTempDir(t)
+	state := realTempDir(t)
+	src := makeSrc(t, "x")
+
+	// 1 回目: 2 entry。
+	lf1 := writeLinkFarm(t, projectManifest(
+		storeEntry(src, ".", ".config/keep"),
+		storeEntry(src, ".", ".config/drop"),
+	))
+	var commits [][2]string
+	if _, err := Apply(Options{
+		LinkFarm: lf1, Name: "c", RootOverride: root, StateDir: state, Commit: fakeCommit(&commits),
+	}); err != nil {
+		t.Fatalf("first Apply: %v", err)
+	}
+	if _, err := os.Lstat(filepath.Join(root, ".config", "drop")); err != nil {
+		t.Fatalf("drop should exist after first apply: %v", err)
+	}
+
+	// 2 回目: drop を外す → stale 除去される。keep は残る。
+	lf2 := writeLinkFarm(t, projectManifest(storeEntry(src, ".", ".config/keep")))
+	res, err := Apply(Options{
+		LinkFarm: lf2, Name: "c", RootOverride: root, StateDir: state, Commit: fakeCommit(&commits),
+	})
+	if err != nil {
+		t.Fatalf("second Apply: %v", err)
+	}
+	if _, err := os.Lstat(filepath.Join(root, ".config", "drop")); !os.IsNotExist(err) {
+		t.Errorf("drop should be removed, lstat err = %v", err)
+	}
+	if _, err := os.Lstat(filepath.Join(root, ".config", "keep")); err != nil {
+		t.Errorf("keep should remain: %v", err)
+	}
+	if len(res.Removed) != 1 || res.Removed[0] != ".config/drop" {
+		t.Errorf("Removed = %v, want [.config/drop]", res.Removed)
+	}
+}
+
+func TestApplyStaleRemovalKeepsForeign(t *testing.T) {
+	root := realTempDir(t)
+	state := realTempDir(t)
+	src := makeSrc(t, "x")
+
+	lf1 := writeLinkFarm(t, projectManifest(storeEntry(src, ".", ".config/drop")))
+	var commits [][2]string
+	if _, err := Apply(Options{
+		LinkFarm: lf1, Name: "c", RootOverride: root, StateDir: state, Commit: fakeCommit(&commits),
+	}); err != nil {
+		t.Fatalf("first Apply: %v", err)
+	}
+
+	// ユーザーが target を別の先へ差し替える（記録と不一致）→ stale 除去しない。
+	tgt := filepath.Join(root, ".config", "drop")
+	_ = os.Remove(tgt)
+	if err := os.Symlink(realTempDir(t), tgt); err != nil {
+		t.Fatal(err)
+	}
+
+	lf2 := writeLinkFarm(t, projectManifest()) // 空 manifest = 全クリア。
+	var warns []string
+	res, err := Apply(Options{
+		LinkFarm: lf2, Name: "c", RootOverride: root, StateDir: state,
+		Commit: fakeCommit(&commits), Warnf: collectWarnings(&warns),
+	})
+	if err != nil {
+		t.Fatalf("second Apply: %v", err)
+	}
+	if len(res.Removed) != 0 {
+		t.Errorf("Removed = %v, want none (mismatch kept)", res.Removed)
+	}
+	if _, err := os.Lstat(tgt); err != nil {
+		t.Errorf("mismatched symlink should be kept: %v", err)
+	}
+	if len(warns) == 0 {
+		t.Error("expected a mismatch warning")
+	}
+}
+
+func TestApplyGitNotInRepoError(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	work := realTempDir(t)
+	t.Setenv("HOME", work)
+	t.Setenv("GIT_CEILING_DIRECTORIES", filepath.Dir(work))
+	src := makeSrc(t, "x")
+	state := realTempDir(t)
+	lf := writeLinkFarm(t, projectManifest(storeEntry(src, ".", ".config/foo")))
+
+	_, err := Apply(Options{
+		LinkFarm: lf, Name: "c", WorkDir: work, StateDir: state, Commit: fakeCommit(nil),
+	})
+	if err == nil {
+		t.Fatal("expected git-not-in-repo error, got nil")
+	}
+}
+
+func TestApplyNoWaitSkipsWhenLocked(t *testing.T) {
+	root := realTempDir(t)
+	state := realTempDir(t)
+	src := makeSrc(t, "x")
+	lf := writeLinkFarm(t, projectManifest(storeEntry(src, ".", ".config/foo")))
+
+	// profileDir を先に作って flock を握っておく。
+	prof := profileDirFor(t, state, root, "c")
+	if err := os.MkdirAll(prof, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	held, err := lock.Acquire(prof, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = held.Release() }()
+
+	res, err := Apply(Options{
+		LinkFarm: lf, Name: "c", RootOverride: root, StateDir: state, NoWait: true, Commit: fakeCommit(nil),
+	})
+	if err != ErrSkipped {
+		t.Fatalf("NoWait while locked: err = %v, want ErrSkipped", err)
+	}
+	if res == nil || !res.Skipped {
+		t.Errorf("expected res.Skipped = true, got %+v", res)
+	}
+	// skip したので配置はされない。
+	if _, err := os.Lstat(filepath.Join(root, ".config", "foo")); !os.IsNotExist(err) {
+		t.Errorf("skip should not place: lstat err = %v", err)
+	}
+}
+
+func TestApplyCopyMethodUnimplemented(t *testing.T) {
+	root := realTempDir(t)
+	state := realTempDir(t)
+	src := makeSrc(t, "x")
+	e := storeEntry(src, ".", ".config/foo")
+	e.Method = manifest.MethodCopy
+	lf := writeLinkFarm(t, projectManifest(e))
+
+	_, err := Apply(Options{
+		LinkFarm: lf, Name: "c", RootOverride: root, StateDir: state, Commit: fakeCommit(nil),
+	})
+	if err == nil {
+		t.Fatal("expected copy-unimplemented error, got nil")
+	}
+}

--- a/internal/engine/place.go
+++ b/internal/engine/place.go
@@ -1,0 +1,160 @@
+package engine
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/yasunori0418/nput/internal/manifest"
+)
+
+// place は新世代 manifest の各 entry を配置する（新規 / 張替を stale 除去より先に・→ ADR-0006）。
+// 本スライスは store / out-of-store の symlink 配置のみ対応する（copy は将来スライス・→ Issue #6）。
+func (a *applier) place(prev *manifest.Manifest) error {
+	prevByTarget := byTarget(prev)
+	for _, e := range a.manifest.Entries {
+		switch e.Method {
+		case manifest.MethodSymlink:
+			if err := a.placeSymlink(e, prevByTarget); err != nil {
+				return err
+			}
+		case manifest.MethodCopy:
+			return fmt.Errorf("nput: method=copy は本スライスでは未実装です (target: %s)", e.Target)
+		default:
+			return fmt.Errorf("nput: 未知の method: %q (target: %s)", e.Method, e.Target)
+		}
+	}
+	return nil
+}
+
+func (a *applier) placeSymlink(e manifest.Entry, prevByTarget map[string]manifest.Entry) error {
+	targetAbs := a.targetAbs(e.Target)
+
+	// 0. 祖先 component を lstat walk。symlink ならネスト不可で error 停止（→ ADR-0015）。
+	if err := a.checkAncestors(e.Target); err != nil {
+		return err
+	}
+
+	// 1. 親ディレクトリを作成（祖先 symlink は 0 で弾き済み）。
+	if err := os.MkdirAll(filepath.Dir(targetAbs), 0o755); err != nil {
+		return fmt.Errorf("nput: 親ディレクトリを作成できません (%s): %w", filepath.Dir(targetAbs), err)
+	}
+
+	dest := linkDest(e)
+
+	// 2. 既存 target の判定（→ docs/spec.md「symlink モード」・ADR-0015）。
+	info, err := os.Lstat(targetAbs)
+	switch {
+	case err == nil && info.Mode()&os.ModeSymlink != 0:
+		// 既存 symlink: 自身の前世代 manifest 記録通りなら silent、それ以外は foreign warning。
+		if !a.recordedLink(e.Target, targetAbs, prevByTarget) {
+			a.opts.Warnf("nput: 記録の無い symlink を上書きします (foreign・後勝ち): %s", e.Target)
+		}
+		if err := os.Remove(targetAbs); err != nil {
+			return fmt.Errorf("nput: 既存 symlink を除去できません (%s): %w", targetAbs, err)
+		}
+		a.result.Replaced = append(a.result.Replaced, e.Target)
+	case err == nil:
+		// 通常ファイル / ディレクトリは上書きしない（→ docs/spec.md エラー仕様）。
+		return fmt.Errorf("nput: target に既存のファイル/ディレクトリがあります（上書きしません）: %s", e.Target)
+	case os.IsNotExist(err):
+		a.result.Placed = append(a.result.Placed, e.Target)
+	default:
+		return fmt.Errorf("nput: target を lstat できません (%s): %w", targetAbs, err)
+	}
+
+	// 3. <配置元>/<subpath> を指す symlink を作成（張替は unlink + symlink・→ ADR-0017）。
+	if err := os.Symlink(dest, targetAbs); err != nil {
+		return fmt.Errorf("nput: symlink を作成できません (%s -> %s): %w", targetAbs, dest, err)
+	}
+	return nil
+}
+
+// checkAncestors は target の各祖先 component を root から順に lstat し、いずれかが
+// symlink なら error を返す（全体 symlink 配置の配下にネストできない・→ ADR-0015）。
+// 祖先が未作成ならそこで打ち切る（配下も存在しないため安全）。
+func (a *applier) checkAncestors(target string) error {
+	clean := filepath.Clean(target)
+	comps := strings.Split(clean, string(os.PathSeparator))
+	cur := a.root
+	for i := 0; i < len(comps)-1; i++ {
+		if comps[i] == "" {
+			continue
+		}
+		cur = filepath.Join(cur, comps[i])
+		info, err := os.Lstat(cur)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil
+			}
+			return fmt.Errorf("nput: 祖先を lstat できません (%s): %w", cur, err)
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("nput: 祖先 %q が symlink です。配下にネストできません (target: %s・→ ADR-0015)", cur, target)
+		}
+	}
+	return nil
+}
+
+// recordedLink は target が「自身の前世代 manifest が記録した symlink」かを判定する。
+// 前世代に同 target の entry があり、かつ実体の symlink が記録通りの先を指すときのみ true
+// （保守的不変条件・→ ADR-0002, ADR-0015）。
+func (a *applier) recordedLink(target, targetAbs string, prevByTarget map[string]manifest.Entry) bool {
+	pe, ok := prevByTarget[target]
+	if !ok {
+		return false
+	}
+	onDisk, err := os.Readlink(targetAbs)
+	if err != nil {
+		return false
+	}
+	return onDisk == linkDest(pe)
+}
+
+// removeStale は前世代にあって新世代から消えた entry を保守的に除去する（最後に実行・→ ADR-0006）。
+// 削除するのは「記録通りの先を指す symlink」のみ。foreign / 内容不一致は警告して残す。
+// copy entry は除去せず orphan を警告する（→ ADR-0002, ADR-0020）。
+func (a *applier) removeStale(prev *manifest.Manifest) error {
+	if prev == nil {
+		return nil
+	}
+	newByTarget := byTarget(a.manifest)
+	for _, pe := range prev.Entries {
+		if _, kept := newByTarget[pe.Target]; kept {
+			continue
+		}
+		if pe.Method == manifest.MethodCopy {
+			a.opts.Warnf("nput: copy entry が消えましたが target は削除しません（orphan・reset で撤去）: %s", pe.Target)
+			continue
+		}
+
+		targetAbs := a.targetAbs(pe.Target)
+		info, err := os.Lstat(targetAbs)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue // 既に無い = no-op。
+			}
+			return fmt.Errorf("nput: stale target を lstat できません (%s): %w", targetAbs, err)
+		}
+		if info.Mode()&os.ModeSymlink == 0 {
+			a.opts.Warnf("nput: stale target が symlink ではないため残します: %s", pe.Target)
+			continue
+		}
+		onDisk, err := os.Readlink(targetAbs)
+		if err != nil || onDisk != linkDest(pe) {
+			a.opts.Warnf("nput: stale symlink が記録と不一致のため残します: %s", pe.Target)
+			continue
+		}
+		if err := os.Remove(targetAbs); err != nil {
+			return fmt.Errorf("nput: stale symlink を除去できません (%s): %w", targetAbs, err)
+		}
+		a.result.Removed = append(a.result.Removed, pe.Target)
+	}
+	return nil
+}
+
+// targetAbs は root 相対 target を絶対パスへ正規化する。
+func (a *applier) targetAbs(target string) string {
+	return filepath.Join(a.root, filepath.Clean(target))
+}

--- a/internal/gitutil/gitutil.go
+++ b/internal/gitutil/gitutil.go
@@ -1,0 +1,45 @@
+// Package gitutil resolves the git toplevel for project mode root resolution
+// (→ ADR-0005, docs/spec.md「root の解決」).
+package gitutil
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// ErrNotInRepo は dir が git リポジトリ外で toplevel を解決できないときに返る。
+var ErrNotInRepo = errors.New("nput: git リポジトリ外です（--root で root を明示してください）")
+
+// ErrGitNotFound は git が PATH に無いときに返る。
+var ErrGitNotFound = errors.New("nput: git が PATH にありません")
+
+// Toplevel は dir を起点に `git rev-parse --show-toplevel` を実行し、
+// 解決後の絶対 root パスを返す（→ ADR-0005）。どのサブディレクトリから叩いても
+// 同じ root に解決される。git が無い／リポジトリ外なら明確なエラーで停止する。
+func Toplevel(dir string) (string, error) {
+	if _, err := exec.LookPath("git"); err != nil {
+		return "", ErrGitNotFound
+	}
+
+	cmd := exec.Command("git", "-C", dir, "rev-parse", "--show-toplevel")
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			// git 自体は起動できたが非ゼロ終了 = リポジトリ外が代表ケース。
+			return "", fmt.Errorf("%w: %s", ErrNotInRepo, strings.TrimSpace(stderr.String()))
+		}
+		return "", fmt.Errorf("nput: git rev-parse の実行に失敗しました: %w", err)
+	}
+
+	top := strings.TrimSpace(stdout.String())
+	if top == "" {
+		return "", ErrNotInRepo
+	}
+	return top, nil
+}

--- a/internal/gitutil/gitutil_test.go
+++ b/internal/gitutil/gitutil_test.go
@@ -1,0 +1,64 @@
+package gitutil
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func initRepo(t *testing.T) string {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	dir := t.TempDir()
+	// macOS の /tmp は /private/tmp への symlink なので解決後パスで比較する。
+	dir, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command("git", "init", dir)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v: %s", err, out)
+	}
+	return dir
+}
+
+func TestToplevelFromSubdir(t *testing.T) {
+	root := initRepo(t)
+	sub := filepath.Join(root, "a", "b")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := Toplevel(sub)
+	if err != nil {
+		t.Fatalf("Toplevel: %v", err)
+	}
+	got, _ = filepath.EvalSymlinks(got)
+	if got != root {
+		t.Errorf("Toplevel = %q, want %q", got, root)
+	}
+}
+
+func TestToplevelOutsideRepo(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	// $HOME 等の祖先が git repo だと誤検知するため、隔離した tmpdir を使う。
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("GIT_CEILING_DIRECTORIES", filepath.Dir(dir))
+
+	if _, err := Toplevel(dir); err == nil {
+		t.Fatal("expected error outside repo, got nil")
+	}
+}
+
+func TestToplevelGitNotInPath(t *testing.T) {
+	t.Setenv("PATH", "")
+	if _, err := Toplevel(t.TempDir()); err != ErrGitNotFound {
+		t.Fatalf("git-not-in-PATH: got %v, want ErrGitNotFound", err)
+	}
+}

--- a/internal/lock/lock.go
+++ b/internal/lock/lock.go
@@ -1,0 +1,58 @@
+// Package lock serializes concurrent apply / reset / rollback on a profileDir
+// via an advisory flock (→ ADR-0011, ADR-0013).
+//
+// syscall.Flock の advisory ロックはプロセス終了時に OS が自動解放するため、
+// クラッシュしても stale lock が残らない。linux / darwin 両対応（→ ADR-0011）。
+package lock
+
+import (
+	"errors"
+	"os"
+	"syscall"
+)
+
+// ErrLocked は非ブロッキング取得（try-lock）で他者が保持中のときに返る。
+// shellHook 経路（--no-wait）の skip 判定に使う（→ ADR-0013）。
+var ErrLocked = errors.New("nput: profileDir is locked by another process")
+
+// Lock は profileDir 上に取得した排他 flock。
+type Lock struct {
+	f *os.File
+}
+
+// Acquire は dir（profileDir）に対し排他 flock を取得する。
+// blocking=true は明示 apply 用の LOCK_EX（取得まで待つ）、
+// blocking=false は shellHook 用の LOCK_NB（保持中なら ErrLocked・→ ADR-0013）。
+// dir は事前に存在している必要がある。
+func Acquire(dir string, blocking bool) (*Lock, error) {
+	f, err := os.Open(dir)
+	if err != nil {
+		return nil, err
+	}
+
+	how := syscall.LOCK_EX
+	if !blocking {
+		how |= syscall.LOCK_NB
+	}
+	if err := syscall.Flock(int(f.Fd()), how); err != nil {
+		_ = f.Close()
+		if !blocking && (errors.Is(err, syscall.EWOULDBLOCK) || errors.Is(err, syscall.EAGAIN)) {
+			return nil, ErrLocked
+		}
+		return nil, err
+	}
+	return &Lock{f: f}, nil
+}
+
+// Release は flock を解放しファイルを閉じる。
+func (l *Lock) Release() error {
+	if l == nil || l.f == nil {
+		return nil
+	}
+	err := syscall.Flock(int(l.f.Fd()), syscall.LOCK_UN)
+	if cerr := l.f.Close(); err == nil {
+		err = cerr
+	}
+	l.f = nil
+	return err
+}

--- a/internal/lock/lock_test.go
+++ b/internal/lock/lock_test.go
@@ -1,0 +1,77 @@
+package lock
+
+import (
+	"testing"
+	"time"
+)
+
+func TestTryLockConflict(t *testing.T) {
+	dir := t.TempDir()
+
+	l1, err := Acquire(dir, true)
+	if err != nil {
+		t.Fatalf("first Acquire: %v", err)
+	}
+	defer func() { _ = l1.Release() }()
+
+	// 保持中の try-lock は ErrLocked。
+	if _, err := Acquire(dir, false); err != ErrLocked {
+		t.Fatalf("try-lock while held: got %v, want ErrLocked", err)
+	}
+}
+
+func TestReleaseAllowsReacquire(t *testing.T) {
+	dir := t.TempDir()
+
+	l1, err := Acquire(dir, false)
+	if err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+	if err := l1.Release(); err != nil {
+		t.Fatalf("Release: %v", err)
+	}
+
+	l2, err := Acquire(dir, false)
+	if err != nil {
+		t.Fatalf("re-Acquire after release: %v", err)
+	}
+	_ = l2.Release()
+}
+
+func TestBlockingWaitsForRelease(t *testing.T) {
+	dir := t.TempDir()
+
+	l1, err := Acquire(dir, true)
+	if err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+
+	acquired := make(chan struct{})
+	go func() {
+		l2, err := Acquire(dir, true) // blocking: 取得まで待つ。
+		if err != nil {
+			t.Errorf("blocking Acquire: %v", err)
+			close(acquired)
+			return
+		}
+		_ = l2.Release()
+		close(acquired)
+	}()
+
+	select {
+	case <-acquired:
+		t.Fatal("blocking Acquire returned before lock was released")
+	case <-time.After(100 * time.Millisecond):
+		// まだ取得できていない = blocking が効いている。
+	}
+
+	if err := l1.Release(); err != nil {
+		t.Fatalf("Release: %v", err)
+	}
+	select {
+	case <-acquired:
+		// 解放後に取得できた。
+	case <-time.After(2 * time.Second):
+		t.Fatal("blocking Acquire did not proceed after release")
+	}
+}

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -1,0 +1,97 @@
+// Package manifest reads and validates the manifest.json contract that
+// lib.mkManifest emits and the engine consumes (→ ADR-0006, ADR-0010, ADR-0013).
+//
+// manifest.json は Nix↔Go の唯一の安定契約。engine は自身の対応版より新しい
+// schemaVersion を拒否する（→ ADR-0006, docs/spec.md「manifest.json スキーマ（v1）」）。
+package manifest
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// SchemaVersion は engine が解釈できる manifest.json の最新版（→ ADR-0013）。
+// MVP は v1 のみを受理し、これより新しい版は拒否する（→ ADR-0006, ADR-0015）。
+const SchemaVersion = 1
+
+// FileName は link-farm derivation 内に埋め込まれる manifest の固定名。
+const FileName = "manifest.json"
+
+// 配置元・配置方法の clean enum（_nputMarker は manifest に漏れない・→ ADR-0010）。
+const (
+	SrcKindStore      = "store"
+	SrcKindOutOfStore = "outOfStore"
+
+	MethodSymlink = "symlink"
+	MethodCopy    = "copy"
+
+	RootKindProject = "project"
+	RootKindHome    = "home"
+	RootKindSystem  = "system"
+	RootKindFixed   = "fixed"
+)
+
+// Root は配置先基準の kind。project / home / system は実行時解決のためパスを持たず、
+// fixed のみ評価時確定の絶対パスを Root に持つ（→ docs/spec.md）。
+type Root struct {
+	RootKind string `json:"rootKind"`
+	Root     string `json:"root,omitempty"`
+}
+
+// Entry は 1 配置定義。identity は Target（属性キー由来・stale 除去の diff キー・→ ADR-0014）。
+type Entry struct {
+	SrcKind string `json:"srcKind"`
+	Src     string `json:"src"`
+	Subpath string `json:"subpath"`
+	Target  string `json:"target"`
+	Method  string `json:"method"`
+}
+
+// Manifest は manifest.json トップレベル。
+type Manifest struct {
+	SchemaVersion int     `json:"schemaVersion"`
+	Root          Root    `json:"root"`
+	Entries       []Entry `json:"entries"`
+}
+
+// Load は link-farm ディレクトリ内の manifest.json を読み、schemaVersion を検証する。
+func Load(linkFarm string) (*Manifest, error) {
+	return LoadFile(filepath.Join(linkFarm, FileName))
+}
+
+// LoadFile は manifest.json ファイルを直接読み、schemaVersion を検証する。
+func LoadFile(path string) (*Manifest, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("nput: manifest.json を読めません: %w", err)
+	}
+
+	var m Manifest
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&m); err != nil {
+		return nil, fmt.Errorf("nput: manifest.json を解析できません (%s): %w", path, err)
+	}
+
+	if err := m.validate(); err != nil {
+		return nil, fmt.Errorf("nput: manifest.json が不正です (%s): %w", path, err)
+	}
+	return &m, nil
+}
+
+func (m *Manifest) validate() error {
+	// engine は自身の対応版より新しい schemaVersion を拒否する（→ ADR-0006）。
+	if m.SchemaVersion > SchemaVersion {
+		return fmt.Errorf("schemaVersion %d は未対応です（この engine は v%d まで対応）", m.SchemaVersion, SchemaVersion)
+	}
+	if m.SchemaVersion < 1 {
+		return fmt.Errorf("schemaVersion %d は不正です", m.SchemaVersion)
+	}
+	if m.Root.RootKind == "" {
+		return fmt.Errorf("root.rootKind が空です")
+	}
+	return nil
+}

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -1,0 +1,76 @@
+package manifest
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeManifest(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	p := filepath.Join(dir, FileName)
+	if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func TestLoadValid(t *testing.T) {
+	dir := writeManifest(t, `{
+	  "schemaVersion": 1,
+	  "root": { "rootKind": "project" },
+	  "entries": [
+	    { "srcKind": "store", "src": "/nix/store/aaa-source", "subpath": "skills/nix", "target": ".claude/skills/nix", "method": "symlink" }
+	  ]
+	}`)
+
+	m, err := Load(dir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if m.SchemaVersion != 1 {
+		t.Errorf("schemaVersion = %d, want 1", m.SchemaVersion)
+	}
+	if m.Root.RootKind != RootKindProject {
+		t.Errorf("rootKind = %q, want project", m.Root.RootKind)
+	}
+	if len(m.Entries) != 1 {
+		t.Fatalf("entries = %d, want 1", len(m.Entries))
+	}
+	e := m.Entries[0]
+	if e.SrcKind != SrcKindStore || e.Src != "/nix/store/aaa-source" || e.Subpath != "skills/nix" || e.Target != ".claude/skills/nix" || e.Method != MethodSymlink {
+		t.Errorf("entry mismatch: %+v", e)
+	}
+}
+
+func TestLoadRejectsNewerSchema(t *testing.T) {
+	dir := writeManifest(t, `{ "schemaVersion": 2, "root": { "rootKind": "project" }, "entries": [] }`)
+	if _, err := Load(dir); err == nil {
+		t.Fatal("expected error for schemaVersion 2, got nil")
+	}
+}
+
+func TestLoadRejectsUnknownField(t *testing.T) {
+	dir := writeManifest(t, `{ "schemaVersion": 1, "root": { "rootKind": "project" }, "entries": [], "bogus": true }`)
+	if _, err := Load(dir); err == nil {
+		t.Fatal("expected error for unknown field, got nil")
+	}
+}
+
+func TestLoadMissingFile(t *testing.T) {
+	if _, err := Load(t.TempDir()); err == nil {
+		t.Fatal("expected error for missing manifest.json, got nil")
+	}
+}
+
+func TestLoadFixedRootHasPath(t *testing.T) {
+	dir := writeManifest(t, `{ "schemaVersion": 1, "root": { "rootKind": "fixed", "root": "/opt/x" }, "entries": [] }`)
+	m, err := Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m.Root.Root != "/opt/x" {
+		t.Errorf("fixed root = %q, want /opt/x", m.Root.Root)
+	}
+}

--- a/internal/paths/paths.go
+++ b/internal/paths/paths.go
@@ -1,0 +1,84 @@
+// Package paths computes the on-disk profile layout the engine operates on
+// (→ ADR-0005, ADR-0013, ADR-0022, ADR-0024, ADR-0025).
+//
+// profileDir は各 config 専用ディレクトリ（= flock キー）。profile リンクはその中の
+// profile、世代は profile-N-link、build out-link は .pending、backref .root は
+// <roothash> 階層に置く（→ docs/spec.md「profile のオンディスクレイアウト」）。
+package paths
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/yasunori0418/nput/internal/manifest"
+)
+
+// rootHashLen は roothash の hex 文字数（128bit・固定長・FS 安全・→ ADR-0013）。
+// lib.mkManifest の anchorName（sha256 の先頭 32 hex）と桁を揃える。
+const rootHashLen = 32
+
+// StateDir は profile 群の基底 <state> を返す。$XDG_STATE_HOME があればそれ、
+// 無ければ $HOME/.local/state（nix 本体の profile 既定と整合・→ ADR-0022）。
+func StateDir() (string, error) {
+	if s := os.Getenv("XDG_STATE_HOME"); s != "" {
+		return s, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("nput: $HOME を解決できません: %w", err)
+	}
+	return filepath.Join(home, ".local", "state"), nil
+}
+
+// RootHash は解決後の絶対 root パスの sha256 を短縮した hex を返す（→ ADR-0013）。
+func RootHash(absRoot string) string {
+	sum := sha256.Sum256([]byte(absRoot))
+	return hex.EncodeToString(sum[:])[:rootHashLen]
+}
+
+// Profile は 1 config 分の profile レイアウトのパス一式。
+type Profile struct {
+	// Dir は profileDir（config 専用ディレクトリ・flock キー）。
+	Dir string
+	// Profile は profile リンク（nix-env --profile の対象）。
+	Profile string
+	// Pending は nix build --out-link の出力先（profile を貫通しない兄弟）。
+	Pending string
+	// BackrefDir は backref .root を置く階層。home（--root なし）では空。
+	BackrefDir string
+	// Backref は元 root の絶対パスを記録する backref ファイル。home では空。
+	Backref string
+}
+
+// Resolve は state 基底・config 名・rootKind・解決後絶対 root・--root 上書き有無から
+// profile レイアウトを確定する（→ docs/spec.md「root の解決」表・ADR-0024, ADR-0025）。
+//
+//   - home（--root なし）              : <state>/nix/profiles/nput/<name>（backref なし）
+//   - project / fixed / --root 上書き : <state>/nix/profiles/nput/<roothash>/<name>
+//     （backref .root は <roothash> 階層）
+func Resolve(stateDir, name, rootKind, absRoot string, rootOverride bool) Profile {
+	base := filepath.Join(stateDir, "nix", "profiles", "nput")
+
+	// home（--root なし）のみ <name> 直キー。それ以外は root ごとに独立系列へ分離する。
+	if rootKind == manifest.RootKindHome && !rootOverride {
+		dir := filepath.Join(base, name)
+		return Profile{
+			Dir:     dir,
+			Profile: filepath.Join(dir, "profile"),
+			Pending: filepath.Join(dir, ".pending"),
+		}
+	}
+
+	hashDir := filepath.Join(base, RootHash(absRoot))
+	dir := filepath.Join(hashDir, name)
+	return Profile{
+		Dir:        dir,
+		Profile:    filepath.Join(dir, "profile"),
+		Pending:    filepath.Join(dir, ".pending"),
+		BackrefDir: hashDir,
+		Backref:    filepath.Join(hashDir, ".root"),
+	}
+}

--- a/internal/paths/paths_test.go
+++ b/internal/paths/paths_test.go
@@ -1,0 +1,89 @@
+package paths
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/yasunori0418/nput/internal/manifest"
+)
+
+func TestRootHashDeterministicAndFixedLen(t *testing.T) {
+	a := RootHash("/home/me/proj")
+	b := RootHash("/home/me/proj")
+	if a != b {
+		t.Errorf("RootHash not deterministic: %q != %q", a, b)
+	}
+	if len(a) != rootHashLen {
+		t.Errorf("RootHash len = %d, want %d", len(a), rootHashLen)
+	}
+	if c := RootHash("/home/me/other"); c == a {
+		t.Errorf("distinct roots collided: %q", c)
+	}
+	// FS 安全（hex のみ）。
+	for _, r := range a {
+		if (r < '0' || r > '9') && (r < 'a' || r > 'f') {
+			t.Errorf("RootHash has non-hex char %q in %q", r, a)
+		}
+	}
+}
+
+func TestResolveProjectUsesRootHash(t *testing.T) {
+	state := "/state"
+	root := "/home/me/proj"
+	p := Resolve(state, "skills", manifest.RootKindProject, root, false)
+
+	wantDir := filepath.Join(state, "nix", "profiles", "nput", RootHash(root), "skills")
+	if p.Dir != wantDir {
+		t.Errorf("Dir = %q, want %q", p.Dir, wantDir)
+	}
+	if p.Profile != filepath.Join(wantDir, "profile") {
+		t.Errorf("Profile = %q", p.Profile)
+	}
+	if p.Pending != filepath.Join(wantDir, ".pending") {
+		t.Errorf("Pending = %q", p.Pending)
+	}
+	wantBackref := filepath.Join(state, "nix", "profiles", "nput", RootHash(root), ".root")
+	if p.Backref != wantBackref {
+		t.Errorf("Backref = %q, want %q", p.Backref, wantBackref)
+	}
+}
+
+func TestResolveHomeUsesNameKey(t *testing.T) {
+	state := "/state"
+	p := Resolve(state, "vim", manifest.RootKindHome, "/home/me", false)
+	wantDir := filepath.Join(state, "nix", "profiles", "nput", "vim")
+	if p.Dir != wantDir {
+		t.Errorf("Dir = %q, want %q", p.Dir, wantDir)
+	}
+	if p.Backref != "" {
+		t.Errorf("home (no --root) should have no backref, got %q", p.Backref)
+	}
+}
+
+func TestResolveHomeWithOverrideUsesRootHash(t *testing.T) {
+	// --root 明示時は home でも roothash キー（→ ADR-0023）。
+	state := "/state"
+	root := "/tmp/sandbox"
+	p := Resolve(state, "vim", manifest.RootKindHome, root, true)
+	wantDir := filepath.Join(state, "nix", "profiles", "nput", RootHash(root), "vim")
+	if p.Dir != wantDir {
+		t.Errorf("Dir = %q, want %q", p.Dir, wantDir)
+	}
+	if p.Backref == "" {
+		t.Error("override should produce a backref")
+	}
+}
+
+func TestResolveFixedUsesRootHash(t *testing.T) {
+	// fixed root（--root なし）も roothash キー（→ ADR-0024）。
+	state := "/state"
+	root := "/opt/x"
+	p := Resolve(state, "c", manifest.RootKindFixed, root, false)
+	if p.Backref == "" {
+		t.Error("fixed root should produce a backref")
+	}
+	wantDir := filepath.Join(state, "nix", "profiles", "nput", RootHash(root), "c")
+	if p.Dir != wantDir {
+		t.Errorf("Dir = %q, want %q", p.Dir, wantDir)
+	}
+}


### PR DESCRIPTION
## 概要

Issue #6（1b: Go engine — project mode で store-symlink 配置 + flake パッケージング）の実装。
#5（feat-lib-mkmanifest）の上に積んだ stacked branch で、base を `feat-lib-mkmanifest` に向けている。

Closes #6

## 対応内容

### 配置エンジン最小核（`internal/`・stdlib-only）
- `internal/manifest` — manifest.json v1 の読み取りと `schemaVersion` 検証（新版拒否・→ ADR-0006, ADR-0013）
- `internal/paths` — `<state>`（`$XDG_STATE_HOME`／`~/.local/state`）解決・`<roothash>`（解決後絶対 root の sha256 短縮 hex）・profileDir キーイング（project/fixed/`--root` は `<roothash>/<name>`、home は `<name>`・→ ADR-0022, ADR-0024, ADR-0025）
- `internal/lock` — `syscall.Flock` による profileDir 単位の排他ロック（blocking/`LOCK_NB`・→ ADR-0011, ADR-0013）
- `internal/gitutil` — `git rev-parse --show-toplevel` による project mode root 解決（git 外／git 不在を明確なエラーで停止・→ ADR-0005）
- `internal/engine` — root 解決 → profileDir 確定 → backref `.root` 書き出し → flock → 前世代 manifest 読み → 祖先 lstat walk → store-symlink 配置 → 保守的 stale 除去 → `nix-env --set` の駆動（→ ADR-0006, ADR-0015, ADR-0025）

配置動作: 祖先が symlink ならエラー停止、target に通常ファイル/ディレクトリ既存ならエラー停止、foreign symlink は warning を出して後勝ち、記録通りの symlink のみ silent 置換／保守的 stale 除去（→ ADR-0015）。

コミット点（`nix-env --set`）は `CommitFunc` で注入可能にし、tmpdir テストでは nix を呼ばない（commit の e2e は 1c）。

### テスト（unit + tmpdir 統合・nix 不使用）
偽 manifest.json・一時 git repo で FS 配置 / flock / profileDir / backref / 祖先 lstat / foreign symlink / 記録一致張替 / 保守的 stale 除去 / `--no-wait` skip を検証（27 テスト）。

### flake パッケージング
- `packages.nput` = `buildGoModule`（`doCheck` で `go test` を実行）
- `nix flake check` に gofmt（treefmt）・`go vet`・`golangci-lint` の check を追加（→ ADR-0025）

## 影響範囲

- 編集: `internal/`・`go.mod`・`flake.nix`(`packages.nput` + check derivation)。`lib/`（#5）と `cmd/` には触れていない。
- `nix build .#nput` / `nix flake check` ともに通過を確認。

## 補足

- **vendorHash = null**: 本スライスは stdlib-only で外部依存ゼロのため。cobra / fatih-color が入る CLI スライス（1c・`cmd/`）で vendorHash 文字列へ切り替わる（→ ADR-0011）。
- **本スライスでは CLI（`cmd/`）を持たない**ため、`packages.nput` は `internal/` をライブラリとしてビルドし `go test` を回す構成（バイナリは未生成）。`nput` バイナリ本体は 1c で追加する。