### PR TITLE
feat(cli): apply --all + root filters と gitignore を追加

### DIFF
--- a/cmd/nput/apply.go
+++ b/cmd/nput/apply.go
@@ -4,20 +4,34 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"sort"
 
 	"github.com/spf13/cobra"
 
 	"github.com/yasunori0418/nput/internal/engine"
+	"github.com/yasunori0418/nput/internal/manifest"
 )
+
+var flagApplyAll bool // --all: nput.* を辞書順に全適用（root filter で絞り込み可）
 
 func newApplyCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "apply [name]",
 		Short: "nput.<name> をビルドし新世代を作って適用（name 省略時は nput.default）",
 		Long: "entrypoint の nput.<name> をビルドして配置する。" +
-			"name を省略すると nput.default を適用する（flake の default 慣例・未定義ならエラー）。",
+			"name を省略すると nput.default を適用する（flake の default 慣例・未定義ならエラー）。" +
+			"--all で nput.* を辞書順に全適用し、--project-root / --home-root / --system-root で root モードを絞れる。",
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if flagApplyAll {
+				if len(args) > 0 {
+					return fmt.Errorf("nput: apply は <name> と --all を併用できません")
+				}
+				return runApplyAll()
+			}
+			if err := ensureNoRootFilter("apply --all"); err != nil {
+				return err
+			}
 			name := "default"
 			if len(args) == 1 {
 				name = args[0]
@@ -25,6 +39,7 @@ func newApplyCmd() *cobra.Command {
 			return runApply(name)
 		},
 	}
+	cmd.Flags().BoolVar(&flagApplyAll, "all", false, "nput.* を辞書順に全適用（一部失敗しても続行・1 つでも失敗なら非ゼロ終了）")
 	cmd.Flags().BoolVar(&flagRecopy, "recopy", false,
 		"config 内の全 copy target を src から無条件上書き再コピー（ローカル編集は破棄・→ ADR-0020）")
 	cmd.Flags().BoolVar(&flagDryrun, "dryrun", false,
@@ -73,15 +88,7 @@ func runApply(name string) error {
 	}
 
 	// 2. engine を駆動する（flock 取得・ロック内 build・配置・コミット・.pending 削除は engine が所有）。
-	res, err := engine.Apply(engine.Options{
-		Name:         name,
-		RootKind:     rootKind,
-		FixedRoot:    fixedRoot,
-		RootOverride: flagRoot,
-		NoWait:       flagNoWait,
-		Recopy:       flagRecopy,
-		Build:        buildFunc(ep, system, name),
-	})
+	res, err := applyOne(ep, system, name, rootKind, fixedRoot)
 	if err != nil {
 		if errors.Is(err, engine.ErrSkipped) {
 			// try-lock skip は正常スキップ（exit 0・→ docs/spec.md 終了コード表）。
@@ -118,6 +125,144 @@ func printApplyPlan(res *engine.Result) {
 	for _, c := range res.Conflicts {
 		fmt.Printf("conflict\t%s\n", c)
 	}
+}
+
+// applyOne は 1 config に engine.Apply を回す（runApply / runApplyAll が共有）。rootKind / fixedRoot は
+// 単体は evalRoot 先取り、--all は一括 eval（evalAllRoots）から渡す。build だけは config ごとに行う。
+func applyOne(ep *entrypoint, system, name, rootKind, fixedRoot string) (*engine.Result, error) {
+	return engine.Apply(engine.Options{
+		Name:         name,
+		RootKind:     rootKind,
+		FixedRoot:    fixedRoot,
+		RootOverride: flagRoot,
+		NoWait:       flagNoWait,
+		Recopy:       flagRecopy,
+		Build:        buildFunc(ep, system, name),
+	})
+}
+
+// runApplyAll は entrypoint の nput.* を辞書順に全適用する（→ docs/spec.md 実行フロー・ADR-0016, ADR-0024）。
+// rootKind は 1 回の一括 eval で取り（プロセス起動を N→1）、build は atomic 性のため config ごと。
+// 一部失敗しても残りを続行し、最後に集約表示・1 つでも失敗なら非ゼロ終了する。
+func runApplyAll() error {
+	filter, err := selectedRootFilter()
+	if err != nil {
+		return err
+	}
+	ep, err := discoverEntrypoint(flagFile)
+	if err != nil {
+		return err
+	}
+	system, err := currentSystem()
+	if err != nil {
+		return err
+	}
+
+	// 1. rootKind を 1 回の一括 eval で取得する（config 名→rootInfo マップ・→ ADR-0024）。
+	roots, err := evalAllRoots(ep, system)
+	if err != nil {
+		return err
+	}
+
+	// 2. 辞書順に並べ、root filter（--project-root 等）が指定されていれば該当モードだけに絞る。
+	names := make([]string, 0, len(roots))
+	for name := range roots {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	var selected []string
+	for _, name := range names {
+		if filter == "" || roots[name].RootKind == filter {
+			selected = append(selected, name)
+		}
+	}
+	if len(selected) == 0 {
+		if !flagQuiet {
+			fmt.Fprintln(os.Stderr, "nput: apply --all: 対象の config がありません")
+		}
+		return nil
+	}
+
+	// 3. 各 config を独立に適用する。一部失敗しても続行し、失敗を集約する（各 config は独立 atomic）。
+	var failures, skipped, applied int
+	for _, name := range selected {
+		ri := roots[name]
+		res, err := applyOne(ep, system, name, ri.RootKind, ri.Root)
+		if err != nil {
+			if errors.Is(err, engine.ErrSkipped) {
+				skipped++
+				if !flagQuiet {
+					fmt.Fprintf(os.Stderr, "nput: apply %s をスキップしました（別の apply が進行中）\n", name)
+				}
+				continue
+			}
+			failures++
+			// 部分失敗は握り潰さず stderr に出して続行する（→ docs/spec.md「一部失敗しても続行」）。
+			fmt.Fprintf(os.Stderr, "nput: apply %s に失敗しました: %v\n", name, err)
+			continue
+		}
+		applied++
+		if !flagQuiet {
+			reportResult(res, name)
+		}
+	}
+
+	// 4. 集約表示と終了コード（error(1) > conflict(2) > 0 の優先・→ docs/spec.md・ADR-0024）。
+	if !flagQuiet {
+		fmt.Fprintf(os.Stderr, "nput: apply --all 完了 (適用 %d / スキップ %d / 失敗 %d / 対象 %d)\n",
+			applied, skipped, failures, len(selected))
+	}
+	// conflict(2) は --dryrun（#13）の読み取り専用経路でのみ生じる。非 dryrun の --all は error/0 のみ。
+	code := applyAllExitCode(failures > 0, false)
+	if code == 0 {
+		return nil
+	}
+	return &exitCodeError{code: code, msg: fmt.Sprintf("nput: apply --all: %d 件の config が失敗しました", failures)}
+}
+
+// applyAllExitCode は apply --all の終了コードを priority error(1) > conflict(2) > 0 で決める
+// （→ docs/spec.md「出力ストリームと終了コード」・ADR-0024）。単純な最大値（2 > 1）は採らない
+// （conflict が深刻な eval / engine error を CI で隠すため）。conflict は --dryrun 経路でのみ生じる。
+func applyAllExitCode(anyError, anyConflict bool) int {
+	switch {
+	case anyError:
+		return 1
+	case anyConflict:
+		return 2
+	default:
+		return 0
+	}
+}
+
+// selectedRootFilter は --project-root / --home-root / --system-root から root モードフィルタを返す
+// （未指定は ""・複数指定はエラー・→ ADR-0017）。返り値は manifest.RootKind* 文字列。
+func selectedRootFilter() (string, error) {
+	var modes []string
+	if flagProjectRoot {
+		modes = append(modes, manifest.RootKindProject)
+	}
+	if flagHomeRoot {
+		modes = append(modes, manifest.RootKindHome)
+	}
+	if flagSystemRoot {
+		modes = append(modes, manifest.RootKindSystem)
+	}
+	if len(modes) > 1 {
+		return "", fmt.Errorf("nput: --project-root / --home-root / --system-root は同時に 1 つだけ指定できます")
+	}
+	if len(modes) == 0 {
+		return "", nil
+	}
+	return modes[0], nil
+}
+
+// ensureNoRootFilter は root filter が --all 以外で使われたときにエラーにする
+// （フィルタは --all の修飾で、名指し apply では <name> が 1 config を pin するため無意味・→ ADR-0017）。
+func ensureNoRootFilter(modifier string) error {
+	if flagProjectRoot || flagHomeRoot || flagSystemRoot {
+		return fmt.Errorf("nput: --project-root / --home-root / --system-root は %s の修飾です", modifier)
+	}
+	return nil
 }
 
 // reportResult は配置レポートを stderr に出す（stdout は機械可読出力に専有・→ ADR-0023）。

--- a/cmd/nput/apply_test.go
+++ b/cmd/nput/apply_test.go
@@ -1,0 +1,49 @@
+package main
+
+import "testing"
+
+// applyAllExitCode は priority error(1) > conflict(2) > 0（単純な最大値ではない・→ ADR-0024）。
+func TestApplyAllExitCode(t *testing.T) {
+	cases := []struct {
+		name              string
+		anyError, anyConf bool
+		want              int
+	}{
+		{"none", false, false, 0},
+		{"error only", true, false, 1},
+		{"conflict only", false, true, 2},
+		{"error wins over conflict", true, true, 1}, // 最大値なら 2 だが error を隠さない
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := applyAllExitCode(c.anyError, c.anyConf); got != c.want {
+				t.Errorf("applyAllExitCode(%v, %v) = %d, want %d", c.anyError, c.anyConf, got, c.want)
+			}
+		})
+	}
+}
+
+func TestSelectedRootFilter(t *testing.T) {
+	defer func() { flagProjectRoot, flagHomeRoot, flagSystemRoot = false, false, false }()
+
+	t.Run("none", func(t *testing.T) {
+		flagProjectRoot, flagHomeRoot, flagSystemRoot = false, false, false
+		got, err := selectedRootFilter()
+		if err != nil || got != "" {
+			t.Fatalf("got (%q, %v), want (\"\", nil)", got, err)
+		}
+	})
+	t.Run("project", func(t *testing.T) {
+		flagProjectRoot, flagHomeRoot, flagSystemRoot = true, false, false
+		got, err := selectedRootFilter()
+		if err != nil || got != "project" {
+			t.Fatalf("got (%q, %v), want (\"project\", nil)", got, err)
+		}
+	})
+	t.Run("multiple → error", func(t *testing.T) {
+		flagProjectRoot, flagHomeRoot, flagSystemRoot = true, true, false
+		if _, err := selectedRootFilter(); err == nil {
+			t.Fatal("複数指定はエラーになるべき")
+		}
+	})
+}

--- a/cmd/nput/gitignore.go
+++ b/cmd/nput/gitignore.go
@@ -1,0 +1,153 @@
+package main
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/yasunori0418/nput/internal/manifest"
+)
+
+func newGitignoreCmd() *cobra.Command {
+	var all bool
+	cmd := &cobra.Command{
+		Use:   "gitignore [name]",
+		Short: "配置 target を .gitignore 向けに stdout 出力（project mode 限定・書き込みなし）",
+		Long: "nput.<name> の配置 target を .gitignore 向けに stdout へ列挙する（ファイルは書き込まない）。" +
+			"出力は root 相対 target に先頭 / を付けたアンカー形式（例: /.claude/skills/nix）で 1 行 1 件、" +
+			"method（symlink / copy）を区別せず全 target を対象とする。project mode 限定で、" +
+			"--all は projectRoot の全 config の target をソート + 重複除去して出力する。",
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if all {
+				if len(args) > 0 {
+					return fmt.Errorf("nput: gitignore は <name> と --all を併用できません")
+				}
+				return runGitignoreAll()
+			}
+			if len(args) != 1 {
+				return fmt.Errorf("nput: gitignore は <name> または --all が必要です")
+			}
+			return runGitignore(args[0])
+		},
+	}
+	cmd.Flags().BoolVar(&all, "all", false, "projectRoot の全 config の target をソート + 重複除去して出力")
+	return cmd
+}
+
+// runGitignore は単体 config の配置 target を列挙する。project mode 限定で、
+// 非 project config（home / fixed）を指定したらエラー停止する（アンカー形式が git toplevel を前提とするため・→ ADR-0023）。
+func runGitignore(name string) error {
+	ep, err := discoverEntrypoint(flagFile)
+	if err != nil {
+		return err
+	}
+	system, err := currentSystem()
+	if err != nil {
+		return err
+	}
+
+	// rootKind 先取り eval で project mode を確認する（build より先に安価に弾く）。
+	rootKind, _, err := evalRoot(ep, system, name)
+	if err != nil {
+		return err
+	}
+	if rootKind != manifest.RootKindProject {
+		return fmt.Errorf("nput: gitignore は project mode 限定です（nput.%s は rootKind=%q・home / fixed では .gitignore のアンカーが意味を成しません）", name, rootKind)
+	}
+
+	targets, err := configTargets(ep, system, name)
+	if err != nil {
+		return err
+	}
+	printGitignore(targets)
+	return nil
+}
+
+// runGitignoreAll は projectRoot の全 config の target をソート + 重複除去して列挙する
+// （repo の .gitignore は 1 つなので一括列挙が自然・→ docs/spec.md・ADR-0018）。
+// 非 project config は対象から除外する（--all は projectRoot の config のみ拾う）。
+func runGitignoreAll() error {
+	ep, err := discoverEntrypoint(flagFile)
+	if err != nil {
+		return err
+	}
+	system, err := currentSystem()
+	if err != nil {
+		return err
+	}
+
+	roots, err := evalAllRoots(ep, system)
+	if err != nil {
+		return err
+	}
+	names := make([]string, 0, len(roots))
+	for name := range roots {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	var all []string
+	for _, name := range names {
+		if roots[name].RootKind != manifest.RootKindProject {
+			continue
+		}
+		targets, err := configTargets(ep, system, name)
+		if err != nil {
+			return err
+		}
+		all = append(all, targets...)
+	}
+	printGitignore(dedupeSorted(all))
+	return nil
+}
+
+// configTargets は config をビルドして manifest.json を読み、配置 target を列挙する
+// （method を区別せず全 entry・→ ADR-0019）。
+func configTargets(ep *entrypoint, system, name string) ([]string, error) {
+	store, err := buildManifestStorePath(ep, system, name)
+	if err != nil {
+		return nil, err
+	}
+	m, err := manifest.Load(store)
+	if err != nil {
+		return nil, err
+	}
+	targets := make([]string, 0, len(m.Entries))
+	for _, e := range m.Entries {
+		targets = append(targets, e.Target)
+	}
+	return targets, nil
+}
+
+// dedupeSorted はソート + 重複除去する（--all の一括列挙用）。
+func dedupeSorted(in []string) []string {
+	sort.Strings(in)
+	out := in[:0]
+	var prev string
+	for i, s := range in {
+		if i == 0 || s != prev {
+			out = append(out, s)
+		}
+		prev = s
+	}
+	return out
+}
+
+// printGitignore は target を /-anchor 形式（先頭 /・末尾 / なし）で stdout へ 1 行 1 件出力する
+// （→ docs/spec.md・ADR-0013）。stdout 専有原則のためパイプ安全（`nput gitignore <name> >> .gitignore`）。
+func printGitignore(targets []string) {
+	for _, t := range targets {
+		fmt.Println(gitignoreAnchor(t))
+	}
+}
+
+// gitignoreAnchor は root 相対 target を /-anchor 形式に整える。target は eval で絶対パス / 末尾 / を
+// 持たないが、防御的に整形する（→ ADR-0013: 先頭 / でアンカー・ディレクトリ / ファイルとも末尾 / なし）。
+func gitignoreAnchor(target string) string {
+	t := strings.TrimSuffix(target, "/")
+	t = strings.TrimPrefix(t, "/")
+	return "/" + t
+}

--- a/cmd/nput/gitignore_test.go
+++ b/cmd/nput/gitignore_test.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+// gitignoreAnchor は root 相対 target を /-anchor 形式（先頭 /・末尾 / なし）に整える（→ ADR-0013）。
+func TestGitignoreAnchor(t *testing.T) {
+	cases := map[string]string{
+		".claude/skills/nix": "/.claude/skills/nix",
+		".config/nvim":       "/.config/nvim",
+		"dir/":               "/dir", // 末尾 / は付けない
+		"/already/anchored":  "/already/anchored",
+		"file.txt":           "/file.txt",
+	}
+	for in, want := range cases {
+		if got := gitignoreAnchor(in); got != want {
+			t.Errorf("gitignoreAnchor(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestDedupeSorted(t *testing.T) {
+	in := []string{".b", ".a", ".b", ".c", ".a"}
+	want := []string{".a", ".b", ".c"}
+	if got := dedupeSorted(in); !reflect.DeepEqual(got, want) {
+		t.Errorf("dedupeSorted = %v, want %v", got, want)
+	}
+	if got := dedupeSorted(nil); len(got) != 0 {
+		t.Errorf("dedupeSorted(nil) = %v, want empty", got)
+	}
+}

--- a/cmd/nput/main.go
+++ b/cmd/nput/main.go
@@ -81,6 +81,7 @@ func newRootCmd() *cobra.Command {
 	root.AddCommand(newResetCmd())
 	root.AddCommand(newRollbackCmd())
 	root.AddCommand(newListGenerationsCmd())
+	root.AddCommand(newGitignoreCmd())
 	return root
 }
 

--- a/cmd/nput/main.go
+++ b/cmd/nput/main.go
@@ -17,16 +17,19 @@ import (
 	"github.com/yasunori0418/nput/internal/manifest"
 )
 
-// グローバルフラグ（→ docs/spec.md「グローバルフラグ」）。本スライスは apply に必要な範囲のみ。
+// グローバルフラグ（→ docs/spec.md「グローバルフラグ」）。
 var (
-	flagFile    string // -f/--file: entrypoint 明示
-	flagRoot    string // --root: 解決 root の明示上書き
-	flagNoWait  bool   // --no-wait: flock 競合時に待たず skip（shellHook 用）
-	flagQuiet   bool   // --quiet: 進捗 / 配置レポートを抑制（warning / error は残す）
-	flagVerbose bool   // --verbose: 内部実行する nix コマンドを開示
-	flagRecopy  bool   // --recopy: apply 修飾。全 copy target を src から無条件上書き再コピー
-	flagYes     bool   // -y/--yes: reset の確認プロンプトをスキップ（スクリプト / CI 用）
-	flagDryrun  bool   // --dryrun: apply / reset 修飾。副作用ゼロで plan を表示
+	flagFile        string // -f/--file: entrypoint 明示
+	flagRoot        string // --root: 解決 root の明示上書き
+	flagNoWait      bool   // --no-wait: flock 競合時に待たず skip（shellHook 用）
+	flagQuiet       bool   // --quiet: 進捗 / 配置レポートを抑制（warning / error は残す）
+	flagVerbose     bool   // --verbose: 内部実行する nix コマンドを開示
+	flagRecopy      bool   // --recopy: apply 修飾。全 copy target を src から無条件上書き再コピー
+	flagYes         bool   // -y/--yes: reset の確認プロンプトをスキップ（スクリプト / CI 用）
+	flagDryrun      bool   // --dryrun: apply / reset 修飾。副作用ゼロで plan を表示
+	flagProjectRoot bool   // --project-root: apply --all の修飾。projectRoot の config のみ適用
+	flagHomeRoot    bool   // --home-root: apply --all の修飾。homeRoot の config のみ適用
+	flagSystemRoot  bool   // --system-root: apply --all の修飾。systemRoot の config のみ適用（将来 seam）
 )
 
 // exitError は cobra RunE が返す、特定の終了コードを伴うエラー（→ docs/spec.md 終了コード表）。
@@ -38,10 +41,27 @@ type exitError struct {
 
 func (e *exitError) Error() string { return e.msg }
 
+// rootCmdLong は --help で内部実行する nix コマンドを開示する（透明性・選択的に手で実行可能・→ ADR-0007）。
+const rootCmdLong = `nput はフェッチ済み git リポジトリをユーザー環境の任意パスへ symlink / copy で配置する。
+config 生成は行わない（config は Nix で書き nix build で評価される）。
+
+内部で実行する nix コマンド（透明性のため開示・選択的に手で実行できる）:
+  apply <name>      nix eval <ep>#nput.<system>.<name>.rootKind --raw
+                    nix build <ep>#nput.<system>.<name> --out-link <profileDir>/.pending
+  apply --all       nix eval <ep>#nput.<system> --apply '<rootKind マップ>' --json
+                    nix build <ep>#nput.<system>.<name>（config ごと）
+  gitignore <name>  nix eval <ep>#nput.<system>.<name>.rootKind --raw
+                    nix build <ep>#nput.<system>.<name> --no-link --print-out-paths
+  rollback /        nix eval <ep>#nput.<system>.<name>.rootKind --raw
+  list-generations
+
+--verbose を付けると実行時に実際の nix コマンドを stderr へ逐次表示する。`
+
 func newRootCmd() *cobra.Command {
 	root := &cobra.Command{
 		Use:   "nput",
 		Short: "Place fetched git repositories at arbitrary paths via symlink or copy.",
+		Long:  rootCmdLong,
 		// エラーは main で 1 度だけ出すため cobra の usage/error 自動表示は抑制する。
 		SilenceUsage:  true,
 		SilenceErrors: true,
@@ -53,6 +73,9 @@ func newRootCmd() *cobra.Command {
 	pf.BoolVar(&flagQuiet, "quiet", false, "進捗 / 配置レポートを抑制（warning / error は残す）")
 	pf.BoolVar(&flagVerbose, "verbose", false, "内部実行する nix コマンド等の詳細を出力")
 	pf.BoolVarP(&flagYes, "yes", "y", false, "reset の確認プロンプトをスキップ（スクリプト / CI 用）")
+	pf.BoolVar(&flagProjectRoot, "project-root", false, "apply --all の修飾。projectRoot の config のみ適用")
+	pf.BoolVar(&flagHomeRoot, "home-root", false, "apply --all の修飾。homeRoot の config のみ適用")
+	pf.BoolVar(&flagSystemRoot, "system-root", false, "apply --all の修飾。systemRoot の config のみ適用（system mode は未実装）")
 
 	root.AddCommand(newApplyCmd())
 	root.AddCommand(newResetCmd())
@@ -60,6 +83,18 @@ func newRootCmd() *cobra.Command {
 	root.AddCommand(newListGenerationsCmd())
 	return root
 }
+
+// exitCodeX は終了コードを運ぶエラーが満たすインターフェース（apply --all の集約終了コード等）。
+type exitCodeX interface{ ExitCode() int }
+
+// exitCodeError は終了コードを明示的に運ぶエラー（→ docs/spec.md「終了コード」）。
+type exitCodeError struct {
+	code int
+	msg  string
+}
+
+func (e *exitCodeError) Error() string { return e.msg }
+func (e *exitCodeError) ExitCode() int { return e.code }
 
 func main() {
 	if err := newRootCmd().Execute(); err != nil {
@@ -80,6 +115,11 @@ func main() {
 			fmt.Fprintln(os.Stderr, "\nnput: CLI（engine）と flake が pin する nput のバージョンがずれている可能性があります。\n"+
 				"  flake の nput input が CLI より新しい manifest を生成しています。\n"+
 				"  CLI を更新するか、flake の nput input を CLI に合わせて下げて両者のバージョンを揃えてください。")
+		}
+		// 終了コードを運ぶエラー（apply --all の集約等）はその code で終了する（→ docs/spec.md・ADR-0024）。
+		var ec exitCodeX
+		if errors.As(err, &ec) {
+			os.Exit(ec.ExitCode())
 		}
 		os.Exit(1)
 	}

--- a/cmd/nput/nix.go
+++ b/cmd/nput/nix.go
@@ -120,6 +120,21 @@ func evalAllRoots(e *entrypoint, system string) (map[string]rootInfo, error) {
 	return roots, nil
 }
 
+// buildManifestStorePath は config をビルドして link-farm の store パスを返す（read-only 経路）。
+// gitignore は配置をしないため out-link gcroot を張らず `--no-link --print-out-paths` で store パスだけ得る。
+// 進捗は stderr、store パスは stdout に出る（→ docs/spec.md 出力ストリーム規律）。
+func buildManifestStorePath(e *entrypoint, system, name string) (string, error) {
+	out, err := runNixCapture("build", e.installable(system, name), "--no-link", "--print-out-paths")
+	if err != nil {
+		return "", err
+	}
+	store := strings.TrimSpace(out)
+	if store == "" {
+		return "", fmt.Errorf("nput: nput.%s.%s の build 成果物パスを取得できません", system, name)
+	}
+	return store, nil
+}
+
 // evalRoot は build 前に rootKind（+ fixed root のときは絶対パス）を安価な nix eval で先取りする
 // （→ docs/spec.md 実行フロー 1・ADR-0023）。これで profileDir を確定し flock → build の順を成立させる。
 func evalRoot(e *entrypoint, system, name string) (rootKind, fixedRoot string, err error) {

--- a/cmd/nput/nix.go
+++ b/cmd/nput/nix.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -88,6 +89,35 @@ func currentSystem() (string, error) {
 // installable は `nix build`/`nix eval` に渡す `<flakeRef>#nput.<system>.<name>` を組む。
 func (e *entrypoint) installable(system, name string) string {
 	return fmt.Sprintf("%s#nput.%s.%s", e.flakeRef, system, name)
+}
+
+// namespace は config 名を伴わない `<flakeRef>#nput.<system>`（config 集合）を組む。
+// apply --all / gitignore --all の一括 eval（config 名→rootKind マップ）に使う（→ ADR-0024）。
+func (e *entrypoint) namespace(system string) string {
+	return fmt.Sprintf("%s#nput.%s", e.flakeRef, system)
+}
+
+// rootInfo は config 1 件の root 情報（一括 eval の値）。fixed のときのみ Root を持つ。
+type rootInfo struct {
+	RootKind string `json:"rootKind"`
+	Root     string `json:"root"`
+}
+
+// evalAllRoots は `apply --all` / `gitignore --all` 用に config 名→rootInfo マップを
+// 1 回の `nix eval` で取得する（eval プロセス起動を N→1 に固定・→ docs/spec.md 実行フロー・ADR-0024）。
+// build はせず passthru の rootKind（+ fixed の root）だけを読む安価な eval。
+func evalAllRoots(e *entrypoint, system string) (map[string]rootInfo, error) {
+	// nput.<system> 配下の各 config から rootKind（+ fixed なら root）だけを抜き出す。
+	apply := `cs: builtins.mapAttrs (_: c: { rootKind = c.rootKind; } // (if c ? root then { root = c.root; } else {})) cs`
+	out, err := runNixCapture("eval", e.namespace(system), "--apply", apply, "--json")
+	if err != nil {
+		return nil, wrapEvalAllErr(err, system)
+	}
+	var roots map[string]rootInfo
+	if err := json.Unmarshal([]byte(out), &roots); err != nil {
+		return nil, fmt.Errorf("nput: nput.%s の一括 eval 結果を解析できません: %w", system, err)
+	}
+	return roots, nil
 }
 
 // evalRoot は build 前に rootKind（+ fixed root のときは絶対パス）を安価な nix eval で先取りする
@@ -221,6 +251,16 @@ func wrapEvalErr(err error, system, name string) error {
 	if strings.Contains(msg, "does not provide attribute") ||
 		(strings.Contains(msg, "attribute") && strings.Contains(msg, "missing")) {
 		return fmt.Errorf("nput: entrypoint に nput.%s.%s が見つかりません（config 名と system を確認してください）\n%s", system, name, msg)
+	}
+	return err
+}
+
+// wrapEvalAllErr は一括 eval の失敗のうち「nput.<system> が無い」ケースを分かりやすくする。
+func wrapEvalAllErr(err error, system string) error {
+	msg := err.Error()
+	if strings.Contains(msg, "does not provide attribute") ||
+		(strings.Contains(msg, "attribute") && strings.Contains(msg, "missing")) {
+		return fmt.Errorf("nput: entrypoint に nput.%s が見つかりません（この system 向けの config がありません）\n%s", system, msg)
 	}
 	return err
 }


### PR DESCRIPTION
## 概要

issue #14 の縦切り（`apply --all` + root filters + `gitignore`）を実装する。

- **`apply --all`**: entrypoint の `nput.*` を辞書順に全適用。rootKind は 1 回の一括 eval（config 名→rootKind マップ）で取得し、build だけ config ごと。一部失敗しても続行し、最後に「適用 / スキップ / 失敗」を集約表示・1 つでも失敗なら非ゼロ終了。
- **root filters**: `--project-root` / `--home-root` / `--system-root` で `--all` の対象 root モードを絞る。名指し apply で付けるとエラー（無意味なため）。
- **集約終了コード**: `error(1) > conflict(2) > 0` の優先を `applyAllExitCode` に実装（単純な最大値は採らない）。`exitCodeError` で `main` から任意 code 終了。
- **`gitignore <name>` / `--all`**: 配置 target を `/`-anchor 形式で stdout 出力（書込なし・全 method 対象）。project mode 限定、`--all` は projectRoot 全 config をソート + 重複除去。
- **透明性**: `nput --help` に内部実行する nix コマンドを開示。

## 関連 issue

Refs #14

未対応（境界）:
- `apply --all --dryrun` の終了コードは優先ロジック（`applyAllExitCode`）まで実装済みだが、`--dryrun` フラグ定義と engine の読み取り専用 dryrun は #13 / #15 の担当。本 PR は engine 不触で既存 `Apply` をループ呼び出しするため、conflict(2) は #13 マージ後に到達する（現状 `--all` は 0/1 のみ）。

## docs / ADR 影響

なし（既存 spec / ADR-0017,0018,0019,0023,0024 の記述に沿った実装で、方針変更なし）。

---

補足: ブランチ起点の `main` がコンパイル不能 + treefmt 崩れだったため、第 1 コミットで解消している（並行ブランチのマージ順で `emitWarnings` の引数追加が rollback 呼び出しに反映されず、`engine_test.go` に gofmt 崩れが残っていた）。
