### PR TITLE
feat(engine): project mode の世代スキップ + lstat ドリフト修復

### DIFF
--- a/internal/engine/copy.go
+++ b/internal/engine/copy.go
@@ -11,6 +11,16 @@ import (
 	"github.com/yasunori0418/nput/internal/planner"
 )
 
+// materializeCopies は copy entry を実 FS に反映する分岐点。--recopy のときは全 copy target を
+// 無条件上書き（recopyAll）、通常は planner の place-once 分類（target 不在のみ新規コピー）に従う
+// （→ ADR-0020）。通常 apply と世代スキップ時のドリフト修復が共有する。
+func (a *applier) materializeCopies(plan planner.Plan, recopy bool) error {
+	if recopy {
+		return a.recopyAll()
+	}
+	return a.placeCopies(plan.Copies)
+}
+
 // placeCopies materializes the planner's place-once CopyActions（target 不在の copy のみ・
 // → ADR-0002, ADR-0016）。既存 target（記録あり / foreign）は planner が CopyAction を
 // 生まないため、ここは「新規コピー」だけを実 FS に反映する薄い executor に徹する。

--- a/internal/engine/drift.go
+++ b/internal/engine/drift.go
@@ -1,0 +1,55 @@
+package engine
+
+import (
+	"path/filepath"
+
+	"github.com/yasunori0418/nput/internal/planner"
+)
+
+// 世代スキップ + lstat ドリフト修復（project mode 限定・→ ADR-0005, ADR-0017,
+// docs/spec.md「project mode の世代」）。
+//
+// devShell / direnv の shellHook はシェル再入のたびに走るため、新 link-farm
+// derivation が前世代と同一なら新世代は積まない（--set を省く・世代無限増殖の回避）。
+// ただし「derivation 同一 ⇒ FS 同一」は foreign tool の書き換えで崩れるため、完全
+// no-op にはせず各 entry の target を lstat 検査し、ドリフトした entry だけ再張りする。
+
+// generationUnchanged は新 link-farm が前世代（profile リンクが指す世代）と同一の store
+// derivation かを返す。profile リンク → 世代リンク → link-farm store パスの連鎖を解決して
+// 新 link-farm の store パスと突き合わせる。どちらかが解決できなければ error を返し、呼び出し側は
+// 安全側（通常 apply = 新世代コミット）に倒す。
+func generationUnchanged(profileLink, newLinkFarm string) (bool, error) {
+	prev, err := filepath.EvalSymlinks(profileLink)
+	if err != nil {
+		return false, err
+	}
+	next, err := filepath.EvalSymlinks(newLinkFarm)
+	if err != nil {
+		return false, err
+	}
+	return prev == next, nil
+}
+
+// repairDrift は世代スキップ時の lstat ドリフト修復を行う。planner が現 FS 状態から算出した
+// プランのうち、ドリフトした entry **だけ** を再収束させ、stale 除去も世代コミットもしない。
+//
+//   - symlink: PlaceNew（target 消失）と PlaceForeign（foreign 書き換え）だけ再張りする。
+//     PlaceReplace は「記録通りの先を指す symlink」= ドリフトなしのため触らない（→ ADR-0017）。
+//     foreign 書き換えの warning は呼び出し側が emitWarnings(plan.Warnings) で既に出している。
+//   - copy: planner.Copies は target 不在の place-once アクションのみを含むため、それを反映すると
+//     「copy は target 不在時のみ place-once 復帰」になる。内容差（ユーザー編集）は CopyAction が
+//     生まれず触らない（→ docs/spec.md「project mode の世代」・ADR-0022）。--recopy のときは
+//     recopyAll で無条件上書きする（recopy は世代外の opt-in）。
+func (a *applier) repairDrift(plan planner.Plan, recopy bool) error {
+	drifted := make([]planner.PlaceAction, 0, len(plan.Place))
+	for _, act := range plan.Place {
+		if act.Kind == planner.PlaceReplace {
+			continue // 記録通りの先を指す symlink = in-sync。ドリフトなしで再張り不要。
+		}
+		drifted = append(drifted, act)
+	}
+	if err := a.place(drifted); err != nil {
+		return err
+	}
+	return a.materializeCopies(plan, recopy)
+}

--- a/internal/engine/drift_test.go
+++ b/internal/engine/drift_test.go
@@ -1,0 +1,291 @@
+package engine
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/yasunori0418/nput/internal/manifest"
+)
+
+// 世代スキップ + lstat ドリフト修復の tmpdir 統合テスト（実 FS・nix 不使用・fakeCommit 経路）。
+// fakeCommit は profile リンクを link-farm へ直接張るため、同一 link-farm を 2 度 apply すると
+// generationUnchanged が成立し（project mode 限定）、新世代を積まず（--set 省略）lstat 修復だけ走る。
+
+// applyOnce は project mode（roothash キー）の 1 回分 apply を回す共通ヘルパ。
+func applyOnce(t *testing.T, lf, name, root, state string, commits *[][2]string, warns *[]string) *Result {
+	t.Helper()
+	opts := Options{
+		LinkFarm: lf, Name: name, RootOverride: root, StateDir: state, Commit: fakeCommit(commits),
+	}
+	if warns != nil {
+		opts.Warnf = collectWarnings(warns)
+	}
+	res, err := Apply(opts)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	return res
+}
+
+func TestApplyGenerationSkipNoDrift(t *testing.T) {
+	root := realTempDir(t)
+	state := realTempDir(t)
+	src := makeSrc(t, "x")
+	// 同一 link-farm を 2 度使う（derivation 同一 = 世代スキップ対象）。
+	lf := writeLinkFarm(t, projectManifest(storeEntry(src, ".", ".config/foo")))
+
+	var commits [][2]string
+	applyOnce(t, lf, "c", root, state, &commits, nil)
+	if len(commits) != 1 {
+		t.Fatalf("first apply commit calls = %d, want 1", len(commits))
+	}
+
+	// 2 回目: link-farm 同一・FS もドリフトなし → 世代スキップ・完全 no-op（commit 増えない）。
+	res := applyOnce(t, lf, "c", root, state, &commits, nil)
+	if !res.GenerationSkipped {
+		t.Errorf("GenerationSkipped = false, want true (same derivation)")
+	}
+	if len(commits) != 1 {
+		t.Errorf("commit calls = %d, want 1 (generation skip omits --set)", len(commits))
+	}
+	if len(res.Placed)+len(res.Replaced)+len(res.Removed) != 0 {
+		t.Errorf("no-drift skip should touch nothing: Placed=%v Replaced=%v Removed=%v", res.Placed, res.Replaced, res.Removed)
+	}
+	// symlink は記録通りのまま。
+	if dest, _ := os.Readlink(filepath.Join(root, ".config", "foo")); dest != src {
+		t.Errorf("symlink dest = %q, want %q (untouched)", dest, src)
+	}
+}
+
+func TestApplyGenerationSkipRepairsDeletedSymlink(t *testing.T) {
+	root := realTempDir(t)
+	state := realTempDir(t)
+	src := makeSrc(t, "x")
+	lf := writeLinkFarm(t, projectManifest(storeEntry(src, ".", ".config/foo")))
+
+	var commits [][2]string
+	applyOnce(t, lf, "c", root, state, &commits, nil)
+
+	// foreign tool が target を消す。
+	tgt := filepath.Join(root, ".config", "foo")
+	if err := os.Remove(tgt); err != nil {
+		t.Fatal(err)
+	}
+
+	// 2 回目: 世代スキップだが、消えた entry を再張りする（完全 no-op にしない）。
+	res := applyOnce(t, lf, "c", root, state, &commits, nil)
+	if !res.GenerationSkipped {
+		t.Errorf("GenerationSkipped = false, want true")
+	}
+	if len(commits) != 1 {
+		t.Errorf("commit calls = %d, want 1 (no new generation)", len(commits))
+	}
+	if len(res.Placed) != 1 || res.Placed[0] != ".config/foo" {
+		t.Errorf("Placed = %v, want [.config/foo] (deleted symlink re-placed)", res.Placed)
+	}
+	if dest, _ := os.Readlink(tgt); dest != src {
+		t.Errorf("re-placed dest = %q, want %q", dest, src)
+	}
+}
+
+func TestApplyGenerationSkipRepairsForeignSymlinkWithWarn(t *testing.T) {
+	root := realTempDir(t)
+	state := realTempDir(t)
+	src := makeSrc(t, "x")
+	lf := writeLinkFarm(t, projectManifest(storeEntry(src, ".", ".config/foo")))
+
+	var commits [][2]string
+	applyOnce(t, lf, "c", root, state, &commits, nil)
+
+	// foreign tool が target を別の先へ書き換える。
+	tgt := filepath.Join(root, ".config", "foo")
+	foreign := realTempDir(t)
+	if err := os.Remove(tgt); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(foreign, tgt); err != nil {
+		t.Fatal(err)
+	}
+
+	// 2 回目: 世代スキップだが foreign 書き換えを warning 付きで再張り（後勝ち）。
+	var warns []string
+	res := applyOnce(t, lf, "c", root, state, &commits, &warns)
+	if !res.GenerationSkipped {
+		t.Errorf("GenerationSkipped = false, want true")
+	}
+	if len(commits) != 1 {
+		t.Errorf("commit calls = %d, want 1 (no new generation)", len(commits))
+	}
+	if len(res.Replaced) != 1 || res.Replaced[0] != ".config/foo" {
+		t.Errorf("Replaced = %v, want [.config/foo] (foreign re-placed)", res.Replaced)
+	}
+	foundForeign := false
+	for _, w := range warns {
+		if strings.Contains(w, "foreign") {
+			foundForeign = true
+		}
+	}
+	if !foundForeign {
+		t.Errorf("expected a foreign warning during drift repair, got %v", warns)
+	}
+	if dest, _ := os.Readlink(tgt); dest != src {
+		t.Errorf("re-placed dest = %q, want %q (last-wins)", dest, src)
+	}
+}
+
+func TestApplyGenerationSkipRepairsDeletedCopy(t *testing.T) {
+	root := realTempDir(t)
+	state := realTempDir(t)
+	src := makeROSrc(t, "file.txt", "store-content")
+	lf := writeLinkFarm(t, projectManifest(copyEntry(src, "file.txt", ".config/foo")))
+
+	var commits [][2]string
+	applyOnce(t, lf, "c", root, state, &commits, nil)
+	tgt := filepath.Join(root, ".config", "foo")
+	if _, err := os.Stat(tgt); err != nil {
+		t.Fatalf("copy target should exist after first apply: %v", err)
+	}
+
+	// foreign tool が copy target を消す → place-once 復帰の対象。
+	if err := os.Remove(tgt); err != nil {
+		t.Fatal(err)
+	}
+
+	res := applyOnce(t, lf, "c", root, state, &commits, nil)
+	if !res.GenerationSkipped {
+		t.Errorf("GenerationSkipped = false, want true")
+	}
+	if len(commits) != 1 {
+		t.Errorf("commit calls = %d, want 1 (no new generation)", len(commits))
+	}
+	if len(res.Copied) != 1 || res.Copied[0] != ".config/foo" {
+		t.Errorf("Copied = %v, want [.config/foo] (deleted copy re-materialized)", res.Copied)
+	}
+	if data, _ := os.ReadFile(tgt); string(data) != "store-content" {
+		t.Errorf("re-copied content = %q, want store-content", data)
+	}
+}
+
+func TestApplyGenerationSkipKeepsEditedCopy(t *testing.T) {
+	root := realTempDir(t)
+	state := realTempDir(t)
+	src := makeROSrc(t, "file.txt", "store-content")
+	lf := writeLinkFarm(t, projectManifest(copyEntry(src, "file.txt", ".config/foo")))
+
+	var commits [][2]string
+	applyOnce(t, lf, "c", root, state, &commits, nil)
+
+	// ユーザーが copy を編集する（内容差）→ 世代スキップの修復では触らない（src 追従は --recopy 限定）。
+	tgt := filepath.Join(root, ".config", "foo")
+	if err := os.WriteFile(tgt, []byte("user-edit"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	res := applyOnce(t, lf, "c", root, state, &commits, nil)
+	if !res.GenerationSkipped {
+		t.Errorf("GenerationSkipped = false, want true")
+	}
+	if len(res.Copied) != 0 {
+		t.Errorf("Copied = %v, want none (edited copy untouched)", res.Copied)
+	}
+	if data, _ := os.ReadFile(tgt); string(data) != "user-edit" {
+		t.Errorf("edited copy content = %q, want user-edit (place-once keeps edits)", data)
+	}
+}
+
+func TestApplyGenerationSkipOnlyProjectMode(t *testing.T) {
+	// home mode は世代スキップしない（毎回新世代）。home mode は同一 link-farm でも commit が増える。
+	root := realTempDir(t)
+	state := realTempDir(t)
+	src := makeSrc(t, "x")
+
+	// home mode manifest（RootKindHome）。RootOverride で root を tmpdir に逃がす（→ ADR-0017 --root 全モード上書き）。
+	hm := manifest.Manifest{
+		SchemaVersion: 1,
+		Root:          manifest.Root{RootKind: manifest.RootKindHome},
+		Entries:       []manifest.Entry{storeEntry(src, ".", ".config/foo")},
+	}
+	lf := writeLinkFarm(t, hm)
+
+	var commits [][2]string
+	apply := func() *Result {
+		res, err := Apply(Options{
+			LinkFarm: lf, Name: "c", RootOverride: root, StateDir: state, Commit: fakeCommit(&commits),
+		})
+		if err != nil {
+			t.Fatalf("Apply: %v", err)
+		}
+		return res
+	}
+
+	apply()
+	res := apply()
+	if res.GenerationSkipped {
+		t.Errorf("home mode must not skip generations (GenerationSkipped = true)")
+	}
+	if len(commits) != 2 {
+		t.Errorf("home mode commit calls = %d, want 2 (new generation each apply)", len(commits))
+	}
+}
+
+func TestApplyGenerationSkipRecopyOverwrites(t *testing.T) {
+	// --recopy は世代スキップ時も copy を無条件上書きする（recopy は世代外の opt-in）。
+	root := realTempDir(t)
+	state := realTempDir(t)
+	src := makeROSrc(t, "file.txt", "store-content")
+	lf := writeLinkFarm(t, projectManifest(copyEntry(src, "file.txt", ".config/foo")))
+
+	var commits [][2]string
+	applyOnce(t, lf, "c", root, state, &commits, nil)
+	tgt := filepath.Join(root, ".config", "foo")
+	if err := os.WriteFile(tgt, []byte("user-edit"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// 2 回目: derivation 同一で世代スキップだが --recopy で copy を上書き。世代は積まない。
+	res, err := Apply(Options{
+		LinkFarm: lf, Name: "c", RootOverride: root, StateDir: state, Recopy: true, Commit: fakeCommit(&commits),
+	})
+	if err != nil {
+		t.Fatalf("recopy Apply: %v", err)
+	}
+	if !res.GenerationSkipped {
+		t.Errorf("GenerationSkipped = false, want true")
+	}
+	if len(commits) != 1 {
+		t.Errorf("commit calls = %d, want 1 (recopy stays out of generations)", len(commits))
+	}
+	if data, _ := os.ReadFile(tgt); string(data) != "store-content" {
+		t.Errorf("recopy should restore src content, got %q", data)
+	}
+	if len(res.Recopied) != 1 || res.Recopied[0] != ".config/foo" {
+		t.Errorf("Recopied = %v, want [.config/foo]", res.Recopied)
+	}
+}
+
+func TestApplyNewDerivationCommitsNewGeneration(t *testing.T) {
+	// link-farm derivation が変われば（別 src）世代スキップせず新世代を積む。
+	root := realTempDir(t)
+	state := realTempDir(t)
+
+	src1 := makeSrc(t, "x")
+	lf1 := writeLinkFarm(t, projectManifest(storeEntry(src1, ".", ".config/foo")))
+	var commits [][2]string
+	applyOnce(t, lf1, "c", root, state, &commits, nil)
+
+	// 別 link-farm（別 src = 別 derivation）→ 世代スキップしない。
+	src2 := makeSrc(t, "x")
+	lf2 := writeLinkFarm(t, projectManifest(storeEntry(src2, ".", ".config/foo")))
+	res := applyOnce(t, lf2, "c", root, state, &commits, nil)
+	if res.GenerationSkipped {
+		t.Errorf("GenerationSkipped = true, want false (derivation changed)")
+	}
+	if len(commits) != 2 {
+		t.Errorf("commit calls = %d, want 2 (new derivation = new generation)", len(commits))
+	}
+	if dest, _ := os.Readlink(filepath.Join(root, ".config", "foo")); dest != src2 {
+		t.Errorf("dest = %q, want %q", dest, src2)
+	}
+}

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -79,6 +79,10 @@ type Result struct {
 	Recopied   []string // --recopy で上書き再コピーした既存 copy target（→ ADR-0020）
 	Removed    []string // stale 除去した target
 	Skipped    bool     // try-lock 競合で skip した（NoWait 経路）
+	// GenerationSkipped は project mode の世代スキップで新世代を積まなかった（--set を省いた）
+	// ことを表す。新 link-farm が前世代と同一のため commit せず、ドリフトした entry だけ
+	// lstat 修復した経路（→ ADR-0005, ADR-0017, docs/spec.md 世代スキップ）。
+	GenerationSkipped bool
 }
 
 // ErrSkipped は NoWait 経路で他の apply が進行中のため skip したことを表す。
@@ -184,26 +188,39 @@ func Apply(opts Options) (*Result, error) {
 		return nil, err
 	}
 
-	// 7. プランを実 FS に反映（新規 / 張替を先に、stale 除去を最後に・→ ADR-0006）。
+	// 7. project mode の世代スキップ判定（新 link-farm derivation が前世代と同一か）。
+	//    同一なら新世代を積まず（--set を省く）、ドリフトした entry だけ lstat 修復して返す
+	//    （完全 no-op にしない）。home / fixed / system は対象外で毎回新世代を積む
+	//    （世代スキップは project mode 限定・→ ADR-0005, ADR-0017, docs/spec.md 世代スキップ）。
+	if rootKind == manifest.RootKindProject && prev != nil {
+		same, err := generationUnchanged(a.profile.Profile, a.opts.LinkFarm)
+		if err != nil {
+			// 前世代 link-farm を解決できないときは安全側に倒して通常 apply（新世代を積む）。
+			a.opts.Warnf("nput: 前世代 link-farm を解決できませんでした。世代スキップせず再コミットします: %v", err)
+		} else if same {
+			if err := a.repairDrift(plan, opts.Recopy); err != nil {
+				return nil, err
+			}
+			a.result.GenerationSkipped = true
+			a.cleanupPending()
+			return a.result, nil
+		}
+	}
+
+	// 8. プランを実 FS に反映（新規 / 張替を先に、stale 除去を最後に・→ ADR-0006）。
 	//    symlink は plan 駆動。copy は --recopy のとき全 copy target を無条件上書き、
 	//    通常は place-once（target 不在のみ新規コピー）に分岐する（→ ADR-0020）。
 	if err := a.place(plan.Place); err != nil {
 		return nil, err
 	}
-	if opts.Recopy {
-		if err := a.recopyAll(); err != nil {
-			return nil, err
-		}
-	} else {
-		if err := a.placeCopies(plan.Copies); err != nil {
-			return nil, err
-		}
+	if err := a.materializeCopies(plan, opts.Recopy); err != nil {
+		return nil, err
 	}
 	if err := a.removeStale(plan.Remove); err != nil {
 		return nil, err
 	}
 
-	// 8. 世代コミット（→ docs/spec.md 実行フロー 2f）。
+	// 9. 世代コミット（→ docs/spec.md 実行フロー 2f）。
 	commit := opts.Commit
 	if commit == nil {
 		commit = nixEnvCommit
@@ -212,15 +229,21 @@ func Apply(opts Options) (*Result, error) {
 		return nil, fmt.Errorf("nput: 世代コミット（nix-env --set）に失敗しました: %w", err)
 	}
 
-	// 9. --set 成功後に .pending を削除する（世代リンクが gcroot を引き継ぐ・→ ADR-0011, ADR-0025）。
-	//    build 経路でのみ pending を張るため、その経路でのみ削除する。
-	if opts.Build != nil {
-		if err := os.Remove(a.profile.Pending); err != nil && !os.IsNotExist(err) {
-			a.opts.Warnf("nput: .pending out-link を削除できませんでした (%s): %v", a.profile.Pending, err)
-		}
-	}
+	// 10. --set 成功後に .pending を削除する（世代リンクが gcroot を引き継ぐ・→ ADR-0011, ADR-0025）。
+	a.cleanupPending()
 
 	return a.result, nil
+}
+
+// cleanupPending は --set 成功後（または世代スキップ後）に .pending out-link を削除する。
+// build 経路でのみ pending を張るため、その経路でのみ削除する（→ ADR-0011, ADR-0025）。
+func (a *applier) cleanupPending() {
+	if a.opts.Build == nil {
+		return
+	}
+	if err := os.Remove(a.profile.Pending); err != nil && !os.IsNotExist(err) {
+		a.opts.Warnf("nput: .pending out-link を削除できませんでした (%s): %v", a.profile.Pending, err)
+	}
 }
 
 type applier struct {

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -126,6 +126,7 @@ func makeROSrc(t *testing.T, subpath, content string) string {
 	}
 	return src
 }
+
 // --- tests -----------------------------------------------------------------
 
 func TestApplyFirstPlacementProjectMode(t *testing.T) {

--- a/internal/engine/generations.go
+++ b/internal/engine/generations.go
@@ -176,7 +176,7 @@ func Rollback(opts RollbackOptions) (*RollbackResult, error) {
 	a := &applier{opts: Options{Warnf: warnf}, result: &Result{Root: root, ProfileDir: prof.Dir}}
 	a.profile = prof
 	a.root = root
-	a.emitWarnings(plan.Warnings)
+	a.emitWarnings(plan.Warnings, false) // rollback は recopy しない（copy foreign skip 抑制は無関係）
 	if err := a.place(plan.Place); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## 概要

issue #15。devShell / direnv の shellHook がシェル再入のたびに走っても世代が
無限増殖しないよう、project mode で **新 link-farm derivation が前世代と同一なら
新世代を積まない**（\`--set\` を省く）。ただし完全 no-op にはせず、各 entry の target
を lstat 検査して**ドリフトした entry だけ再収束**させる。

- 世代スキップ判定（\`generationUnchanged\`）: profile→世代→store パスを解決し新
  link-farm と突き合わせ。解決不能時は安全側に倒して通常 apply（新世代）。
- ドリフト修復（\`repairDrift\`）: planner プランの PlaceNew（消失）/ PlaceForeign
  （foreign 書換・warning 付き後勝ち）だけ再張り。PlaceReplace（記録通り=in-sync）
  は不可触。copy は target 不在時のみ place-once 復帰、内容差（編集）は不可触。
- 世代スキップは **project mode 限定**（home / fixed / system は毎回新世代）。
- cross-config 同一 target の振動はユーザー責任（foreign warning で可視化・止める
  機構は持たない・→ ADR-0023, document-only）。
- 付随: rollback の \`emitWarnings\` 呼び出しが並行マージでビルド破綻していたのを修正。

実 FS の tmpdir 統合テスト（nix 不使用・fakeCommit 経路）で判定 + 修復を検証。
\`nix flake check\` green。

## 関連 issue

Closes #15

## docs / ADR 影響

なし。本挙動は既に ADR-0017・ADR-0005・docs/spec.md「project mode の世代」が規定済みで、今回はその実装。