### PR TITLE
feat(engine): stale 除去 + 保守的不変条件（planner/differ + conservative stale-remover）

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -17,6 +17,7 @@ import (
 	"github.com/yasunori0418/nput/internal/lock"
 	"github.com/yasunori0418/nput/internal/manifest"
 	"github.com/yasunori0418/nput/internal/paths"
+	"github.com/yasunori0418/nput/internal/planner"
 )
 
 // CommitFunc は配置成功後に世代を積むコミット点（→ ADR-0006, docs/spec.md 実行フロー f）。
@@ -161,15 +162,26 @@ func Apply(opts Options) (*Result, error) {
 	// 5. 前世代 manifest を読む（無ければ初回 = stale 除去ゼロ）。
 	prev := a.loadPrevManifest()
 
-	// 6. 配置 → stale 除去（新規 / 張替を先に、stale 除去を最後に・→ ADR-0006）。
-	if err := a.place(prev); err != nil {
+	// 6. planner で place/replace/remove プランを算出する（純ロジック・→ internal/planner）。
+	plan, err := planner.Compute(prev, a.manifest, a.root, planner.OSFS)
+	if err != nil {
 		return nil, err
 	}
-	if err := a.removeStale(prev); err != nil {
+	if len(plan.Conflicts) > 0 {
+		c := plan.Conflicts[0]
+		return nil, fmt.Errorf("nput: %s (target: %s)", c.Reason, c.Entry.Target)
+	}
+	a.emitWarnings(plan.Warnings)
+
+	// 7. プランを実 FS に反映（新規 / 張替を先に、stale 除去を最後に・→ ADR-0006）。
+	if err := a.place(plan.Place); err != nil {
+		return nil, err
+	}
+	if err := a.removeStale(plan.Remove); err != nil {
 		return nil, err
 	}
 
-	// 7. 世代コミット（→ docs/spec.md 実行フロー 2f）。
+	// 8. 世代コミット（→ docs/spec.md 実行フロー 2f）。
 	commit := opts.Commit
 	if commit == nil {
 		commit = nixEnvCommit
@@ -178,7 +190,7 @@ func Apply(opts Options) (*Result, error) {
 		return nil, fmt.Errorf("nput: 世代コミット（nix-env --set）に失敗しました: %w", err)
 	}
 
-	// 8. --set 成功後に .pending を削除する（世代リンクが gcroot を引き継ぐ・→ ADR-0011, ADR-0025）。
+	// 9. --set 成功後に .pending を削除する（世代リンクが gcroot を引き継ぐ・→ ADR-0011, ADR-0025）。
 	//    build 経路でのみ pending を張るため、その経路でのみ削除する。
 	if opts.Build != nil {
 		if err := os.Remove(a.profile.Pending); err != nil && !os.IsNotExist(err) {
@@ -267,21 +279,19 @@ func (a *applier) loadPrevManifest() *manifest.Manifest {
 	return m
 }
 
-func byTarget(m *manifest.Manifest) map[string]manifest.Entry {
-	if m == nil {
-		return nil
+// emitWarnings は planner が算出した非致命 warning を stderr（opts.Warnf）へ出す。
+// warning は --quiet でも消えない（→ docs/spec.md ストリーム規律・ADR-0015, ADR-0024）。
+func (a *applier) emitWarnings(ws []planner.Warning) {
+	for _, w := range ws {
+		switch w.Kind {
+		case planner.WarnForeignReplace:
+			a.opts.Warnf("nput: 記録の無い symlink を上書きします (foreign・後勝ち): %s", w.Target)
+		case planner.WarnStaleMismatch:
+			a.opts.Warnf("nput: stale symlink が記録と不一致のため残します: %s", w.Target)
+		case planner.WarnStaleNonSymlink:
+			a.opts.Warnf("nput: stale target が symlink ではないため残します: %s", w.Target)
+		case planner.WarnCopyOrphan:
+			a.opts.Warnf("nput: copy entry が消えましたが target は削除しません（orphan・reset で撤去）: %s", w.Target)
+		}
 	}
-	out := make(map[string]manifest.Entry, len(m.Entries))
-	for _, e := range m.Entries {
-		out[e.Target] = e
-	}
-	return out
-}
-
-// linkDest は entry の symlink が指すべき先（<src>/<subpath>）を返す。
-func linkDest(e manifest.Entry) string {
-	if e.Subpath == "" || e.Subpath == "." {
-		return e.Src
-	}
-	return filepath.Join(e.Src, e.Subpath)
 }

--- a/internal/engine/place.go
+++ b/internal/engine/place.go
@@ -4,157 +4,36 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
-	"github.com/yasunori0418/nput/internal/manifest"
+	"github.com/yasunori0418/nput/internal/planner"
 )
 
-// place は新世代 manifest の各 entry を配置する（新規 / 張替を stale 除去より先に・→ ADR-0006）。
-// 本スライスは store / out-of-store の symlink 配置のみ対応する（copy は将来スライス・→ Issue #6）。
-func (a *applier) place(prev *manifest.Manifest) error {
-	prevByTarget := byTarget(prev)
-	for _, e := range a.manifest.Entries {
-		switch e.Method {
-		case manifest.MethodSymlink:
-			if err := a.placeSymlink(e, prevByTarget); err != nil {
-				return err
+// place materializes the planner's Place actions as native symlinks
+// （新規 / 張替を stale 除去より先に・→ ADR-0006）。プランは planner.Compute が
+// 現 FS 状態から算出済みで、ここは plan を実 FS に反映する薄い executor に徹する。
+// 本スライスは store / out-of-store の symlink 配置のみ（copy は将来スライス・→ Issue #6）。
+func (a *applier) place(actions []planner.PlaceAction) error {
+	for _, act := range actions {
+		// 親ディレクトリを作成（祖先 symlink は planner が conflict として弾き済み・→ ADR-0015）。
+		if err := os.MkdirAll(filepath.Dir(act.TargetAbs), 0o755); err != nil {
+			return fmt.Errorf("nput: 親ディレクトリを作成できません (%s): %w", filepath.Dir(act.TargetAbs), err)
+		}
+
+		switch act.Kind {
+		case planner.PlaceNew:
+			a.result.Placed = append(a.result.Placed, act.Entry.Target)
+		case planner.PlaceReplace, planner.PlaceForeign:
+			// 張替は unlink + symlink（rename ベースの atomic swap は採らない・→ ADR-0017）。
+			// foreign 上書きの warning は planner.Warnings 経由で emitWarnings 済み（→ ADR-0015）。
+			if err := os.Remove(act.TargetAbs); err != nil {
+				return fmt.Errorf("nput: 既存 symlink を除去できません (%s): %w", act.TargetAbs, err)
 			}
-		case manifest.MethodCopy:
-			return fmt.Errorf("nput: method=copy は本スライスでは未実装です (target: %s)", e.Target)
-		default:
-			return fmt.Errorf("nput: 未知の method: %q (target: %s)", e.Method, e.Target)
+			a.result.Replaced = append(a.result.Replaced, act.Entry.Target)
+		}
+
+		if err := os.Symlink(act.Dest, act.TargetAbs); err != nil {
+			return fmt.Errorf("nput: symlink を作成できません (%s -> %s): %w", act.TargetAbs, act.Dest, err)
 		}
 	}
 	return nil
-}
-
-func (a *applier) placeSymlink(e manifest.Entry, prevByTarget map[string]manifest.Entry) error {
-	targetAbs := a.targetAbs(e.Target)
-
-	// 0. 祖先 component を lstat walk。symlink ならネスト不可で error 停止（→ ADR-0015）。
-	if err := a.checkAncestors(e.Target); err != nil {
-		return err
-	}
-
-	// 1. 親ディレクトリを作成（祖先 symlink は 0 で弾き済み）。
-	if err := os.MkdirAll(filepath.Dir(targetAbs), 0o755); err != nil {
-		return fmt.Errorf("nput: 親ディレクトリを作成できません (%s): %w", filepath.Dir(targetAbs), err)
-	}
-
-	dest := linkDest(e)
-
-	// 2. 既存 target の判定（→ docs/spec.md「symlink モード」・ADR-0015）。
-	info, err := os.Lstat(targetAbs)
-	switch {
-	case err == nil && info.Mode()&os.ModeSymlink != 0:
-		// 既存 symlink: 自身の前世代 manifest 記録通りなら silent、それ以外は foreign warning。
-		if !a.recordedLink(e.Target, targetAbs, prevByTarget) {
-			a.opts.Warnf("nput: 記録の無い symlink を上書きします (foreign・後勝ち): %s", e.Target)
-		}
-		if err := os.Remove(targetAbs); err != nil {
-			return fmt.Errorf("nput: 既存 symlink を除去できません (%s): %w", targetAbs, err)
-		}
-		a.result.Replaced = append(a.result.Replaced, e.Target)
-	case err == nil:
-		// 通常ファイル / ディレクトリは上書きしない（→ docs/spec.md エラー仕様）。
-		return fmt.Errorf("nput: target に既存のファイル/ディレクトリがあります（上書きしません）: %s", e.Target)
-	case os.IsNotExist(err):
-		a.result.Placed = append(a.result.Placed, e.Target)
-	default:
-		return fmt.Errorf("nput: target を lstat できません (%s): %w", targetAbs, err)
-	}
-
-	// 3. <配置元>/<subpath> を指す symlink を作成（張替は unlink + symlink・→ ADR-0017）。
-	if err := os.Symlink(dest, targetAbs); err != nil {
-		return fmt.Errorf("nput: symlink を作成できません (%s -> %s): %w", targetAbs, dest, err)
-	}
-	return nil
-}
-
-// checkAncestors は target の各祖先 component を root から順に lstat し、いずれかが
-// symlink なら error を返す（全体 symlink 配置の配下にネストできない・→ ADR-0015）。
-// 祖先が未作成ならそこで打ち切る（配下も存在しないため安全）。
-func (a *applier) checkAncestors(target string) error {
-	clean := filepath.Clean(target)
-	comps := strings.Split(clean, string(os.PathSeparator))
-	cur := a.root
-	for i := 0; i < len(comps)-1; i++ {
-		if comps[i] == "" {
-			continue
-		}
-		cur = filepath.Join(cur, comps[i])
-		info, err := os.Lstat(cur)
-		if err != nil {
-			if os.IsNotExist(err) {
-				return nil
-			}
-			return fmt.Errorf("nput: 祖先を lstat できません (%s): %w", cur, err)
-		}
-		if info.Mode()&os.ModeSymlink != 0 {
-			return fmt.Errorf("nput: 祖先 %q が symlink です。配下にネストできません (target: %s・→ ADR-0015)", cur, target)
-		}
-	}
-	return nil
-}
-
-// recordedLink は target が「自身の前世代 manifest が記録した symlink」かを判定する。
-// 前世代に同 target の entry があり、かつ実体の symlink が記録通りの先を指すときのみ true
-// （保守的不変条件・→ ADR-0002, ADR-0015）。
-func (a *applier) recordedLink(target, targetAbs string, prevByTarget map[string]manifest.Entry) bool {
-	pe, ok := prevByTarget[target]
-	if !ok {
-		return false
-	}
-	onDisk, err := os.Readlink(targetAbs)
-	if err != nil {
-		return false
-	}
-	return onDisk == linkDest(pe)
-}
-
-// removeStale は前世代にあって新世代から消えた entry を保守的に除去する（最後に実行・→ ADR-0006）。
-// 削除するのは「記録通りの先を指す symlink」のみ。foreign / 内容不一致は警告して残す。
-// copy entry は除去せず orphan を警告する（→ ADR-0002, ADR-0020）。
-func (a *applier) removeStale(prev *manifest.Manifest) error {
-	if prev == nil {
-		return nil
-	}
-	newByTarget := byTarget(a.manifest)
-	for _, pe := range prev.Entries {
-		if _, kept := newByTarget[pe.Target]; kept {
-			continue
-		}
-		if pe.Method == manifest.MethodCopy {
-			a.opts.Warnf("nput: copy entry が消えましたが target は削除しません（orphan・reset で撤去）: %s", pe.Target)
-			continue
-		}
-
-		targetAbs := a.targetAbs(pe.Target)
-		info, err := os.Lstat(targetAbs)
-		if err != nil {
-			if os.IsNotExist(err) {
-				continue // 既に無い = no-op。
-			}
-			return fmt.Errorf("nput: stale target を lstat できません (%s): %w", targetAbs, err)
-		}
-		if info.Mode()&os.ModeSymlink == 0 {
-			a.opts.Warnf("nput: stale target が symlink ではないため残します: %s", pe.Target)
-			continue
-		}
-		onDisk, err := os.Readlink(targetAbs)
-		if err != nil || onDisk != linkDest(pe) {
-			a.opts.Warnf("nput: stale symlink が記録と不一致のため残します: %s", pe.Target)
-			continue
-		}
-		if err := os.Remove(targetAbs); err != nil {
-			return fmt.Errorf("nput: stale symlink を除去できません (%s): %w", targetAbs, err)
-		}
-		a.result.Removed = append(a.result.Removed, pe.Target)
-	}
-	return nil
-}
-
-// targetAbs は root 相対 target を絶対パスへ正規化する。
-func (a *applier) targetAbs(target string) string {
-	return filepath.Join(a.root, filepath.Clean(target))
 }

--- a/internal/engine/staleremove.go
+++ b/internal/engine/staleremove.go
@@ -1,0 +1,43 @@
+package engine
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/yasunori0418/nput/internal/planner"
+)
+
+// removeStale applies the planner's Remove actions, re-verifying the conservative
+// invariant against the real FS immediately before each unlink. The plan already
+// restricts removals to「前世代記録あり かつ 現状も記録通りの先を指す symlink」,
+// but placement (and any concurrent change) runs between planning and removal, so
+// the stale-remover re-checks lstat/readlink and unlinks only when the invariant
+// still holds; drifted targets are kept with a warning (→ ADR-0002, ADR-0006,
+// docs/spec.md「stale 除去の対象と安全不変条件」).
+func (a *applier) removeStale(actions []planner.RemoveAction) error {
+	for _, act := range actions {
+		if !reverifyStale(act) {
+			a.opts.Warnf("nput: stale symlink が plan 後にドリフトしたため残します: %s", act.Entry.Target)
+			continue
+		}
+		if err := os.Remove(act.TargetAbs); err != nil {
+			return fmt.Errorf("nput: stale symlink を除去できません (%s): %w", act.TargetAbs, err)
+		}
+		a.result.Removed = append(a.result.Removed, act.Entry.Target)
+	}
+	return nil
+}
+
+// reverifyStale re-checks the conservative invariant on the real FS right before
+// unlink: the target must still be a symlink pointing to the recorded dest.
+func reverifyStale(act planner.RemoveAction) bool {
+	info, err := os.Lstat(act.TargetAbs)
+	if err != nil || info.Mode()&os.ModeSymlink == 0 {
+		return false
+	}
+	onDisk, err := os.Readlink(act.TargetAbs)
+	if err != nil {
+		return false
+	}
+	return onDisk == planner.LinkDest(act.Entry)
+}

--- a/internal/planner/planner.go
+++ b/internal/planner/planner.go
@@ -1,0 +1,274 @@
+// Package planner is the diff/plan deep module of the placement engine: given
+// the previous-generation manifest, the new manifest, the resolved root, and an
+// FS prober, it computes a place/replace/remove plan as pure logic. The
+// conservative stale-removal invariant lives here — a stale symlink is only
+// scheduled for removal when the previous generation recorded it AND the on-disk
+// link still points to the recorded destination. Regular files, foreign links,
+// and record/reality mismatches are never removed; copy entries are never
+// removed (orphan warning only); the first apply (no previous manifest) removes
+// nothing (→ ADR-0002, ADR-0006, ADR-0015, docs/spec.md「stale 除去の対象と安全不変条件」).
+//
+// The plan is computed without mutating the filesystem. The engine consumes the
+// plan: it materializes Place actions and hands Remove actions to the
+// conservative stale-remover, which re-verifies the invariant against the real
+// FS immediately before unlinking.
+package planner
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/yasunori0418/nput/internal/manifest"
+)
+
+// FS abstracts the lstat/readlink probes the planner needs, so diff
+// classification is a pure function over (manifests, FS state) and can be
+// table-tested with a fake FS without touching the real filesystem
+// (→ ADR-0006, docs/spec.md「stale 除去の対象と安全不変条件」).
+type FS interface {
+	Lstat(path string) (os.FileInfo, error)
+	Readlink(path string) (string, error)
+}
+
+// osFS is the real-filesystem FS used at engine runtime.
+type osFS struct{}
+
+func (osFS) Lstat(path string) (os.FileInfo, error) { return os.Lstat(path) }
+func (osFS) Readlink(path string) (string, error)   { return os.Readlink(path) }
+
+// OSFS probes the real filesystem (engine runtime).
+var OSFS FS = osFS{}
+
+// PlaceKind classifies how a new-generation entry maps onto the current FS.
+type PlaceKind int
+
+const (
+	// PlaceNew は target が不在で新規 symlink を作る。
+	PlaceNew PlaceKind = iota
+	// PlaceReplace は自身の前世代 manifest が記録した symlink を silent に張り替える。
+	PlaceReplace
+	// PlaceForeign は記録の無い symlink（foreign）を warning 付きで後勝ち置換する（→ ADR-0015）。
+	PlaceForeign
+)
+
+// PlaceAction is a symlink to materialize at TargetAbs pointing to Dest.
+type PlaceAction struct {
+	Entry     manifest.Entry
+	TargetAbs string
+	Dest      string // LinkDest(Entry): <src>/<subpath>
+	Kind      PlaceKind
+}
+
+// RemoveAction is a stale symlink that satisfies the conservative invariant at
+// plan time (recorded by prev AND on-disk points to the recorded dest). The
+// stale-remover re-verifies this against the real FS before unlinking.
+type RemoveAction struct {
+	Entry     manifest.Entry
+	TargetAbs string
+}
+
+// Conflict is a placement target the engine must stop on: occupied by a non-symlink
+// (regular file / directory) or nested under a symlinked ancestor (→ ADR-0015).
+type Conflict struct {
+	Entry     manifest.Entry
+	TargetAbs string
+	Reason    string
+}
+
+// WarnKind enumerates non-fatal conditions the planner surfaces to the user.
+type WarnKind int
+
+const (
+	// WarnForeignReplace は記録の無い symlink を上書きする（place・後勝ち・→ ADR-0015）。
+	WarnForeignReplace WarnKind = iota
+	// WarnStaleMismatch は stale target が記録と不一致な symlink のため残す（→ ADR-0002）。
+	WarnStaleMismatch
+	// WarnStaleNonSymlink は stale target が symlink でない（通常ファイル等）ため残す。
+	WarnStaleNonSymlink
+	// WarnCopyOrphan は消えた copy entry の orphan（削除はしない・reset で撤去・→ ADR-0020）。
+	WarnCopyOrphan
+)
+
+// Warning is a non-fatal condition surfaced to the user for a given target.
+type Warning struct {
+	Kind   WarnKind
+	Target string
+}
+
+// Plan is the computed place/replace/remove plan plus non-fatal warnings and
+// fatal conflicts. The engine executes Place then Remove (「新規/張替を先に、stale
+// 除去を最後に」・→ ADR-0006); a non-empty Conflicts means apply must stop.
+type Plan struct {
+	Place     []PlaceAction
+	Remove    []RemoveAction
+	Conflicts []Conflict
+	Warnings  []Warning
+}
+
+// LinkDest は entry の symlink が指すべき先（<src>/<subpath>）を返す。
+func LinkDest(e manifest.Entry) string {
+	if e.Subpath == "" || e.Subpath == "." {
+		return e.Src
+	}
+	return filepath.Join(e.Src, e.Subpath)
+}
+
+// Compute は前世代 manifest（prev・nil なら初回）と新 manifest（next）を root と FS
+// 状態に照らして diff し、place/replace/remove プランを算出する純ロジック。
+// 副作用は持たず、FS への反映は engine（place + stale-remover）が行う。
+func Compute(prev, next *manifest.Manifest, root string, fs FS) (Plan, error) {
+	var plan Plan
+
+	// --- place / replace 側: 新世代の各 entry を現 FS に照らして分類する ---
+	prevByTarget := byTarget(prev)
+	for _, e := range entriesOf(next) {
+		switch e.Method {
+		case manifest.MethodSymlink:
+			// 本スライスは symlink のみ対応。
+		case manifest.MethodCopy:
+			return Plan{}, fmt.Errorf("nput: method=copy は本スライスでは未実装です (target: %s)", e.Target)
+		default:
+			return Plan{}, fmt.Errorf("nput: 未知の method: %q (target: %s)", e.Method, e.Target)
+		}
+
+		targetAbs := filepath.Join(root, filepath.Clean(e.Target))
+
+		// 祖先 component が symlink ならネスト不可で conflict（→ ADR-0015）。
+		offender, err := ancestorSymlink(root, e.Target, fs)
+		if err != nil {
+			return Plan{}, err
+		}
+		if offender != "" {
+			plan.Conflicts = append(plan.Conflicts, Conflict{
+				Entry:     e,
+				TargetAbs: targetAbs,
+				Reason:    fmt.Sprintf("祖先 %q が symlink です。配下にネストできません (→ ADR-0015)", offender),
+			})
+			continue
+		}
+
+		info, err := fs.Lstat(targetAbs)
+		switch {
+		case err == nil && info.Mode()&os.ModeSymlink != 0:
+			kind := PlaceForeign
+			if recordedLink(e.Target, targetAbs, prevByTarget, fs) {
+				kind = PlaceReplace
+			} else {
+				plan.Warnings = append(plan.Warnings, Warning{Kind: WarnForeignReplace, Target: e.Target})
+			}
+			plan.Place = append(plan.Place, PlaceAction{Entry: e, TargetAbs: targetAbs, Dest: LinkDest(e), Kind: kind})
+		case err == nil:
+			// 通常ファイル / ディレクトリは上書きしない（→ docs/spec.md エラー仕様）。
+			plan.Conflicts = append(plan.Conflicts, Conflict{
+				Entry:     e,
+				TargetAbs: targetAbs,
+				Reason:    "target に既存のファイル/ディレクトリがあります（上書きしません）",
+			})
+		case os.IsNotExist(err):
+			plan.Place = append(plan.Place, PlaceAction{Entry: e, TargetAbs: targetAbs, Dest: LinkDest(e), Kind: PlaceNew})
+		default:
+			return Plan{}, fmt.Errorf("nput: target を lstat できません (%s): %w", targetAbs, err)
+		}
+	}
+
+	// --- remove 側: stale entry（prev ∖ next）を保守的不変条件下で算出する ---
+	// 初回（prev == nil）は何も消さない（→ ADR-0006）。
+	if prev != nil {
+		nextByTarget := byTarget(next)
+		for _, pe := range prev.Entries {
+			if _, kept := nextByTarget[pe.Target]; kept {
+				continue
+			}
+			if pe.Method == manifest.MethodCopy {
+				// copy はユーザー所有データ。削除せず orphan を警告（→ ADR-0002, ADR-0020）。
+				plan.Warnings = append(plan.Warnings, Warning{Kind: WarnCopyOrphan, Target: pe.Target})
+				continue
+			}
+
+			targetAbs := filepath.Join(root, filepath.Clean(pe.Target))
+			info, err := fs.Lstat(targetAbs)
+			switch {
+			case err != nil && os.IsNotExist(err):
+				continue // 既に無い = no-op（警告なし）。
+			case err != nil:
+				return Plan{}, fmt.Errorf("nput: stale target を lstat できません (%s): %w", targetAbs, err)
+			case info.Mode()&os.ModeSymlink == 0:
+				// 通常ファイル / ディレクトリには触れない（→ docs/spec.md 安全不変条件）。
+				plan.Warnings = append(plan.Warnings, Warning{Kind: WarnStaleNonSymlink, Target: pe.Target})
+				continue
+			}
+
+			onDisk, err := fs.Readlink(targetAbs)
+			if err != nil || onDisk != LinkDest(pe) {
+				// 記録と実体が不一致（foreign / ユーザー差し替え）→ 削除せず警告（→ ADR-0002）。
+				plan.Warnings = append(plan.Warnings, Warning{Kind: WarnStaleMismatch, Target: pe.Target})
+				continue
+			}
+			plan.Remove = append(plan.Remove, RemoveAction{Entry: pe, TargetAbs: targetAbs})
+		}
+	}
+
+	return plan, nil
+}
+
+func entriesOf(m *manifest.Manifest) []manifest.Entry {
+	if m == nil {
+		return nil
+	}
+	return m.Entries
+}
+
+func byTarget(m *manifest.Manifest) map[string]manifest.Entry {
+	if m == nil {
+		return nil
+	}
+	out := make(map[string]manifest.Entry, len(m.Entries))
+	for _, e := range m.Entries {
+		out[e.Target] = e
+	}
+	return out
+}
+
+// recordedLink は target が「自身の前世代 manifest が記録した symlink」かを判定する。
+// 前世代に同 target の entry があり、かつ実体の symlink が記録通りの先を指すときのみ true
+// （保守的不変条件・→ ADR-0002, ADR-0015）。
+func recordedLink(target, targetAbs string, prevByTarget map[string]manifest.Entry, fs FS) bool {
+	pe, ok := prevByTarget[target]
+	if !ok {
+		return false
+	}
+	onDisk, err := fs.Readlink(targetAbs)
+	if err != nil {
+		return false
+	}
+	return onDisk == LinkDest(pe)
+}
+
+// ancestorSymlink walks the target's ancestor components under root and returns
+// the first existing ancestor that is a symlink (全体 symlink 配置の配下にネスト不可・
+// → ADR-0015). A non-existent ancestor stops the walk (its descendants don't exist
+// either), returning "" with no error.
+func ancestorSymlink(root, target string, fs FS) (string, error) {
+	clean := filepath.Clean(target)
+	comps := strings.Split(clean, string(os.PathSeparator))
+	cur := root
+	for i := 0; i < len(comps)-1; i++ {
+		if comps[i] == "" {
+			continue
+		}
+		cur = filepath.Join(cur, comps[i])
+		info, err := fs.Lstat(cur)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return "", nil
+			}
+			return "", fmt.Errorf("nput: 祖先を lstat できません (%s): %w", cur, err)
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return cur, nil
+		}
+	}
+	return "", nil
+}

--- a/internal/planner/planner_test.go
+++ b/internal/planner/planner_test.go
@@ -1,0 +1,333 @@
+package planner
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/yasunori0418/nput/internal/manifest"
+)
+
+// --- fake FS（純関数 planner を実 FS なしで table-test するための偽 lstat/readlink）---
+
+type fakeEntry struct {
+	mode os.FileMode // ModeSymlink / ModeDir / 0(regular) を立てる
+	dest string      // symlink のとき readlink が返す先
+}
+
+func sym(dest string) fakeEntry { return fakeEntry{mode: os.ModeSymlink, dest: dest} }
+func dir() fakeEntry            { return fakeEntry{mode: os.ModeDir} }
+func reg() fakeEntry            { return fakeEntry{mode: 0} }
+
+type fakeFS map[string]fakeEntry
+
+func (f fakeFS) Lstat(path string) (os.FileInfo, error) {
+	e, ok := f[path]
+	if !ok {
+		return nil, os.ErrNotExist // os.IsNotExist が true になる
+	}
+	return fakeInfo{name: filepath.Base(path), mode: e.mode}, nil
+}
+
+func (f fakeFS) Readlink(path string) (string, error) {
+	e, ok := f[path]
+	if !ok || e.mode&os.ModeSymlink == 0 {
+		return "", os.ErrInvalid
+	}
+	return e.dest, nil
+}
+
+type fakeInfo struct {
+	name string
+	mode os.FileMode
+}
+
+func (i fakeInfo) Name() string       { return i.name }
+func (i fakeInfo) Size() int64        { return 0 }
+func (i fakeInfo) Mode() os.FileMode  { return i.mode }
+func (i fakeInfo) ModTime() time.Time { return time.Time{} }
+func (i fakeInfo) IsDir() bool        { return i.mode&os.ModeDir != 0 }
+func (i fakeInfo) Sys() any           { return nil }
+
+// --- manifest helpers -------------------------------------------------------
+
+const root = "/root"
+
+func entry(src, subpath, target, method string) manifest.Entry {
+	return manifest.Entry{
+		SrcKind: manifest.SrcKindStore,
+		Src:     src,
+		Subpath: subpath,
+		Target:  target,
+		Method:  method,
+	}
+}
+
+func sl(src, target string) manifest.Entry { return entry(src, ".", target, manifest.MethodSymlink) }
+func cp(src, target string) manifest.Entry { return entry(src, ".", target, manifest.MethodCopy) }
+
+func mani(entries ...manifest.Entry) *manifest.Manifest {
+	return &manifest.Manifest{
+		SchemaVersion: 1,
+		Root:          manifest.Root{RootKind: manifest.RootKindProject},
+		Entries:       entries,
+	}
+}
+
+func abs(target string) string { return filepath.Join(root, filepath.Clean(target)) }
+
+// --- expectations -----------------------------------------------------------
+
+type want struct {
+	placeNew     []string
+	placeReplace []string
+	placeForeign []string
+	remove       []string
+	warns        []WarnKind
+	conflicts    int
+}
+
+func placeTargets(p Plan, kind PlaceKind) []string {
+	var out []string
+	for _, a := range p.Place {
+		if a.Kind == kind {
+			out = append(out, a.Entry.Target)
+		}
+	}
+	return out
+}
+
+func removeTargets(p Plan) []string {
+	var out []string
+	for _, a := range p.Remove {
+		out = append(out, a.Entry.Target)
+	}
+	return out
+}
+
+func warnKinds(p Plan) []WarnKind {
+	var out []WarnKind
+	for _, w := range p.Warnings {
+		out = append(out, w.Kind)
+	}
+	return out
+}
+
+func sortedEq(t *testing.T, label string, got, want []string) {
+	t.Helper()
+	g := append([]string(nil), got...)
+	w := append([]string(nil), want...)
+	sort.Strings(g)
+	sort.Strings(w)
+	if len(g) != len(w) {
+		t.Errorf("%s = %v, want %v", label, got, want)
+		return
+	}
+	for i := range g {
+		if g[i] != w[i] {
+			t.Errorf("%s = %v, want %v", label, got, want)
+			return
+		}
+	}
+}
+
+func warnEq(t *testing.T, got, want []WarnKind) {
+	t.Helper()
+	g := append([]WarnKind(nil), got...)
+	w := append([]WarnKind(nil), want...)
+	sort.Slice(g, func(i, j int) bool { return g[i] < g[j] })
+	sort.Slice(w, func(i, j int) bool { return w[i] < w[j] })
+	if len(g) != len(w) {
+		t.Errorf("warnings = %v, want %v", got, want)
+		return
+	}
+	for i := range g {
+		if g[i] != w[i] {
+			t.Errorf("warnings = %v, want %v", got, want)
+			return
+		}
+	}
+}
+
+func TestComputeTableDriven(t *testing.T) {
+	const srcA, srcB = "/nix/store/aaa-src", "/nix/store/bbb-src"
+
+	tests := []struct {
+		name string
+		prev *manifest.Manifest
+		next *manifest.Manifest
+		fs   fakeFS
+		want want
+	}{
+		{
+			// 初回（前世代マニフェストなし）: 何も削除しない・新規配置のみ。
+			name: "first apply: prev nil, remove zero",
+			prev: nil,
+			next: mani(sl(srcA, ".config/foo")),
+			fs:   fakeFS{},
+			want: want{placeNew: []string{".config/foo"}},
+		},
+		{
+			// 記録あり×記録通り: 自身の前世代 symlink を silent 張替（foreign 警告なし）。
+			name: "recorded link → silent replace",
+			prev: mani(sl(srcA, ".config/foo")),
+			next: mani(sl(srcB, ".config/foo")),
+			fs:   fakeFS{abs(".config/foo"): sym(srcA)},
+			want: want{placeReplace: []string{".config/foo"}},
+		},
+		{
+			// foreign symlink（記録なし）: warning を出して後勝ち置換。
+			name: "foreign symlink → warn + replace",
+			prev: nil,
+			next: mani(sl(srcB, ".config/foo")),
+			fs:   fakeFS{abs(".config/foo"): sym("/somewhere/foreign")},
+			want: want{placeForeign: []string{".config/foo"}, warns: []WarnKind{WarnForeignReplace}},
+		},
+		{
+			// 通常ファイルが target に既存: 上書きしない conflict。
+			name: "regular file at place target → conflict",
+			prev: nil,
+			next: mani(sl(srcB, ".config/foo")),
+			fs:   fakeFS{abs(".config/foo"): reg()},
+			want: want{conflicts: 1},
+		},
+		{
+			// 祖先 component が symlink: 配下にネストできない conflict（→ ADR-0015）。
+			name: "ancestor symlink → conflict",
+			prev: nil,
+			next: mani(sl(srcB, ".claude/skills/nix")),
+			fs:   fakeFS{abs(".claude"): sym("/some/store")},
+			want: want{conflicts: 1},
+		},
+		{
+			// stale 記録通り: 保守的不変条件を満たすので remove。
+			name: "stale recorded link → remove",
+			prev: mani(sl(srcA, ".config/keep"), sl(srcA, ".config/drop")),
+			next: mani(sl(srcA, ".config/keep")),
+			fs: fakeFS{
+				abs(".config/keep"): sym(srcA),
+				abs(".config/drop"): sym(srcA),
+			},
+			want: want{
+				placeReplace: []string{".config/keep"},
+				remove:       []string{".config/drop"},
+			},
+		},
+		{
+			// entries = {}（空 manifest）: 前世代の全 nput symlink を保守的に除去（警告なし）。
+			name: "empty manifest → remove all recorded (no warning)",
+			prev: mani(sl(srcA, "a"), sl(srcA, "b")),
+			next: mani(),
+			fs: fakeFS{
+				abs("a"): sym(srcA),
+				abs("b"): sym(srcA),
+			},
+			want: want{remove: []string{"a", "b"}},
+		},
+		{
+			// stale 記録あり but 実体が別先を指す（不一致）: 削除せず warning。
+			name: "stale mismatch (recorded but points elsewhere) → keep + warn",
+			prev: mani(sl(srcA, ".config/foo")),
+			next: mani(),
+			fs:   fakeFS{abs(".config/foo"): sym("/other/place")},
+			want: want{warns: []WarnKind{WarnStaleMismatch}},
+		},
+		{
+			// stale target が通常ファイル: nput 非管理として残し warning。
+			name: "stale non-symlink (regular file) → keep + warn",
+			prev: mani(sl(srcA, ".config/foo")),
+			next: mani(),
+			fs:   fakeFS{abs(".config/foo"): reg()},
+			want: want{warns: []WarnKind{WarnStaleNonSymlink}},
+		},
+		{
+			// stale target が既に無い: no-op（警告なし）。
+			name: "stale already gone → no-op",
+			prev: mani(sl(srcA, ".config/foo")),
+			next: mani(),
+			fs:   fakeFS{},
+			want: want{},
+		},
+		{
+			// copy entry が消えた: 削除せず orphan を警告（FS 状態に依らない）。
+			name: "copy orphan → keep + warn",
+			prev: mani(cp(srcA, ".config/foo")),
+			next: mani(),
+			fs:   fakeFS{abs(".config/foo"): reg()},
+			want: want{warns: []WarnKind{WarnCopyOrphan}},
+		},
+		{
+			// 複合: 新規 + silent 張替 + foreign 警告 + stale 除去 + mismatch 残し。
+			name: "mixed plan",
+			prev: mani(sl(srcA, "keep"), sl(srcA, "drop"), sl(srcA, "mism")),
+			next: mani(sl(srcB, "keep"), sl(srcB, "fresh"), sl(srcB, "foreign")),
+			fs: fakeFS{
+				abs("keep"):    sym(srcA),          // 記録通り → silent replace
+				abs("drop"):    sym(srcA),          // stale 記録通り → remove
+				abs("mism"):    sym("/elsewhere"),  // stale 不一致 → keep + warn
+				abs("foreign"): sym("/foreign/ln"), // 記録なし symlink → foreign warn + replace
+				// fresh は不在 → PlaceNew
+			},
+			want: want{
+				placeNew:     []string{"fresh"},
+				placeReplace: []string{"keep"},
+				placeForeign: []string{"foreign"},
+				remove:       []string{"drop"},
+				warns:        []WarnKind{WarnForeignReplace, WarnStaleMismatch},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			plan, err := Compute(tt.prev, tt.next, root, tt.fs)
+			if err != nil {
+				t.Fatalf("Compute: unexpected error: %v", err)
+			}
+			sortedEq(t, "placeNew", placeTargets(plan, PlaceNew), tt.want.placeNew)
+			sortedEq(t, "placeReplace", placeTargets(plan, PlaceReplace), tt.want.placeReplace)
+			sortedEq(t, "placeForeign", placeTargets(plan, PlaceForeign), tt.want.placeForeign)
+			sortedEq(t, "remove", removeTargets(plan), tt.want.remove)
+			warnEq(t, warnKinds(plan), tt.want.warns)
+			if len(plan.Conflicts) != tt.want.conflicts {
+				t.Errorf("conflicts = %d, want %d (%v)", len(plan.Conflicts), tt.want.conflicts, plan.Conflicts)
+			}
+		})
+	}
+}
+
+// TestComputeCopyInNextErrors は新世代に copy entry があると未実装エラーになることを検証する
+// （本スライスは symlink のみ・→ Issue #6）。
+func TestComputeCopyInNextErrors(t *testing.T) {
+	_, err := Compute(nil, mani(cp("/nix/store/x", ".config/foo")), root, fakeFS{})
+	if err == nil {
+		t.Fatal("expected error for copy entry in next manifest, got nil")
+	}
+}
+
+// TestComputeUnknownMethodErrors は未知 method を弾くことを検証する。
+func TestComputeUnknownMethodErrors(t *testing.T) {
+	e := sl("/nix/store/x", ".config/foo")
+	e.Method = "bogus"
+	_, err := Compute(nil, mani(e), root, fakeFS{})
+	if err == nil {
+		t.Fatal("expected error for unknown method, got nil")
+	}
+}
+
+// TestComputeAncestorDirNotSymlink は祖先が通常ディレクトリなら conflict にならないことを確認する。
+func TestComputeAncestorDirNotSymlink(t *testing.T) {
+	plan, err := Compute(nil, mani(sl("/nix/store/x", ".config/foo")), root,
+		fakeFS{abs(".config"): dir()})
+	if err != nil {
+		t.Fatalf("Compute: %v", err)
+	}
+	if len(plan.Conflicts) != 0 {
+		t.Errorf("conflicts = %v, want none (ancestor is a dir)", plan.Conflicts)
+	}
+	if len(plan.Place) != 1 || plan.Place[0].Kind != PlaceNew {
+		t.Errorf("Place = %v, want one PlaceNew", plan.Place)
+	}
+}


### PR DESCRIPTION
## 概要

walking skeleton（#7）の単発 apply に、前世代との diff による保守的 stale 除去を end-to-end で足す。配置ロジックの diff 算出を engine から切り出し、deep module として整理した。

- **`internal/planner`（planner/differ・新規）**: 前世代 manifest・新 manifest・root・FS prober を入力に place/replace/remove プランを純ロジックで算出する。保守的不変条件（前世代記録あり かつ 現状も記録通りの先を指す symlink のみ remove 対象）を内包し、通常ファイル・foreign link・記録/実体不一致は remove せず警告、初回（prev nil）は remove ゼロ、空 manifest は全 nput symlink を警告なしで除去、copy entry は remove に含めず orphan 警告とする。FS を interface 注入で純関数化し、偽 FS による table-driven テストで「旧新 manifest + FS 状態 → 算出 plan」を網羅検証する。
- **`internal/engine`（refactor）**: インラインだった place / removeStale / recordedLink / checkAncestors を planner.Compute へ移し、engine は算出済みプランを実 FS へ反映する薄い executor に整理。conflict（通常ファイル既存・祖先 symlink）はプランから検出して停止し、warning はプラン由来を emitWarnings で出す。
- **conservative stale-remover（`staleremove.go`・分離）**: remove プランを unlink する直前に lstat/readlink で保守的不変条件を再検査し、plan 後にドリフトした target は削除せず警告で残す（TOCTOU 防御）。

配置順は従来どおり「新規/張替を先に、stale 除去を最後に」。`nix build .#nput`・`nix flake check`（go-vet / golangci-lint / go test / nix-unit / namaka）すべて通過。

## 関連 issue

Closes #9

## docs / ADR 影響

なし（既存の docs/spec.md・ADR-0002 / 0015 で確定済みの保守的不変条件に準拠した実装のみ。方針転換・新規 ADR なし）。
