### PR TITLE
feat(engine): out-of-store symlink の実行時リンク先存在チェックとテストを追加

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -173,6 +173,12 @@ func Apply(opts Options) (*Result, error) {
 	}
 	a.emitWarnings(plan.Warnings)
 
+	// 6.5 out-of-store のリンク先存在を配置直前に検査（dangling 禁止・→ ADR-0001, ADR-0013）。
+	//     FS 変更前に閉じるため、不在なら何も配置せずエラー停止する。
+	if err := a.checkOutOfStore(); err != nil {
+		return nil, err
+	}
+
 	// 7. プランを実 FS に反映（新規 / 張替を先に、stale 除去を最後に・→ ADR-0006）。
 	if err := a.place(plan.Place); err != nil {
 		return nil, err

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -95,6 +95,17 @@ func storeEntry(src, subpath, target string) manifest.Entry {
 	}
 }
 
+// outOfStoreEntry は marker のローカル絶対パス（store 外）を指す out-of-store symlink entry。
+func outOfStoreEntry(src, subpath, target string) manifest.Entry {
+	return manifest.Entry{
+		SrcKind: manifest.SrcKindOutOfStore,
+		Src:     src,
+		Subpath: subpath,
+		Target:  target,
+		Method:  manifest.MethodSymlink,
+	}
+}
+
 // --- tests -----------------------------------------------------------------
 
 func TestApplyFirstPlacementProjectMode(t *testing.T) {
@@ -422,6 +433,134 @@ func TestApplyNoWaitSkipsWhenLocked(t *testing.T) {
 	// skip したので配置はされない。
 	if _, err := os.Lstat(filepath.Join(root, ".config", "foo")); !os.IsNotExist(err) {
 		t.Errorf("skip should not place: lstat err = %v", err)
+	}
+}
+
+func TestApplyOutOfStorePlacesLiveSymlink(t *testing.T) {
+	root := realTempDir(t)
+	state := realTempDir(t)
+	// store 外のローカル実体を out-of-store のリンク先に使う。
+	src := makeSrc(t, "lua/init.lua")
+	lf := writeLinkFarm(t, projectManifest(outOfStoreEntry(src, "lua", ".config/nvim")))
+
+	res, err := Apply(Options{
+		LinkFarm: lf, Name: "c", RootOverride: root, StateDir: state, Commit: fakeCommit(nil),
+	})
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	target := filepath.Join(root, ".config", "nvim")
+	dest, err := os.Readlink(target)
+	if err != nil {
+		t.Fatalf("Readlink target: %v", err)
+	}
+	// live symlink は marker の絶対パス（<src>/<subpath>）を直接指す。
+	if want := filepath.Join(src, "lua"); dest != want {
+		t.Errorf("symlink dest = %q, want %q (local abs path)", dest, want)
+	}
+	// dangling でなく実体に解決できる。
+	if _, err := os.Stat(target); err != nil {
+		t.Errorf("symlink should resolve to a live path: %v", err)
+	}
+	if len(res.Placed) != 1 || res.Placed[0] != ".config/nvim" {
+		t.Errorf("Placed = %v", res.Placed)
+	}
+}
+
+func TestApplyOutOfStoreStaleRemoval(t *testing.T) {
+	root := realTempDir(t)
+	state := realTempDir(t)
+	src := makeSrc(t, "x")
+
+	// 1 回目: out-of-store entry を配置（manifest に marker の絶対パスが記録される）。
+	lf1 := writeLinkFarm(t, projectManifest(outOfStoreEntry(src, ".", ".config/nvim")))
+	var commits [][2]string
+	if _, err := Apply(Options{
+		LinkFarm: lf1, Name: "c", RootOverride: root, StateDir: state, Commit: fakeCommit(&commits),
+	}); err != nil {
+		t.Fatalf("first Apply: %v", err)
+	}
+	tgt := filepath.Join(root, ".config", "nvim")
+	if dest, _ := os.Readlink(tgt); dest != src {
+		t.Fatalf("first apply dest = %q, want %q", dest, src)
+	}
+
+	// 2 回目: 空 manifest。記録された out-of-store パスを指す link なので保守的不変条件を満たし除去。
+	lf2 := writeLinkFarm(t, projectManifest())
+	res, err := Apply(Options{
+		LinkFarm: lf2, Name: "c", RootOverride: root, StateDir: state, Commit: fakeCommit(&commits),
+	})
+	if err != nil {
+		t.Fatalf("second Apply: %v", err)
+	}
+	if _, err := os.Lstat(tgt); !os.IsNotExist(err) {
+		t.Errorf("recorded out-of-store link should be removed: lstat err = %v", err)
+	}
+	if len(res.Removed) != 1 || res.Removed[0] != ".config/nvim" {
+		t.Errorf("Removed = %v, want [.config/nvim]", res.Removed)
+	}
+}
+
+func TestApplyOutOfStoreStaleKeepsMismatch(t *testing.T) {
+	root := realTempDir(t)
+	state := realTempDir(t)
+	src := makeSrc(t, "x")
+
+	lf1 := writeLinkFarm(t, projectManifest(outOfStoreEntry(src, ".", ".config/nvim")))
+	var commits [][2]string
+	if _, err := Apply(Options{
+		LinkFarm: lf1, Name: "c", RootOverride: root, StateDir: state, Commit: fakeCommit(&commits),
+	}); err != nil {
+		t.Fatalf("first Apply: %v", err)
+	}
+
+	// ユーザーが target を別のローカル先へ差し替える（記録と不一致）→ stale 除去しない。
+	tgt := filepath.Join(root, ".config", "nvim")
+	_ = os.Remove(tgt)
+	if err := os.Symlink(realTempDir(t), tgt); err != nil {
+		t.Fatal(err)
+	}
+
+	lf2 := writeLinkFarm(t, projectManifest())
+	var warns []string
+	res, err := Apply(Options{
+		LinkFarm: lf2, Name: "c", RootOverride: root, StateDir: state,
+		Commit: fakeCommit(&commits), Warnf: collectWarnings(&warns),
+	})
+	if err != nil {
+		t.Fatalf("second Apply: %v", err)
+	}
+	if len(res.Removed) != 0 {
+		t.Errorf("Removed = %v, want none (mismatch kept)", res.Removed)
+	}
+	if _, err := os.Lstat(tgt); err != nil {
+		t.Errorf("mismatched out-of-store link should be kept: %v", err)
+	}
+	if len(warns) == 0 {
+		t.Error("expected a mismatch warning")
+	}
+}
+
+func TestApplyOutOfStoreMissingPathError(t *testing.T) {
+	root := realTempDir(t)
+	state := realTempDir(t)
+	// 存在しないローカルパスを out-of-store のリンク先にする。
+	missing := filepath.Join(realTempDir(t), "does-not-exist")
+	lf := writeLinkFarm(t, projectManifest(outOfStoreEntry(missing, ".", ".config/nvim")))
+
+	_, err := Apply(Options{
+		LinkFarm: lf, Name: "c", RootOverride: root, StateDir: state, Commit: fakeCommit(nil),
+	})
+	if err == nil {
+		t.Fatal("expected error for missing out-of-store path, got nil")
+	}
+	if !strings.Contains(err.Error(), "out-of-store") {
+		t.Errorf("error should mention out-of-store: %v", err)
+	}
+	// 不在検査は配置前に閉じるため target は作られない。
+	if _, err := os.Lstat(filepath.Join(root, ".config", "nvim")); !os.IsNotExist(err) {
+		t.Errorf("should not place on missing path: lstat err = %v", err)
 	}
 }
 

--- a/internal/engine/preflight.go
+++ b/internal/engine/preflight.go
@@ -1,0 +1,33 @@
+package engine
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/yasunori0418/nput/internal/manifest"
+	"github.com/yasunori0418/nput/internal/planner"
+)
+
+// checkOutOfStore は out-of-store symlink entry のリンク先（marker のローカル絶対パス +
+// subpath = planner.LinkDest）が実在することを配置直前に検査する。不在なら dangling symlink
+// を張ることになるため engine 実行時エラーで停止する（「リンク先不在は実行時エラー」・→ ADR-0001,
+// ADR-0013, docs/spec.md「out-of-store symlink」）。
+//
+// 検査は out-of-store のみに閉じる: store link は farm derivation のビルドで実在が保証され、
+// copy は別経路（place-once・本検査の対象外）。method=copy × out-of-store marker は
+// normalizeManifest が eval 時に弾くため、ここに copy の out-of-store entry は来ない（→ ADR-0013）。
+func (a *applier) checkOutOfStore() error {
+	for _, e := range a.manifest.Entries {
+		if e.SrcKind != manifest.SrcKindOutOfStore {
+			continue
+		}
+		dest := planner.LinkDest(e)
+		if _, err := os.Lstat(dest); err != nil {
+			if os.IsNotExist(err) {
+				return fmt.Errorf("nput: out-of-store のリンク先が存在しません (target: %s -> %s)。dangling symlink は張りません（→ ADR-0001）", e.Target, dest)
+			}
+			return fmt.Errorf("nput: out-of-store のリンク先を確認できません (target: %s -> %s): %w", e.Target, dest, err)
+		}
+	}
+	return nil
+}

--- a/tests/nix-unit.nix
+++ b/tests/nix-unit.nix
@@ -50,6 +50,40 @@ in
     };
   };
 
+  # out-of-store marker → clean enum 変換（→ ADR-0001, ADR-0010, ADR-0013）。
+  # srcKind = "outOfStore" / src = marker の絶対パスが記録され、_nputMarker は漏れない
+  # （expected は exact 一致なので余分なキーが残れば fail する）。
+  testOutOfStoreEntry = {
+    expr =
+      builtins.head
+        (norm nput.projectRoot {
+          ".config/nvim" = {
+            src = nput.mkOutOfStoreSymlink "/home/me/dotfiles/nvim";
+            subpath = "lua";
+          };
+        }).entries;
+    expected = {
+      srcKind = "outOfStore";
+      src = "/home/me/dotfiles/nvim";
+      subpath = "lua";
+      target = ".config/nvim";
+      method = "symlink";
+    };
+  };
+
+  # out-of-store entry に _nputMarker 判別タグが漏れていないことを明示アサートする。
+  testOutOfStoreMarkerNotLeaked = {
+    expr =
+      (builtins.head
+        (norm nput.projectRoot {
+          ".config/nvim" = {
+            src = nput.mkOutOfStoreSymlink "/home/me/dotfiles/nvim";
+          };
+        }).entries
+      ) ? _nputMarker;
+    expected = false;
+  };
+
   # ---- デフォルト適用（subpath="." / target=属性キー / method="symlink"）-----
   testDefaultsApplied = {
     expr =


### PR DESCRIPTION
## 概要

out-of-store symlink（`mkOutOfStoreSymlink`）の end-to-end 縦切り（issue #12）の
残作業を実装する。lib 層の marker→clean enum 変換・farm アンカー除外・copy×marker
の throwIf・既存 symlink 経路での配置は先行 PR で完成済みのため、本 PR は次の 2 点に閉じる。

- **engine 実行時のリンク先存在チェック**: marker のローカル絶対パス（`LinkDest`）が
  不在なら dangling symlink を張ることになるため、配置直前の pre-flight で検査し
  engine 実行時エラーで停止する。検査は out-of-store のみに閉じ、store / copy 経路や
  `place.go` の symlink ループには触れない。
- **テスト**: out-of-store placer の tmpdir 統合テストと、marker タグ→clean enum 変換の
  nix-unit ケースを追加。

## 関連 issue

Refs #12

## docs / ADR 影響

なし（ADR-0001 / ADR-0013 で既定済みの挙動を実装。spec「配置動作仕様 / out-of-store
symlink」の範囲内で、新たな方針転換は伴わない）。
