### PR TITLE
feat: copy place-once 配置と apply --recopy 上書き再コピーを実装

### DIFF
--- a/cmd/nput/apply.go
+++ b/cmd/nput/apply.go
@@ -11,7 +11,7 @@ import (
 )
 
 func newApplyCmd() *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "apply [name]",
 		Short: "nput.<name> をビルドし新世代を作って適用（name 省略時は nput.default）",
 		Long: "entrypoint の nput.<name> をビルドして配置する。" +
@@ -25,6 +25,9 @@ func newApplyCmd() *cobra.Command {
 			return runApply(name)
 		},
 	}
+	cmd.Flags().BoolVar(&flagRecopy, "recopy", false,
+		"config 内の全 copy target を src から無条件上書き再コピー（ローカル編集は破棄・→ ADR-0020）")
+	return cmd
 }
 
 // runApply は docs/spec.md「実行フロー」を駆動する:
@@ -52,6 +55,7 @@ func runApply(name string) error {
 		FixedRoot:    fixedRoot,
 		RootOverride: flagRoot,
 		NoWait:       flagNoWait,
+		Recopy:       flagRecopy,
 		Build:        buildFunc(ep, system, name),
 	})
 	if err != nil {
@@ -80,10 +84,16 @@ func reportResult(res *engine.Result, name string) {
 	for _, t := range res.Replaced {
 		fmt.Fprintf(os.Stderr, "  replaced %s\n", t)
 	}
+	for _, t := range res.Copied {
+		fmt.Fprintf(os.Stderr, "  copied   %s\n", t)
+	}
+	for _, t := range res.Recopied {
+		fmt.Fprintf(os.Stderr, "  recopied %s\n", t)
+	}
 	for _, t := range res.Removed {
 		fmt.Fprintf(os.Stderr, "  removed  %s\n", t)
 	}
-	if len(res.Placed)+len(res.Replaced)+len(res.Removed) == 0 {
+	if len(res.Placed)+len(res.Replaced)+len(res.Copied)+len(res.Recopied)+len(res.Removed) == 0 {
 		fmt.Fprintln(os.Stderr, "  no-op")
 	}
 }

--- a/cmd/nput/main.go
+++ b/cmd/nput/main.go
@@ -21,6 +21,7 @@ var (
 	flagNoWait  bool   // --no-wait: flock 競合時に待たず skip（shellHook 用）
 	flagQuiet   bool   // --quiet: 進捗 / 配置レポートを抑制（warning / error は残す）
 	flagVerbose bool   // --verbose: 内部実行する nix コマンドを開示
+	flagRecopy  bool   // --recopy: apply 修飾。全 copy target を src から無条件上書き再コピー
 )
 
 func newRootCmd() *cobra.Command {

--- a/internal/engine/copy.go
+++ b/internal/engine/copy.go
@@ -1,0 +1,143 @@
+package engine
+
+import (
+	"fmt"
+	"io"
+	iofs "io/fs"
+	"os"
+	"path/filepath"
+
+	"github.com/yasunori0418/nput/internal/manifest"
+	"github.com/yasunori0418/nput/internal/planner"
+)
+
+// placeCopies materializes the planner's place-once CopyActions（target 不在の copy のみ・
+// → ADR-0002, ADR-0016）。既存 target（記録あり / foreign）は planner が CopyAction を
+// 生まないため、ここは「新規コピー」だけを実 FS に反映する薄い executor に徹する。
+func (a *applier) placeCopies(actions []planner.CopyAction) error {
+	for _, act := range actions {
+		if err := os.MkdirAll(filepath.Dir(act.TargetAbs), 0o755); err != nil {
+			return fmt.Errorf("nput: 親ディレクトリを作成できません (%s): %w", filepath.Dir(act.TargetAbs), err)
+		}
+		if err := copyTree(act.Src, act.TargetAbs); err != nil {
+			return fmt.Errorf("nput: copy 配置に失敗しました (%s -> %s): %w", act.Src, act.TargetAbs, err)
+		}
+		a.result.Copied = append(a.result.Copied, act.Entry.Target)
+	}
+	return nil
+}
+
+// recopyAll は apply --recopy の copy 上書き経路（→ ADR-0020, docs/spec.md「recopy」）。
+// config 内の全 copy entry について、target が在れば削除してから無条件に再コピーする
+// （差分判定なし・ローカル編集は破棄）。place-once 分類（planner.Copies）は使わず manifest を
+// 直接走査するが、祖先 symlink / 構造不一致は planner の conflict ゲートで apply 前に弾かれている。
+func (a *applier) recopyAll() error {
+	for _, e := range a.manifest.Entries {
+		if e.Method != manifest.MethodCopy {
+			continue
+		}
+		targetAbs := filepath.Join(a.root, filepath.Clean(e.Target))
+		existed := false
+		if _, err := os.Lstat(targetAbs); err == nil {
+			existed = true
+			if err := os.RemoveAll(targetAbs); err != nil {
+				return fmt.Errorf("nput: recopy 対象を削除できません (%s): %w", targetAbs, err)
+			}
+		} else if !os.IsNotExist(err) {
+			return fmt.Errorf("nput: recopy target を lstat できません (%s): %w", targetAbs, err)
+		}
+
+		if err := os.MkdirAll(filepath.Dir(targetAbs), 0o755); err != nil {
+			return fmt.Errorf("nput: 親ディレクトリを作成できません (%s): %w", filepath.Dir(targetAbs), err)
+		}
+		if err := copyTree(planner.LinkDest(e), targetAbs); err != nil {
+			return fmt.Errorf("nput: recopy に失敗しました (%s -> %s): %w", planner.LinkDest(e), targetAbs, err)
+		}
+		if existed {
+			a.result.Recopied = append(a.result.Recopied, e.Target)
+		} else {
+			a.result.Copied = append(a.result.Copied, e.Target)
+		}
+	}
+	return nil
+}
+
+// copyTree は src（ファイル / ディレクトリ / symlink）を dst へネイティブにコピーする
+// （→ ADR-0016, docs/spec.md「copy モード」）。
+//   - mode は保存しつつ owner-write（0o200）を付与する（store の read-only 0444/0555 →
+//     編集可能な 0644/0755）。
+//   - src ツリー内の symlink は deref せず symlink のまま複製する（循環 / サイズ膨張回避）。
+func copyTree(src, dst string) error {
+	info, err := os.Lstat(src)
+	if err != nil {
+		return fmt.Errorf("copy src を lstat できません (%s): %w", src, err)
+	}
+	switch {
+	case info.Mode()&os.ModeSymlink != 0:
+		return copySymlink(src, dst)
+	case !info.IsDir():
+		return copyFile(src, dst, info.Mode())
+	}
+
+	return filepath.WalkDir(src, func(path string, d iofs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+		dstPath := filepath.Join(dst, rel)
+		fi, err := d.Info()
+		if err != nil {
+			return err
+		}
+		switch {
+		case fi.Mode()&os.ModeSymlink != 0:
+			return copySymlink(path, dstPath)
+		case d.IsDir():
+			if err := os.MkdirAll(dstPath, 0o755); err != nil {
+				return err
+			}
+			// umask に依らず最終 mode を確定する（owner-write 付与）。
+			return os.Chmod(dstPath, fi.Mode().Perm()|0o200)
+		default:
+			return copyFile(path, dstPath, fi.Mode())
+		}
+	})
+}
+
+// copyFile は単一ファイルを内容コピーし、mode 保存 + owner-write を付与する。
+func copyFile(src, dst string, mode os.FileMode) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = in.Close() }()
+
+	perm := mode.Perm() | 0o200
+	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, perm)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		_ = out.Close()
+		return err
+	}
+	if err := out.Close(); err != nil {
+		return err
+	}
+	// OpenFile の mode は umask でマスクされるため、最終 perm を明示確定する。
+	return os.Chmod(dst, perm)
+}
+
+// copySymlink は symlink を deref せず、同じリンク先で複製する（→ ADR-0016）。
+func copySymlink(src, dst string) error {
+	target, err := os.Readlink(src)
+	if err != nil {
+		return err
+	}
+	// 再コピー時の残骸対策（recopy は親を RemoveAll 済みだが防御的に消す）。
+	_ = os.Remove(dst)
+	return os.Symlink(target, dst)
+}

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -55,6 +55,9 @@ type Options struct {
 	StateDir string
 	// NoWait は flock を try-lock にする（shellHook 経路・保持中なら ErrSkipped・→ ADR-0013）。
 	NoWait bool
+	// Recopy は apply --recopy 修飾（config 内の全 copy target を src から無条件上書き再コピー・→ ADR-0020）。
+	// place-once を破る opt-in 経路。symlink 部の通常 apply（stale 除去 + 世代コミット）は不変。
+	Recopy bool
 
 	// Build はロック内 build の差し替え（nil = opts.LinkFarm を既ビルド済みとして使う）。
 	Build BuildFunc
@@ -70,8 +73,10 @@ type Options struct {
 type Result struct {
 	Root       string   // 解決後の絶対 root パス
 	ProfileDir string   // 確定した profileDir
-	Placed     []string // 新規配置した target
+	Placed     []string // 新規配置した symlink target
 	Replaced   []string // 既存 symlink を張り替えた target
+	Copied     []string // place-once で新規コピーした copy target
+	Recopied   []string // --recopy で上書き再コピーした既存 copy target（→ ADR-0020）
 	Removed    []string // stale 除去した target
 	Skipped    bool     // try-lock 競合で skip した（NoWait 経路）
 }
@@ -171,7 +176,7 @@ func Apply(opts Options) (*Result, error) {
 		c := plan.Conflicts[0]
 		return nil, fmt.Errorf("nput: %s (target: %s)", c.Reason, c.Entry.Target)
 	}
-	a.emitWarnings(plan.Warnings)
+	a.emitWarnings(plan.Warnings, opts.Recopy)
 
 	// 6.5 out-of-store のリンク先存在を配置直前に検査（dangling 禁止・→ ADR-0001, ADR-0013）。
 	//     FS 変更前に閉じるため、不在なら何も配置せずエラー停止する。
@@ -180,8 +185,19 @@ func Apply(opts Options) (*Result, error) {
 	}
 
 	// 7. プランを実 FS に反映（新規 / 張替を先に、stale 除去を最後に・→ ADR-0006）。
+	//    symlink は plan 駆動。copy は --recopy のとき全 copy target を無条件上書き、
+	//    通常は place-once（target 不在のみ新規コピー）に分岐する（→ ADR-0020）。
 	if err := a.place(plan.Place); err != nil {
 		return nil, err
+	}
+	if opts.Recopy {
+		if err := a.recopyAll(); err != nil {
+			return nil, err
+		}
+	} else {
+		if err := a.placeCopies(plan.Copies); err != nil {
+			return nil, err
+		}
 	}
 	if err := a.removeStale(plan.Remove); err != nil {
 		return nil, err
@@ -287,7 +303,9 @@ func (a *applier) loadPrevManifest() *manifest.Manifest {
 
 // emitWarnings は planner が算出した非致命 warning を stderr（opts.Warnf）へ出す。
 // warning は --quiet でも消えない（→ docs/spec.md ストリーム規律・ADR-0015, ADR-0024）。
-func (a *applier) emitWarnings(ws []planner.Warning) {
+// recopy=true のときは copy foreign skip 警告を抑制する（recopy は foreign も上書きするため
+// 「skip した」は誤報になる・→ ADR-0020）。
+func (a *applier) emitWarnings(ws []planner.Warning, recopy bool) {
 	for _, w := range ws {
 		switch w.Kind {
 		case planner.WarnForeignReplace:
@@ -298,6 +316,11 @@ func (a *applier) emitWarnings(ws []planner.Warning) {
 			a.opts.Warnf("nput: stale target が symlink ではないため残します: %s", w.Target)
 		case planner.WarnCopyOrphan:
 			a.opts.Warnf("nput: copy entry が消えましたが target は削除しません（orphan・reset で撤去）: %s", w.Target)
+		case planner.WarnCopyForeign:
+			if recopy {
+				continue
+			}
+			a.opts.Warnf("nput: copy target に既存の実ファイルがあるため copy をスキップしました（foreign・place-once）: %s", w.Target)
 		}
 	}
 }

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -106,6 +106,26 @@ func outOfStoreEntry(src, subpath, target string) manifest.Entry {
 	}
 }
 
+func copyEntry(src, subpath, target string) manifest.Entry {
+	e := storeEntry(src, subpath, target)
+	e.Method = manifest.MethodCopy
+	return e
+}
+
+// makeROSrc は store 相当の read-only ファイル（0o444）を <subpath> に作って src dir を返す。
+// copy の mode 保存 + owner-write 付与（0444 → 0644）を検証するための src。
+func makeROSrc(t *testing.T, subpath, content string) string {
+	t.Helper()
+	src := realTempDir(t)
+	full := filepath.Join(src, subpath)
+	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(full, []byte(content), 0o444); err != nil {
+		t.Fatal(err)
+	}
+	return src
+}
 // --- tests -----------------------------------------------------------------
 
 func TestApplyFirstPlacementProjectMode(t *testing.T) {
@@ -564,18 +584,218 @@ func TestApplyOutOfStoreMissingPathError(t *testing.T) {
 	}
 }
 
-func TestApplyCopyMethodUnimplemented(t *testing.T) {
+func TestApplyCopyPlaceOnceFile(t *testing.T) {
 	root := realTempDir(t)
 	state := realTempDir(t)
-	src := makeSrc(t, "x")
-	e := storeEntry(src, ".", ".config/foo")
-	e.Method = manifest.MethodCopy
-	lf := writeLinkFarm(t, projectManifest(e))
+	src := makeROSrc(t, "file.txt", "store-content")
+	lf := writeLinkFarm(t, projectManifest(copyEntry(src, "file.txt", ".config/foo")))
 
-	_, err := Apply(Options{
+	res, err := Apply(Options{
 		LinkFarm: lf, Name: "c", RootOverride: root, StateDir: state, Commit: fakeCommit(nil),
 	})
-	if err == nil {
-		t.Fatal("expected copy-unimplemented error, got nil")
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	target := filepath.Join(root, ".config", "foo")
+	// 内容がコピーされる（symlink ではなく実ファイル）。
+	fi, err := os.Lstat(target)
+	if err != nil {
+		t.Fatalf("Lstat target: %v", err)
+	}
+	if fi.Mode()&os.ModeSymlink != 0 {
+		t.Errorf("copy target should be a regular file, got symlink")
+	}
+	data, err := os.ReadFile(target)
+	if err != nil || string(data) != "store-content" {
+		t.Errorf("content = %q (err %v), want store-content", data, err)
+	}
+	// mode は保存しつつ owner-write を付与（0444 → 0644）。
+	if fi.Mode().Perm() != 0o644 {
+		t.Errorf("mode = %o, want 0644 (mode-preserve + owner-write)", fi.Mode().Perm())
+	}
+	if len(res.Copied) != 1 || res.Copied[0] != ".config/foo" {
+		t.Errorf("Copied = %v, want [.config/foo]", res.Copied)
+	}
+}
+
+func TestApplyCopyPlaceOnceKeepsExisting(t *testing.T) {
+	root := realTempDir(t)
+	state := realTempDir(t)
+	src := makeROSrc(t, "file.txt", "store-content")
+	lf := writeLinkFarm(t, projectManifest(copyEntry(src, "file.txt", ".config/foo")))
+
+	// 1 回目: 新規コピー。
+	var commits [][2]string
+	if _, err := Apply(Options{
+		LinkFarm: lf, Name: "c", RootOverride: root, StateDir: state, Commit: fakeCommit(&commits),
+	}); err != nil {
+		t.Fatalf("first Apply: %v", err)
+	}
+	// ユーザーが編集する。
+	target := filepath.Join(root, ".config", "foo")
+	if err := os.WriteFile(target, []byte("user-edit"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// 2 回目: place-once により target は触られない（編集が残る）。
+	res, err := Apply(Options{
+		LinkFarm: lf, Name: "c", RootOverride: root, StateDir: state, Commit: fakeCommit(&commits),
+	})
+	if err != nil {
+		t.Fatalf("second Apply: %v", err)
+	}
+	data, _ := os.ReadFile(target)
+	if string(data) != "user-edit" {
+		t.Errorf("place-once should keep user edit, content = %q", data)
+	}
+	if len(res.Copied) != 0 {
+		t.Errorf("Copied = %v, want none (recorded place-once no-op)", res.Copied)
+	}
+}
+
+func TestApplyCopyForeignFileSkipsWithWarn(t *testing.T) {
+	root := realTempDir(t)
+	state := realTempDir(t)
+	src := makeROSrc(t, "file.txt", "store-content")
+
+	// 記録の無い foreign 実ファイルを target に置く。
+	target := filepath.Join(root, ".config", "foo")
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(target, []byte("foreign"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	lf := writeLinkFarm(t, projectManifest(copyEntry(src, "file.txt", ".config/foo")))
+
+	var warns []string
+	res, err := Apply(Options{
+		LinkFarm: lf, Name: "c", RootOverride: root, StateDir: state,
+		Commit: fakeCommit(nil), Warnf: collectWarnings(&warns),
+	})
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	// place-once skip: foreign ファイルは上書きしない。
+	if data, _ := os.ReadFile(target); string(data) != "foreign" {
+		t.Errorf("foreign file should be kept, content = %q", data)
+	}
+	if len(res.Copied) != 0 {
+		t.Errorf("Copied = %v, want none (foreign skipped)", res.Copied)
+	}
+	if len(warns) == 0 {
+		t.Error("expected a copy foreign warning")
+	}
+}
+
+func TestApplyCopyDirRecursivePreservesSymlinks(t *testing.T) {
+	root := realTempDir(t)
+	state := realTempDir(t)
+
+	// src ツリー: ディレクトリ + ファイル + 内部 symlink。
+	src := realTempDir(t)
+	if err := os.MkdirAll(filepath.Join(src, "tree", "sub"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "tree", "sub", "f.txt"), []byte("hi"), 0o444); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("sub/f.txt", filepath.Join(src, "tree", "link")); err != nil {
+		t.Fatal(err)
+	}
+	lf := writeLinkFarm(t, projectManifest(copyEntry(src, "tree", ".config/tree")))
+
+	if _, err := Apply(Options{
+		LinkFarm: lf, Name: "c", RootOverride: root, StateDir: state, Commit: fakeCommit(nil),
+	}); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	dst := filepath.Join(root, ".config", "tree")
+	if data, _ := os.ReadFile(filepath.Join(dst, "sub", "f.txt")); string(data) != "hi" {
+		t.Errorf("nested file content = %q, want hi", data)
+	}
+	// 内部 symlink は deref されず symlink のまま複製される。
+	li, err := os.Lstat(filepath.Join(dst, "link"))
+	if err != nil {
+		t.Fatalf("Lstat link: %v", err)
+	}
+	if li.Mode()&os.ModeSymlink == 0 {
+		t.Error("internal symlink should remain a symlink (no deref)")
+	}
+	if dest, _ := os.Readlink(filepath.Join(dst, "link")); dest != "sub/f.txt" {
+		t.Errorf("symlink dest = %q, want sub/f.txt", dest)
+	}
+}
+
+func TestApplyRecopyOverwrites(t *testing.T) {
+	root := realTempDir(t)
+	state := realTempDir(t)
+	src := makeROSrc(t, "file.txt", "store-content")
+	lf := writeLinkFarm(t, projectManifest(copyEntry(src, "file.txt", ".config/foo")))
+
+	// 1 回目: 新規コピー。
+	var commits [][2]string
+	if _, err := Apply(Options{
+		LinkFarm: lf, Name: "c", RootOverride: root, StateDir: state, Commit: fakeCommit(&commits),
+	}); err != nil {
+		t.Fatalf("first Apply: %v", err)
+	}
+	target := filepath.Join(root, ".config", "foo")
+	if err := os.WriteFile(target, []byte("user-edit"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// 2 回目: --recopy で無条件上書き → src 内容に戻る。
+	res, err := Apply(Options{
+		LinkFarm: lf, Name: "c", RootOverride: root, StateDir: state,
+		Recopy: true, Commit: fakeCommit(&commits),
+	})
+	if err != nil {
+		t.Fatalf("recopy Apply: %v", err)
+	}
+	if data, _ := os.ReadFile(target); string(data) != "store-content" {
+		t.Errorf("recopy should restore src content, got %q", data)
+	}
+	if len(res.Recopied) != 1 || res.Recopied[0] != ".config/foo" {
+		t.Errorf("Recopied = %v, want [.config/foo]", res.Recopied)
+	}
+}
+
+func TestApplyRecopyForeignFileOverwrites(t *testing.T) {
+	root := realTempDir(t)
+	state := realTempDir(t)
+	src := makeROSrc(t, "file.txt", "store-content")
+
+	// 記録の無い foreign ファイル: 通常 apply なら skip だが --recopy は無条件上書き。
+	target := filepath.Join(root, ".config", "foo")
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(target, []byte("foreign"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	lf := writeLinkFarm(t, projectManifest(copyEntry(src, "file.txt", ".config/foo")))
+
+	var warns []string
+	res, err := Apply(Options{
+		LinkFarm: lf, Name: "c", RootOverride: root, StateDir: state,
+		Recopy: true, Commit: fakeCommit(nil), Warnf: collectWarnings(&warns),
+	})
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if data, _ := os.ReadFile(target); string(data) != "store-content" {
+		t.Errorf("recopy should overwrite foreign file, got %q", data)
+	}
+	if len(res.Recopied) != 1 {
+		t.Errorf("Recopied = %v, want 1", res.Recopied)
+	}
+	// recopy 経路では foreign skip 警告を出さない（上書きするため誤報）。
+	for _, w := range warns {
+		if strings.Contains(w, "スキップ") {
+			t.Errorf("unexpected copy foreign skip warning during recopy: %q", w)
+		}
 	}
 }

--- a/internal/planner/planner.go
+++ b/internal/planner/planner.go
@@ -61,6 +61,15 @@ type PlaceAction struct {
 	Kind      PlaceKind
 }
 
+// CopyAction is a place-once copy to materialize: copy Src (= <src>/<subpath>)
+// into TargetAbs（target 不在のときのみ・place-once・→ ADR-0002, ADR-0016）。
+// 既存 target（記録あり / foreign）は触らないため CopyAction を生まない。
+type CopyAction struct {
+	Entry     manifest.Entry
+	TargetAbs string
+	Src       string // LinkDest(Entry): <src>/<subpath>（コピー元）
+}
+
 // RemoveAction is a stale symlink that satisfies the conservative invariant at
 // plan time (recorded by prev AND on-disk points to the recorded dest). The
 // stale-remover re-verifies this against the real FS before unlinking.
@@ -89,6 +98,9 @@ const (
 	WarnStaleNonSymlink
 	// WarnCopyOrphan は消えた copy entry の orphan（削除はしない・reset で撤去・→ ADR-0020）。
 	WarnCopyOrphan
+	// WarnCopyForeign は copy target に記録の無い実ファイルがあり place-once で skip する
+	// （上書きしない・masking 防止に可視化・symlink の foreign 警告と対称・→ ADR-0022）。
+	WarnCopyForeign
 )
 
 // Warning is a non-fatal condition surfaced to the user for a given target.
@@ -98,10 +110,11 @@ type Warning struct {
 }
 
 // Plan is the computed place/replace/remove plan plus non-fatal warnings and
-// fatal conflicts. The engine executes Place then Remove (「新規/張替を先に、stale
-// 除去を最後に」・→ ADR-0006); a non-empty Conflicts means apply must stop.
+// fatal conflicts. The engine executes Place / Copies then Remove (「新規/張替を先に、
+// stale 除去を最後に」・→ ADR-0006); a non-empty Conflicts means apply must stop.
 type Plan struct {
 	Place     []PlaceAction
+	Copies    []CopyAction
 	Remove    []RemoveAction
 	Conflicts []Conflict
 	Warnings  []Warning
@@ -124,18 +137,9 @@ func Compute(prev, next *manifest.Manifest, root string, fs FS) (Plan, error) {
 	// --- place / replace 側: 新世代の各 entry を現 FS に照らして分類する ---
 	prevByTarget := byTarget(prev)
 	for _, e := range entriesOf(next) {
-		switch e.Method {
-		case manifest.MethodSymlink:
-			// 本スライスは symlink のみ対応。
-		case manifest.MethodCopy:
-			return Plan{}, fmt.Errorf("nput: method=copy は本スライスでは未実装です (target: %s)", e.Target)
-		default:
-			return Plan{}, fmt.Errorf("nput: 未知の method: %q (target: %s)", e.Method, e.Target)
-		}
-
 		targetAbs := filepath.Join(root, filepath.Clean(e.Target))
 
-		// 祖先 component が symlink ならネスト不可で conflict（→ ADR-0015）。
+		// 祖先 component が symlink ならネスト不可で conflict（全 method 共通・→ ADR-0015）。
 		offender, err := ancestorSymlink(root, e.Target, fs)
 		if err != nil {
 			return Plan{}, err
@@ -147,6 +151,17 @@ func Compute(prev, next *manifest.Manifest, root string, fs FS) (Plan, error) {
 				Reason:    fmt.Sprintf("祖先 %q が symlink です。配下にネストできません (→ ADR-0015)", offender),
 			})
 			continue
+		}
+
+		// method ごとに place-once / 張替の分類を分岐する。
+		if e.Method == manifest.MethodCopy {
+			if err := classifyCopy(&plan, e, targetAbs, prevByTarget, fs); err != nil {
+				return Plan{}, err
+			}
+			continue
+		}
+		if e.Method != manifest.MethodSymlink {
+			return Plan{}, fmt.Errorf("nput: 未知の method: %q (target: %s)", e.Method, e.Target)
 		}
 
 		info, err := fs.Lstat(targetAbs)
@@ -244,6 +259,58 @@ func recordedLink(target, targetAbs string, prevByTarget map[string]manifest.Ent
 		return false
 	}
 	return onDisk == LinkDest(pe)
+}
+
+// classifyCopy は copy entry を place-once 意味論で分類する（→ ADR-0002, ADR-0016, ADR-0022,
+// docs/spec.md「copy モード」）。
+//
+//	target 不在            → CopyAction（新規 place-once コピー）
+//	target 既存・構造不一致 → conflict（subpath dir × target file / subpath file × target dir）
+//	target 既存・記録あり   → no-op（nput が前世代で配置済み・place-once で触らない）
+//	target 既存・foreign    → skip + WarnCopyForeign（記録の無い実ファイル・masking 防止）
+//
+// recopy（apply --recopy）は place-once を破る別経路で、engine 側が manifest の copy entry を
+// 直接上書きする。planner は通常の place-once 分類のみを行う（→ ADR-0020）。
+func classifyCopy(plan *Plan, e manifest.Entry, targetAbs string, prevByTarget map[string]manifest.Entry, fs FS) error {
+	info, err := fs.Lstat(targetAbs)
+	switch {
+	case err == nil:
+		// target 既存: まず src 構造と種別が一致するか検査する。
+		mismatch, err := copyStructureMismatch(e, info, fs)
+		if err != nil {
+			return err
+		}
+		if mismatch {
+			plan.Conflicts = append(plan.Conflicts, Conflict{
+				Entry:     e,
+				TargetAbs: targetAbs,
+				Reason:    "copy の src 構造と target の種別が不一致です（dir↔file・上書きしません）",
+			})
+			return nil
+		}
+		// place-once: 前世代が記録した copy なら触らない。記録の無い実ファイルは foreign 警告。
+		if pe, ok := prevByTarget[e.Target]; ok && pe.Method == manifest.MethodCopy {
+			return nil
+		}
+		plan.Warnings = append(plan.Warnings, Warning{Kind: WarnCopyForeign, Target: e.Target})
+		return nil
+	case os.IsNotExist(err):
+		plan.Copies = append(plan.Copies, CopyAction{Entry: e, TargetAbs: targetAbs, Src: LinkDest(e)})
+		return nil
+	default:
+		return fmt.Errorf("nput: copy target を lstat できません (%s): %w", targetAbs, err)
+	}
+}
+
+// copyStructureMismatch は src（<src>/<subpath>）の dir/file 種別と既存 target の種別が
+// 食い違うか判定する（subpath dir × target file / subpath file × target dir・→ docs/spec.md）。
+// symlink target は IsDir()=false で「file 側」として扱う。
+func copyStructureMismatch(e manifest.Entry, targetInfo os.FileInfo, fs FS) (bool, error) {
+	srcInfo, err := fs.Lstat(LinkDest(e))
+	if err != nil {
+		return false, fmt.Errorf("nput: copy src を lstat できません (%s): %w", LinkDest(e), err)
+	}
+	return srcInfo.IsDir() != targetInfo.IsDir(), nil
 }
 
 // ancestorSymlink walks the target's ancestor components under root and returns

--- a/internal/planner/planner_test.go
+++ b/internal/planner/planner_test.go
@@ -84,6 +84,7 @@ type want struct {
 	placeNew     []string
 	placeReplace []string
 	placeForeign []string
+	copies       []string
 	remove       []string
 	warns        []WarnKind
 	conflicts    int
@@ -102,6 +103,14 @@ func placeTargets(p Plan, kind PlaceKind) []string {
 func removeTargets(p Plan) []string {
 	var out []string
 	for _, a := range p.Remove {
+		out = append(out, a.Entry.Target)
+	}
+	return out
+}
+
+func copyTargets(p Plan) []string {
+	var out []string
+	for _, a := range p.Copies {
 		out = append(out, a.Entry.Target)
 	}
 	return out
@@ -259,6 +268,54 @@ func TestComputeTableDriven(t *testing.T) {
 			want: want{warns: []WarnKind{WarnCopyOrphan}},
 		},
 		{
+			// copy target 不在: place-once で新規コピー。
+			name: "copy target absent → place-once copy",
+			prev: nil,
+			next: mani(cp(srcA, ".config/foo")),
+			fs:   fakeFS{},
+			want: want{copies: []string{".config/foo"}},
+		},
+		{
+			// copy 既存・記録あり（前世代も copy）: place-once で no-op。
+			name: "copy recorded → no-op",
+			prev: mani(cp(srcA, ".config/foo")),
+			next: mani(cp(srcA, ".config/foo")),
+			fs:   fakeFS{srcA: reg(), abs(".config/foo"): reg()},
+			want: want{},
+		},
+		{
+			// copy 既存・記録なし（foreign 実ファイル）: skip + warning。
+			name: "copy foreign file → skip + warn",
+			prev: nil,
+			next: mani(cp(srcA, ".config/foo")),
+			fs:   fakeFS{srcA: reg(), abs(".config/foo"): reg()},
+			want: want{warns: []WarnKind{WarnCopyForeign}},
+		},
+		{
+			// 構造不一致（src dir × target file）: conflict。
+			name: "copy structure mismatch (src dir, target file) → conflict",
+			prev: nil,
+			next: mani(cp(srcA, ".config/foo")),
+			fs:   fakeFS{srcA: dir(), abs(".config/foo"): reg()},
+			want: want{conflicts: 1},
+		},
+		{
+			// 構造不一致（src file × target dir）: conflict。
+			name: "copy structure mismatch (src file, target dir) → conflict",
+			prev: nil,
+			next: mani(cp(srcA, ".config/foo")),
+			fs:   fakeFS{srcA: reg(), abs(".config/foo"): dir()},
+			want: want{conflicts: 1},
+		},
+		{
+			// copy 既存・記録あり・dir/dir 一致: no-op。
+			name: "copy recorded dir → no-op",
+			prev: mani(cp(srcA, ".config/foo")),
+			next: mani(cp(srcA, ".config/foo")),
+			fs:   fakeFS{srcA: dir(), abs(".config/foo"): dir()},
+			want: want{},
+		},
+		{
 			// 複合: 新規 + silent 張替 + foreign 警告 + stale 除去 + mismatch 残し。
 			name: "mixed plan",
 			prev: mani(sl(srcA, "keep"), sl(srcA, "drop"), sl(srcA, "mism")),
@@ -289,21 +346,13 @@ func TestComputeTableDriven(t *testing.T) {
 			sortedEq(t, "placeNew", placeTargets(plan, PlaceNew), tt.want.placeNew)
 			sortedEq(t, "placeReplace", placeTargets(plan, PlaceReplace), tt.want.placeReplace)
 			sortedEq(t, "placeForeign", placeTargets(plan, PlaceForeign), tt.want.placeForeign)
+			sortedEq(t, "copies", copyTargets(plan), tt.want.copies)
 			sortedEq(t, "remove", removeTargets(plan), tt.want.remove)
 			warnEq(t, warnKinds(plan), tt.want.warns)
 			if len(plan.Conflicts) != tt.want.conflicts {
 				t.Errorf("conflicts = %d, want %d (%v)", len(plan.Conflicts), tt.want.conflicts, plan.Conflicts)
 			}
 		})
-	}
-}
-
-// TestComputeCopyInNextErrors は新世代に copy entry があると未実装エラーになることを検証する
-// （本スライスは symlink のみ・→ Issue #6）。
-func TestComputeCopyInNextErrors(t *testing.T) {
-	_, err := Compute(nil, mani(cp("/nix/store/x", ".config/foo")), root, fakeFS{})
-	if err == nil {
-		t.Fatal("expected error for copy entry in next manifest, got nil")
 	}
 }
 


### PR DESCRIPTION
## 概要

out-of-store symlink（`mkOutOfStoreSymlink`）の end-to-end 縦切り（issue #12）の
残作業を実装する。lib 層の marker→clean enum 変換・farm アンカー除外・copy×marker
の throwIf・既存 symlink 経路での配置は先行 PR で完成済みのため、本 PR は次の 2 点に閉じる。

- **engine 実行時のリンク先存在チェック**: marker のローカル絶対パス（`LinkDest`）が
  不在なら dangling symlink を張ることになるため、配置直前の pre-flight で検査し
  engine 実行時エラーで停止する。検査は out-of-store のみに閉じ、store / copy 経路や
  `place.go` の symlink ループには触れない。
- **テスト**: out-of-store placer の tmpdir 統合テストと、marker タグ→clean enum 変換の
  nix-unit ケースを追加。

## 関連 issue

Refs #12

## docs / ADR 影響

なし（ADR-0001 / ADR-0013 で既定済みの挙動を実装。spec「配置動作仕様 / out-of-store
symlink」の範囲内で、新たな方針転換は伴わない）。
