### PR TITLE
feat: home mode の rollback / list-generations と世代マネージャ

### DIFF
--- a/cmd/nput/list-generations.go
+++ b/cmd/nput/list-generations.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"sort"
+
+	"github.com/spf13/cobra"
+
+	"github.com/yasunori0418/nput/internal/engine"
+	"github.com/yasunori0418/nput/internal/manifest"
+	"github.com/yasunori0418/nput/internal/paths"
+)
+
+func newListGenerationsCmd() *cobra.Command {
+	var all bool
+	cmd := &cobra.Command{
+		Use:   "list-generations [name]",
+		Short: "世代一覧を表示（home mode 限定）",
+		Long: "home mode の profile の世代一覧を表示する読み取り専用コマンド。" +
+			"<name> でその config を、--all で home mode の全 config を一覧する。",
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if all {
+				if len(args) > 0 {
+					return fmt.Errorf("nput: list-generations は <name> と --all を併用できません")
+				}
+				return runListAllGenerations()
+			}
+			if len(args) != 1 {
+				return fmt.Errorf("nput: list-generations は <name> または --all が必要です")
+			}
+			return runListGenerations(args[0])
+		},
+	}
+	cmd.Flags().BoolVar(&all, "all", false, "home mode の全 config の世代を一覧")
+	return cmd
+}
+
+// runListGenerations は eval 先取りで rootKind を確認（home mode 限定）し、profileDir を確定して世代一覧を出す。
+func runListGenerations(name string) error {
+	ep, err := discoverEntrypoint(flagFile)
+	if err != nil {
+		return err
+	}
+	system, err := currentSystem()
+	if err != nil {
+		return err
+	}
+
+	rootKind, fixedRoot, err := evalRoot(ep, system, name)
+	if err != nil {
+		return err
+	}
+	if rootKind != manifest.RootKindHome {
+		return fmt.Errorf("nput: list-generations は home mode 限定です（nput.%s は rootKind=%q）", name, rootKind)
+	}
+
+	prof, _, err := engine.ProfileFor(engine.ProfileOptions{
+		Name:         name,
+		RootKind:     rootKind,
+		FixedRoot:    fixedRoot,
+		RootOverride: flagRoot,
+	})
+	if err != nil {
+		return err
+	}
+	gens, err := engine.ListGenerations(prof.Profile)
+	if err != nil {
+		return err
+	}
+	printGenerations(gens)
+	return nil
+}
+
+// runListAllGenerations は <state>/nix/profiles/nput 直下の home profile（直下に profile リンクを持つ
+// <name> ディレクトリ）を走査して各 config の世代を一覧する。entrypoint eval は不要（ディスク走査のみ）。
+// roothash 系列（project / fixed / --root）は <roothash>/<name> 構造で直下に profile を持たないため自然に除外される。
+func runListAllGenerations() error {
+	stateDir, err := paths.StateDir()
+	if err != nil {
+		return err
+	}
+	base := paths.Base(stateDir)
+	dents, err := os.ReadDir(base)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil // profile 未作成 = 一覧ゼロ。
+		}
+		return fmt.Errorf("nput: profile 基底を読めません (%s): %w", base, err)
+	}
+
+	var names []string
+	for _, d := range dents {
+		if !d.IsDir() {
+			continue
+		}
+		prof := paths.Resolve(stateDir, d.Name(), manifest.RootKindHome, "", false)
+		if _, err := os.Lstat(prof.Profile); err != nil {
+			continue // 直下に profile が無い = roothash 系列 / 空ディレクトリ。
+		}
+		names = append(names, d.Name())
+	}
+	sort.Strings(names)
+
+	for i, name := range names {
+		if i > 0 {
+			fmt.Println()
+		}
+		fmt.Printf("# %s\n", name)
+		prof := paths.Resolve(stateDir, name, manifest.RootKindHome, "", false)
+		gens, err := engine.ListGenerations(prof.Profile)
+		if err != nil {
+			return err
+		}
+		printGenerations(gens)
+	}
+	return nil
+}
+
+// printGenerations は世代一覧を stdout に出す（読み取りコマンドの一次出力・→ ADR-0023）。
+func printGenerations(gens []engine.Generation) {
+	for _, g := range gens {
+		marker := ""
+		if g.Current {
+			marker = "\t(current)"
+		}
+		fmt.Printf("%d\t%s%s\n", g.Number, g.Date, marker)
+	}
+}

--- a/cmd/nput/main.go
+++ b/cmd/nput/main.go
@@ -8,10 +8,13 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
+
+	"github.com/yasunori0418/nput/internal/manifest"
 )
 
 // グローバルフラグ（→ docs/spec.md「グローバルフラグ」）。本スライスは apply に必要な範囲のみ。
@@ -40,12 +43,21 @@ func newRootCmd() *cobra.Command {
 	pf.BoolVar(&flagVerbose, "verbose", false, "内部実行する nix コマンド等の詳細を出力")
 
 	root.AddCommand(newApplyCmd())
+	root.AddCommand(newRollbackCmd())
+	root.AddCommand(newListGenerationsCmd())
 	return root
 }
 
 func main() {
 	if err := newRootCmd().Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err)
+		// CLI/flake pin 間の schemaVersion skew は engine が拒否する（→ manifest.validate）。
+		// 上位で検知して原因と解消策を補う（→ docs/spec.md「manifest.json スキーマ」）。
+		if errors.Is(err, manifest.ErrSchemaVersionUnsupported) {
+			fmt.Fprintln(os.Stderr, "\nnput: CLI（engine）と flake が pin する nput のバージョンがずれている可能性があります。\n"+
+				"  flake の nput input が CLI より新しい manifest を生成しています。\n"+
+				"  CLI を更新するか、flake の nput input を CLI に合わせて下げて両者のバージョンを揃えてください。")
+		}
 		os.Exit(1)
 	}
 }

--- a/cmd/nput/rollback.go
+++ b/cmd/nput/rollback.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/yasunori0418/nput/internal/engine"
+	"github.com/yasunori0418/nput/internal/manifest"
+)
+
+func newRollbackCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "rollback <name>",
+		Short: "nput.<name> を前世代へ戻す（home mode 限定・名指し必須）",
+		Long: "home mode の profile を 1 世代前へ戻す。profile ポインタ移動だけでは任意 root の FS は変わらないため、" +
+			"現世代 N を baseline・前世代 N-1 を target として FS を再収束（N∖N-1 を保守的 stale 除去・N-1 を再配置）してから" +
+			"profile ポインタを移す。名指し必須（--all 非対応）・前世代が無ければエラー停止。",
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runRollback(args[0])
+		},
+	}
+}
+
+// runRollback は eval 先取りで rootKind を確認（home mode 限定）し、engine.Rollback を駆動する。
+func runRollback(name string) error {
+	ep, err := discoverEntrypoint(flagFile)
+	if err != nil {
+		return err
+	}
+	system, err := currentSystem()
+	if err != nil {
+		return err
+	}
+
+	rootKind, fixedRoot, err := evalRoot(ep, system, name)
+	if err != nil {
+		return err
+	}
+	if rootKind != manifest.RootKindHome {
+		return fmt.Errorf("nput: rollback は home mode 限定です（nput.%s は rootKind=%q・project / fixed は世代を公開しません）", name, rootKind)
+	}
+
+	res, err := engine.Rollback(engine.RollbackOptions{
+		Name:         name,
+		RootKind:     rootKind,
+		FixedRoot:    fixedRoot,
+		RootOverride: flagRoot,
+	})
+	if err != nil {
+		return err
+	}
+
+	if !flagQuiet {
+		reportRollback(res, name)
+	}
+	return nil
+}
+
+// reportRollback は世代遷移と配置差分を stderr に出す（stdout は機械可読出力に専有・→ ADR-0023）。
+func reportRollback(res *engine.RollbackResult, name string) {
+	fmt.Fprintf(os.Stderr, "nput: rollback %s 完了 (世代 %d → %d, root=%s)\n", name, res.From, res.To, res.Root)
+	for _, t := range res.Placed {
+		fmt.Fprintf(os.Stderr, "  placed   %s\n", t)
+	}
+	for _, t := range res.Replaced {
+		fmt.Fprintf(os.Stderr, "  replaced %s\n", t)
+	}
+	for _, t := range res.Removed {
+		fmt.Fprintf(os.Stderr, "  removed  %s\n", t)
+	}
+	if len(res.Placed)+len(res.Replaced)+len(res.Removed) == 0 {
+		fmt.Fprintln(os.Stderr, "  no-op")
+	}
+}

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -232,12 +232,19 @@ type applier struct {
 }
 
 func (a *applier) resolveRoot(rootKind, fixedRoot string) (string, error) {
-	if a.opts.RootOverride != "" {
-		return filepath.Abs(a.opts.RootOverride)
+	return resolveRoot(rootKind, fixedRoot, a.opts.RootOverride, a.opts.WorkDir, a.opts.Git)
+}
+
+// resolveRoot は rootKind（+ fixed root のときは絶対パス）から配置先の絶対 root を解決する
+// （→ docs/spec.md「root の解決」）。Apply / Rollback / ProfileFor が共有する純解決ロジックで、
+// `--root` 上書き時は kind に依らず上書きパスを使う。
+func resolveRoot(rootKind, fixedRoot, rootOverride, workDir string, git GitFunc) (string, error) {
+	if rootOverride != "" {
+		return filepath.Abs(rootOverride)
 	}
 	switch rootKind {
 	case manifest.RootKindProject:
-		dir := a.opts.WorkDir
+		dir := workDir
 		if dir == "" {
 			cwd, err := os.Getwd()
 			if err != nil {
@@ -245,7 +252,6 @@ func (a *applier) resolveRoot(rootKind, fixedRoot string) (string, error) {
 			}
 			dir = cwd
 		}
-		git := a.opts.Git
 		if git == nil {
 			git = gitutil.Toplevel
 		}

--- a/internal/engine/generations.go
+++ b/internal/engine/generations.go
@@ -1,0 +1,250 @@
+package engine
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+
+	"github.com/yasunori0418/nput/internal/lock"
+	"github.com/yasunori0418/nput/internal/manifest"
+	"github.com/yasunori0418/nput/internal/paths"
+	"github.com/yasunori0418/nput/internal/planner"
+)
+
+// 世代操作は `nix-env --profile <profileDir>/profile` 系で統一する（→ docs/spec.md 世代管理仕様・
+// ADR-0015, ADR-0025）。コミット（--set）は commit.go、ここでは rollback（--switch-generation）・
+// 一覧（--list-generations）を扱う。--set と同じく注入可能にして tmpdir テストでは nix を呼ばない。
+
+// Generation は profile の 1 世代（nix-env --list-generations の 1 行）。
+type Generation struct {
+	Number  int    // 世代番号
+	Date    string // 作成日時（nix-env の表示そのまま。解析せず原文を運ぶ）
+	Current bool   // 現世代（profile リンクが指す）か
+}
+
+// ListGenerationsFunc は世代一覧の取得点（既定は nix-env --list-generations）。tmpdir テストで差し替える。
+type ListGenerationsFunc func(profileLink string) ([]Generation, error)
+
+// SwitchGenerationFunc は profile ポインタ移動点（既定は nix-env --switch-generation）。tmpdir テストで差し替える。
+type SwitchGenerationFunc func(profileLink string, gen int) error
+
+// ProfileOptions は profileDir を確定するための入力（Rollback / list-generations が共有）。
+type ProfileOptions struct {
+	Name         string
+	RootKind     string
+	FixedRoot    string
+	RootOverride string
+	WorkDir      string
+	StateDir     string
+	Git          GitFunc
+}
+
+// ProfileFor は root を解決し profileDir レイアウトを確定する（apply の前段と同型・→ ADR-0023, ADR-0024）。
+// build をしない rollback / list-generations が flock / 世代読みのために共通で使う。
+func ProfileFor(opts ProfileOptions) (paths.Profile, string, error) {
+	root, err := resolveRoot(opts.RootKind, opts.FixedRoot, opts.RootOverride, opts.WorkDir, opts.Git)
+	if err != nil {
+		return paths.Profile{}, "", err
+	}
+	stateDir := opts.StateDir
+	if stateDir == "" {
+		stateDir, err = paths.StateDir()
+		if err != nil {
+			return paths.Profile{}, "", err
+		}
+	}
+	prof := paths.Resolve(stateDir, opts.Name, opts.RootKind, root, opts.RootOverride != "")
+	return prof, root, nil
+}
+
+// ListGenerations は profileLink の世代一覧を返す（既定の nix-env 実装）。CLI の list-generations が使う。
+func ListGenerations(profileLink string) ([]Generation, error) {
+	return nixEnvListGenerations(profileLink)
+}
+
+// RollbackOptions は Rollback の入力。Rollback は home mode 限定だが、その判定は CLI が担い
+// engine は rootKind に依らず profileDir を解決して前世代へ収束させる。
+type RollbackOptions struct {
+	Name         string
+	RootKind     string
+	FixedRoot    string
+	RootOverride string
+	WorkDir      string
+	StateDir     string
+
+	// ListGenerations / SwitchGeneration は nix-env 呼び出しの差し替え（nil = 既定の nix-env 実装）。
+	ListGenerations  ListGenerationsFunc
+	SwitchGeneration SwitchGenerationFunc
+	// Git は git toplevel 解決の差し替え（nil = gitutil.Toplevel）。home mode では未使用。
+	Git GitFunc
+	// Warnf は warning の出力先（nil = stderr）。
+	Warnf func(format string, args ...any)
+}
+
+// RollbackResult は Rollback の結果レポート。Result（配置差分）に世代遷移 From→To を添える。
+type RollbackResult struct {
+	Result
+	From int // 戻る前の現世代 N
+	To   int // 戻った先の前世代 N-1
+}
+
+// Rollback は home mode の profile を 1 世代前へ戻す。profile ポインタ移動だけでは任意 root の FS は
+// 変わらないため、現世代 N を baseline・前世代 N-1 を target として planner で diff し、N∖N-1 を保守的に
+// stale 除去・N-1 の entry を再配置してから **最後に** profile ポインタを移す（→ docs/spec.md ロールバック・ADR-0015）。
+// ポインタを先に動かすと baseline が N-2 へずれ stale 除去が誤るため、FS 収束を先・ポインタ移動を最後にする。
+func Rollback(opts RollbackOptions) (*RollbackResult, error) {
+	warnf := opts.Warnf
+	if warnf == nil {
+		warnf = func(format string, args ...any) {
+			fmt.Fprintf(os.Stderr, format+"\n", args...)
+		}
+	}
+	listFn := opts.ListGenerations
+	if listFn == nil {
+		listFn = nixEnvListGenerations
+	}
+	switchFn := opts.SwitchGeneration
+	if switchFn == nil {
+		switchFn = nixEnvSwitchGeneration
+	}
+
+	// 1. profileDir 確定（root 解決 → レイアウト・apply と共通の前段）。
+	prof, root, err := ProfileFor(ProfileOptions{
+		Name: opts.Name, RootKind: opts.RootKind, FixedRoot: opts.FixedRoot,
+		RootOverride: opts.RootOverride, WorkDir: opts.WorkDir, StateDir: opts.StateDir, Git: opts.Git,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// profileDir が無ければ一度も apply していない → 戻る世代が存在しない。
+	if _, err := os.Stat(prof.Dir); err != nil {
+		return nil, fmt.Errorf("nput: profile がありません（一度も apply していません）: %s", prof.Dir)
+	}
+
+	// 2. flock（blocking）で並行 apply / rollback と直列化する（→ ADR-0013）。
+	l, err := lock.Acquire(prof.Dir, true)
+	if err != nil {
+		return nil, fmt.Errorf("nput: flock の取得に失敗しました (%s): %w", prof.Dir, err)
+	}
+	defer func() { _ = l.Release() }()
+
+	// 3. 世代一覧から現世代 N と前世代 N-1 を特定する。
+	gens, err := listFn(prof.Profile)
+	if err != nil {
+		return nil, err
+	}
+	curIdx := -1
+	for i, g := range gens {
+		if g.Current {
+			curIdx = i
+		}
+	}
+	if curIdx < 0 {
+		return nil, fmt.Errorf("nput: 現世代を特定できません（profile: %s）", prof.Profile)
+	}
+	if curIdx == 0 {
+		return nil, fmt.Errorf("nput: 前世代がありません（最古の世代のため rollback できません）")
+	}
+	cur := gens[curIdx]
+	prev := gens[curIdx-1]
+
+	// 4. baseline = 現世代 N の manifest（FS の現状）/ target = 前世代 N-1 の manifest。
+	baseline, err := manifest.Load(prof.Profile)
+	if err != nil {
+		return nil, fmt.Errorf("nput: 現世代 manifest を読めません: %w", err)
+	}
+	target, err := manifest.Load(paths.GenerationLink(prof.Profile, prev.Number))
+	if err != nil {
+		return nil, fmt.Errorf("nput: 前世代 manifest を読めません (世代 %d): %w", prev.Number, err)
+	}
+
+	// 5. planner で N∖N-1 stale 除去・N-1 entry 再配置のプランを算出する（apply エンジンを (baseline, target) 差し替えで再利用）。
+	plan, err := planner.Compute(baseline, target, root, planner.OSFS)
+	if err != nil {
+		return nil, err
+	}
+	if len(plan.Conflicts) > 0 {
+		c := plan.Conflicts[0]
+		return nil, fmt.Errorf("nput: %s (target: %s)", c.Reason, c.Entry.Target)
+	}
+
+	// 6. プランを実 FS に反映（新規/張替を先に、stale 除去を最後に・→ ADR-0006）。
+	a := &applier{opts: Options{Warnf: warnf}, result: &Result{Root: root, ProfileDir: prof.Dir}}
+	a.profile = prof
+	a.root = root
+	a.emitWarnings(plan.Warnings)
+	if err := a.place(plan.Place); err != nil {
+		return nil, err
+	}
+	if err := a.removeStale(plan.Remove); err != nil {
+		return nil, err
+	}
+
+	// 7. 最後に profile ポインタを N-1 へ移す（→ docs/spec.md ロールバック手順 3）。
+	if err := switchFn(prof.Profile, prev.Number); err != nil {
+		return nil, fmt.Errorf("nput: profile ポインタの移動に失敗しました（--switch-generation %d）: %w", prev.Number, err)
+	}
+
+	return &RollbackResult{Result: *a.result, From: cur.Number, To: prev.Number}, nil
+}
+
+// nixEnvListGenerations は既定の世代一覧取得（nix-env --profile <p> --list-generations）。
+// stdout を捕捉して解析する（機械可読出力の取り込み）。
+func nixEnvListGenerations(profileLink string) ([]Generation, error) {
+	if _, err := exec.LookPath("nix-env"); err != nil {
+		return nil, fmt.Errorf("nix-env が PATH にありません: %w", err)
+	}
+	cmd := exec.Command("nix-env", "--profile", profileLink, "--list-generations")
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		trimmed := strings.TrimSpace(stderr.String())
+		if trimmed != "" {
+			return nil, fmt.Errorf("nput: nix-env --list-generations に失敗しました: %w\n%s", err, trimmed)
+		}
+		return nil, fmt.Errorf("nput: nix-env --list-generations に失敗しました: %w", err)
+	}
+	return parseGenerations(stdout.String())
+}
+
+// nixEnvSwitchGeneration は既定の profile ポインタ移動（nix-env --profile <p> --switch-generation <gen>）。
+// nix の出力は stderr に流す（stdout は機械可読出力に専有・→ docs/spec.md ストリーム規律）。
+func nixEnvSwitchGeneration(profileLink string, gen int) error {
+	if _, err := exec.LookPath("nix-env"); err != nil {
+		return fmt.Errorf("nix-env が PATH にありません: %w", err)
+	}
+	cmd := exec.Command("nix-env", "--profile", profileLink, "--switch-generation", strconv.Itoa(gen))
+	cmd.Stdout = os.Stderr
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+// parseGenerations は `nix-env --list-generations` の出力を解析する。各行は
+// 「<番号>   <日時>   [(current)]」形式（先頭・区切りは空白可変）。
+func parseGenerations(out string) ([]Generation, error) {
+	var gens []Generation
+	for _, line := range strings.Split(out, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) == 0 {
+			continue
+		}
+		n, err := strconv.Atoi(fields[0])
+		if err != nil {
+			return nil, fmt.Errorf("nput: 世代一覧の行を解析できません: %q", line)
+		}
+		g := Generation{Number: n}
+		end := len(fields)
+		if fields[end-1] == "(current)" {
+			g.Current = true
+			end--
+		}
+		g.Date = strings.Join(fields[1:end], " ")
+		gens = append(gens, g)
+	}
+	return gens, nil
+}

--- a/internal/engine/generations_test.go
+++ b/internal/engine/generations_test.go
@@ -1,0 +1,202 @@
+package engine
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/yasunori0418/nput/internal/manifest"
+	"github.com/yasunori0418/nput/internal/paths"
+)
+
+func homeManifest(entries ...manifest.Entry) manifest.Manifest {
+	return manifest.Manifest{
+		SchemaVersion: 1,
+		Root:          manifest.Root{RootKind: manifest.RootKindHome},
+		Entries:       entries,
+	}
+}
+
+func TestParseGenerations(t *testing.T) {
+	out := "" +
+		"   1   2026-06-01 10:00:00   \n" +
+		"   2   2026-06-02 11:30:00   (current)\n"
+	gens, err := parseGenerations(out)
+	if err != nil {
+		t.Fatalf("parseGenerations: %v", err)
+	}
+	if len(gens) != 2 {
+		t.Fatalf("len = %d, want 2", len(gens))
+	}
+	if gens[0].Number != 1 || gens[0].Current {
+		t.Errorf("gen[0] = %+v", gens[0])
+	}
+	if gens[0].Date != "2026-06-01 10:00:00" {
+		t.Errorf("gen[0].Date = %q", gens[0].Date)
+	}
+	if gens[1].Number != 2 || !gens[1].Current {
+		t.Errorf("gen[1] = %+v", gens[1])
+	}
+	if gens[1].Date != "2026-06-02 11:30:00" {
+		t.Errorf("gen[1].Date = %q (should not include (current))", gens[1].Date)
+	}
+}
+
+func TestParseGenerationsEmpty(t *testing.T) {
+	gens, err := parseGenerations("\n  \n")
+	if err != nil {
+		t.Fatalf("parseGenerations: %v", err)
+	}
+	if len(gens) != 0 {
+		t.Errorf("len = %d, want 0", len(gens))
+	}
+}
+
+func TestParseGenerationsBadLine(t *testing.T) {
+	if _, err := parseGenerations("not-a-number 2026-06-01\n"); err == nil {
+		t.Fatal("expected parse error for non-numeric generation, got nil")
+	}
+}
+
+// TestRollbackReconverges は現世代 N → 前世代 N-1 への FS 再収束を検証する。
+// gen1 = {a, b}, gen2(現) = {a, c}。rollback で c を stale 除去・b を再配置し a は残す。
+func TestRollbackReconverges(t *testing.T) {
+	root := realTempDir(t)
+	state := realTempDir(t)
+	srcA := makeSrc(t, "x")
+	srcB := makeSrc(t, "x")
+	srcC := makeSrc(t, "x")
+
+	// --root 上書きで home + roothash キーにし $HOME 非依存にする。
+	prof := paths.Resolve(state, "vim", manifest.RootKindHome, root, true)
+	if err := os.MkdirAll(prof.Dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	lf1 := writeLinkFarm(t, homeManifest(
+		storeEntry(srcA, ".", "a"),
+		storeEntry(srcB, ".", "b"),
+	))
+	lf2 := writeLinkFarm(t, homeManifest(
+		storeEntry(srcA, ".", "a"),
+		storeEntry(srcC, ".", "c"),
+	))
+
+	// 世代リンク（profile-N-link）と現 profile（gen2）を用意する。
+	if err := os.Symlink(lf1, paths.GenerationLink(prof.Profile, 1)); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(lf2, paths.GenerationLink(prof.Profile, 2)); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(lf2, prof.Profile); err != nil {
+		t.Fatal(err)
+	}
+
+	// 現状 FS = gen2: a→srcA, c→srcC を配置済みにする。
+	if err := os.Symlink(srcA, filepath.Join(root, "a")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(srcC, filepath.Join(root, "c")); err != nil {
+		t.Fatal(err)
+	}
+
+	var switched int
+	res, err := Rollback(RollbackOptions{
+		Name:         "vim",
+		RootKind:     manifest.RootKindHome,
+		RootOverride: root,
+		StateDir:     state,
+		ListGenerations: func(string) ([]Generation, error) {
+			return []Generation{{Number: 1}, {Number: 2, Current: true}}, nil
+		},
+		SwitchGeneration: func(_ string, gen int) error { switched = gen; return nil },
+	})
+	if err != nil {
+		t.Fatalf("Rollback: %v", err)
+	}
+
+	if res.From != 2 || res.To != 1 {
+		t.Errorf("From/To = %d/%d, want 2/1", res.From, res.To)
+	}
+	if switched != 1 {
+		t.Errorf("switched generation = %d, want 1", switched)
+	}
+
+	// FS は gen1 と一致する: a 残存・b 新規・c 除去。
+	if dest, err := os.Readlink(filepath.Join(root, "a")); err != nil || dest != srcA {
+		t.Errorf("a: dest=%q err=%v, want %q", dest, err, srcA)
+	}
+	if dest, err := os.Readlink(filepath.Join(root, "b")); err != nil || dest != srcB {
+		t.Errorf("b: dest=%q err=%v, want %q", dest, err, srcB)
+	}
+	if _, err := os.Lstat(filepath.Join(root, "c")); !os.IsNotExist(err) {
+		t.Errorf("c should be removed, lstat err = %v", err)
+	}
+	if len(res.Removed) != 1 || res.Removed[0] != "c" {
+		t.Errorf("Removed = %v, want [c]", res.Removed)
+	}
+}
+
+// TestRollbackNoPreviousErrors は現世代が最古（前世代なし）のとき rollback がエラー停止することを検証する。
+func TestRollbackNoPreviousErrors(t *testing.T) {
+	root := realTempDir(t)
+	state := realTempDir(t)
+	prof := paths.Resolve(state, "vim", manifest.RootKindHome, root, true)
+	if err := os.MkdirAll(prof.Dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	lf := writeLinkFarm(t, homeManifest(storeEntry(makeSrc(t, "x"), ".", "a")))
+	if err := os.Symlink(lf, prof.Profile); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := Rollback(RollbackOptions{
+		Name: "vim", RootKind: manifest.RootKindHome, RootOverride: root, StateDir: state,
+		ListGenerations:  func(string) ([]Generation, error) { return []Generation{{Number: 1, Current: true}}, nil },
+		SwitchGeneration: func(string, int) error { return nil },
+	})
+	if err == nil || !strings.Contains(err.Error(), "前世代") {
+		t.Fatalf("expected no-previous-generation error, got %v", err)
+	}
+}
+
+// TestRollbackNoProfileErrors は profileDir が無い（未 apply）とき rollback がエラー停止することを検証する。
+func TestRollbackNoProfileErrors(t *testing.T) {
+	root := realTempDir(t)
+	state := realTempDir(t)
+	_, err := Rollback(RollbackOptions{
+		Name: "vim", RootKind: manifest.RootKindHome, RootOverride: root, StateDir: state,
+		ListGenerations:  func(string) ([]Generation, error) { return nil, nil },
+		SwitchGeneration: func(string, int) error { return nil },
+	})
+	if err == nil || !strings.Contains(err.Error(), "profile") {
+		t.Fatalf("expected no-profile error, got %v", err)
+	}
+}
+
+// TestResolveRootHome は rootKind=home が $HOME を返すことを検証する（root resolver 単体）。
+func TestResolveRootHome(t *testing.T) {
+	home := realTempDir(t)
+	t.Setenv("HOME", home)
+	got, err := resolveRoot(manifest.RootKindHome, "", "", "", nil)
+	if err != nil {
+		t.Fatalf("resolveRoot home: %v", err)
+	}
+	if got != home {
+		t.Errorf("resolveRoot home = %q, want %q", got, home)
+	}
+}
+
+// TestResolveRootOverrideWins は --root 上書きが rootKind に依らず優先されることを検証する。
+func TestResolveRootOverrideWins(t *testing.T) {
+	override := realTempDir(t)
+	got, err := resolveRoot(manifest.RootKindHome, "", override, "", nil)
+	if err != nil {
+		t.Fatalf("resolveRoot override: %v", err)
+	}
+	if got != override {
+		t.Errorf("resolveRoot override = %q, want %q", got, override)
+	}
+}

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -8,10 +8,15 @@ package manifest
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 )
+
+// ErrSchemaVersionUnsupported は engine の対応版（SchemaVersion）より新しい manifest を読んだことを表す。
+// CLI/flake pin 間の schemaVersion skew を上位（CLI）で errors.Is 判定し案内を補うための sentinel（→ ADR-0006）。
+var ErrSchemaVersionUnsupported = errors.New("nput: schemaVersion が engine の対応版より新しい")
 
 // SchemaVersion は engine が解釈できる manifest.json の最新版（→ ADR-0013）。
 // MVP は v1 のみを受理し、これより新しい版は拒否する（→ ADR-0006, ADR-0015）。
@@ -85,7 +90,7 @@ func LoadFile(path string) (*Manifest, error) {
 func (m *Manifest) validate() error {
 	// engine は自身の対応版より新しい schemaVersion を拒否する（→ ADR-0006）。
 	if m.SchemaVersion > SchemaVersion {
-		return fmt.Errorf("schemaVersion %d は未対応です（この engine は v%d まで対応）", m.SchemaVersion, SchemaVersion)
+		return fmt.Errorf("schemaVersion %d は未対応です（この engine は v%d まで対応）: %w", m.SchemaVersion, SchemaVersion, ErrSchemaVersionUnsupported)
 	}
 	if m.SchemaVersion < 1 {
 		return fmt.Errorf("schemaVersion %d は不正です", m.SchemaVersion)

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -1,6 +1,7 @@
 package manifest
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -46,8 +47,13 @@ func TestLoadValid(t *testing.T) {
 
 func TestLoadRejectsNewerSchema(t *testing.T) {
 	dir := writeManifest(t, `{ "schemaVersion": 2, "root": { "rootKind": "project" }, "entries": [] }`)
-	if _, err := Load(dir); err == nil {
+	_, err := Load(dir)
+	if err == nil {
 		t.Fatal("expected error for schemaVersion 2, got nil")
+	}
+	// CLI が skew 案内を補えるよう sentinel を errors.Is で判定できること（→ docs/spec.md）。
+	if !errors.Is(err, ErrSchemaVersionUnsupported) {
+		t.Errorf("error should wrap ErrSchemaVersionUnsupported, got %v", err)
 	}
 }
 

--- a/internal/paths/paths.go
+++ b/internal/paths/paths.go
@@ -39,6 +39,18 @@ func RootHash(absRoot string) string {
 	return hex.EncodeToString(sum[:])[:rootHashLen]
 }
 
+// Base は profile 群の基底 <state>/nix/profiles/nput を返す。home（--root なし）の
+// profileDir はこの直下の <name>、roothash 系列は <roothash>/<name>（→ ADR-0024）。
+func Base(stateDir string) string {
+	return filepath.Join(stateDir, "nix", "profiles", "nput")
+}
+
+// GenerationLink は profile リンクの兄弟として nix-env が作る世代リンク
+// <profileDir>/profile-<gen>-link のパスを返す（→ docs/spec.md オンディスクレイアウト・ADR-0025）。
+func GenerationLink(profileLink string, gen int) string {
+	return fmt.Sprintf("%s-%d-link", profileLink, gen)
+}
+
 // Profile は 1 config 分の profile レイアウトのパス一式。
 type Profile struct {
 	// Dir は profileDir（config 専用ディレクトリ・flock キー）。
@@ -60,7 +72,7 @@ type Profile struct {
 //   - project / fixed / --root 上書き : <state>/nix/profiles/nput/<roothash>/<name>
 //     （backref .root は <roothash> 階層）
 func Resolve(stateDir, name, rootKind, absRoot string, rootOverride bool) Profile {
-	base := filepath.Join(stateDir, "nix", "profiles", "nput")
+	base := Base(stateDir)
 
 	// home（--root なし）のみ <name> 直キー。それ以外は root ごとに独立系列へ分離する。
 	if rootKind == manifest.RootKindHome && !rootOverride {


### PR DESCRIPTION
## 対応 issue

Closes #10（2b: home mode + 世代 + rollback / list-generations）の残作業分。

## 背景

コードは issue AC より先行しており、root resolver（home/fixed/system）・profileDir レイアウト・`--set` 世代コミット・`manifest.validate()` の上位版拒否は既に完成済み。本 PR は**残作業のみ**（世代マネージャ・rollback の FS 再収束・CLI 2 コマンド・skew 案内）を足す。

## 対応内容

- **paths**: `Base`（home profile 基底 `<state>/nix/profiles/nput`）と `GenerationLink`（`profile-N-link`）ヘルパを追加（`Resolve` も `Base` 経由に統一）。
- **engine（generation manager）**: `nix-env --list-generations` / `--switch-generation` を `--set` と同じ注入可能パターンでラップ。`ProfileFor` で rollback / list が profileDir を共有確定。
- **engine（rollback）**: 現世代 N を baseline・前世代 N-1 を target として `planner.Compute` に渡し、`N∖N-1` を保守的 stale 除去・N-1 entry を再配置 → **最後に** profile ポインタ移動（ポインタ先行移動で baseline がずれる誤りを回避・→ ADR-0015）。前世代が無ければエラー停止。
- **CLI**: `rollback <name>`（home mode 限定・名指し必須・`--all` 非対応）/ `list-generations [<name>|--all]` を新規ファイルで追加し cobra ルートへ登録。いずれも eval 先取りで rootKind を確認し home 以外はエラー。`--all` は state 走査で home profile を列挙（entrypoint eval 不要）。
- **manifest / CLI（skew）**: schemaVersion 上位版拒否を `ErrSchemaVersionUnsupported` で wrap し、`main` で `errors.Is` 検知して CLI/flake pin 不一致の解消策を案内。

## 境界（厳守した）

- `place.go`（#11）・out-of-store 存在チェック（#12）・`cmd/nput/apply.go`（#11）には触れていない。新規コマンドは別ファイルで追加。

## 検証

- `go test ./...` 全パス（rollback FS 再収束 / no-previous エラー / no-profile エラー / 世代パーサ / root resolver home / schemaVersion sentinel の単体テストを追加）。
- `nix flake check` 全パス（go-vet / golangci-lint / treefmt / nix-unit / buildGoModule の doCheck）。

## レビュー観点

- rollback のポインタ移動を最後に行う順序が ADR-0015 と一致しているか。
- `list-generations --all` の home profile 判定（直下 `profile` リンクの有無で roothash 系列を除外）が妥当か。
