### PR TITLE
feat(cli): reset + dryrun（FS-only teardown + プラン表示 + 終了コード規律）

### DIFF
--- a/cmd/nput/apply.go
+++ b/cmd/nput/apply.go
@@ -27,6 +27,8 @@ func newApplyCmd() *cobra.Command {
 	}
 	cmd.Flags().BoolVar(&flagRecopy, "recopy", false,
 		"config 内の全 copy target を src から無条件上書き再コピー（ローカル編集は破棄・→ ADR-0020）")
+	cmd.Flags().BoolVar(&flagDryrun, "dryrun", false,
+		"副作用ゼロで place/replace/remove/conflict/no-op を表示（conflict 検出時 exit 2・→ ADR-0006）")
 	return cmd
 }
 
@@ -46,6 +48,28 @@ func runApply(name string) error {
 	rootKind, fixedRoot, err := evalRoot(ep, system, name)
 	if err != nil {
 		return err
+	}
+
+	// 1.5 --dryrun は副作用ゼロのプレビュー（flock / pending gcroot を取らず build だけ read-only で回す・→ ADR-0023）。
+	if flagDryrun {
+		res, err := engine.Apply(engine.Options{
+			Name:         name,
+			RootKind:     rootKind,
+			FixedRoot:    fixedRoot,
+			RootOverride: flagRoot,
+			Recopy:       flagRecopy,
+			DryRun:       true,
+			Build:        dryBuildFunc(ep, system, name),
+		})
+		if err != nil {
+			return err
+		}
+		printApplyPlan(res)
+		// conflict があれば exit 2（CI の事前 gate・→ docs/spec.md 終了コード表）。
+		if len(res.Conflicts) > 0 {
+			return &exitError{code: 2}
+		}
+		return nil
 	}
 
 	// 2. engine を駆動する（flock 取得・ロック内 build・配置・コミット・.pending 削除は engine が所有）。
@@ -73,6 +97,27 @@ func runApply(name string) error {
 		reportResult(res, name)
 	}
 	return nil
+}
+
+// printApplyPlan は apply --dryrun のプランを stdout に出す（機械可読出力を専有・1 行 1 アクション・
+// → docs/spec.md ストリーム規律・ADR-0023, ADR-0024）。--quiet 下でも抑制しない（stdout 専有原則）。
+// conflict 行も plan の一部として stdout に載せ、終了コード（exit 2）が機械判別を補う。
+func printApplyPlan(res *engine.Result) {
+	for _, t := range res.Placed {
+		fmt.Printf("place\t%s\n", t)
+	}
+	for _, t := range res.Replaced {
+		fmt.Printf("replace\t%s\n", t)
+	}
+	for _, t := range res.Copied {
+		fmt.Printf("copy\t%s\n", t)
+	}
+	for _, t := range res.Removed {
+		fmt.Printf("remove\t%s\n", t)
+	}
+	for _, c := range res.Conflicts {
+		fmt.Printf("conflict\t%s\n", c)
+	}
 }
 
 // reportResult は配置レポートを stderr に出す（stdout は機械可読出力に専有・→ ADR-0023）。

--- a/cmd/nput/main.go
+++ b/cmd/nput/main.go
@@ -25,7 +25,18 @@ var (
 	flagQuiet   bool   // --quiet: 進捗 / 配置レポートを抑制（warning / error は残す）
 	flagVerbose bool   // --verbose: 内部実行する nix コマンドを開示
 	flagRecopy  bool   // --recopy: apply 修飾。全 copy target を src から無条件上書き再コピー
+	flagYes     bool   // -y/--yes: reset の確認プロンプトをスキップ（スクリプト / CI 用）
+	flagDryrun  bool   // --dryrun: apply / reset 修飾。副作用ゼロで plan を表示
 )
+
+// exitError は cobra RunE が返す、特定の終了コードを伴うエラー（→ docs/spec.md 終了コード表）。
+// apply --dryrun の conflict は exit 2。msg が空なら main は追加出力せず code だけで終了する。
+type exitError struct {
+	code int
+	msg  string
+}
+
+func (e *exitError) Error() string { return e.msg }
 
 func newRootCmd() *cobra.Command {
 	root := &cobra.Command{
@@ -41,8 +52,10 @@ func newRootCmd() *cobra.Command {
 	pf.BoolVar(&flagNoWait, "no-wait", false, "flock 競合時に待たず skip（shellHook 用）")
 	pf.BoolVar(&flagQuiet, "quiet", false, "進捗 / 配置レポートを抑制（warning / error は残す）")
 	pf.BoolVar(&flagVerbose, "verbose", false, "内部実行する nix コマンド等の詳細を出力")
+	pf.BoolVarP(&flagYes, "yes", "y", false, "reset の確認プロンプトをスキップ（スクリプト / CI 用）")
 
 	root.AddCommand(newApplyCmd())
+	root.AddCommand(newResetCmd())
 	root.AddCommand(newRollbackCmd())
 	root.AddCommand(newListGenerationsCmd())
 	return root
@@ -50,6 +63,16 @@ func newRootCmd() *cobra.Command {
 
 func main() {
 	if err := newRootCmd().Execute(); err != nil {
+		// 終了コードを伴うエラー（apply --dryrun conflict=2 等）は code だけで終了する
+		// （plan は既に stdout に出力済み・→ docs/spec.md 終了コード表）。
+		var ee *exitError
+		if errors.As(err, &ee) {
+			if ee.msg != "" {
+				fmt.Fprintln(os.Stderr, ee.msg)
+			}
+			os.Exit(ee.code)
+		}
+
 		fmt.Fprintln(os.Stderr, err)
 		// CLI/flake pin 間の schemaVersion skew は engine が拒否する（→ manifest.validate）。
 		// 上位で検知して原因と解消策を補う（→ docs/spec.md「manifest.json スキーマ」）。

--- a/cmd/nput/nix.go
+++ b/cmd/nput/nix.go
@@ -125,6 +125,26 @@ func buildFunc(e *entrypoint, system, name string) func(pending string) (string,
 	}
 }
 
+// dryBuildFunc は --dryrun 用の build コールバックを返す（→ engine.BuildFunc）。通常 build と違い
+// `nix build --no-link --print-out-paths` で **gcroot（out-link）を張らずに** link-farm の store path を
+// 得る（dryrun は副作用ゼロ・pending out-link を作らない・→ ADR-0011, ADR-0023）。pending 引数は使わない。
+func dryBuildFunc(e *entrypoint, system, name string) func(pending string) (string, error) {
+	inst := e.installable(system, name)
+	return func(string) (string, error) {
+		out, err := runNixCapture("build", inst, "--no-link", "--print-out-paths")
+		if err != nil {
+			return "", err
+		}
+		store := strings.TrimSpace(out)
+		if store == "" {
+			return "", fmt.Errorf("nput: nix build --print-out-paths が空でした (%s)", inst)
+		}
+		// --print-out-paths は複数行を返し得る（multi-output）。link-farm は単一 output なので最終行を採る。
+		lines := strings.Split(store, "\n")
+		return strings.TrimSpace(lines[len(lines)-1]), nil
+	}
+}
+
 // runNixCapture は nix の stdout を捕捉して返す（eval 等の機械可読出力用）。
 func runNixCapture(args ...string) (string, error) {
 	if flagVerbose {

--- a/cmd/nput/reset.go
+++ b/cmd/nput/reset.go
@@ -1,0 +1,177 @@
+package main
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/yasunori0418/nput/internal/engine"
+)
+
+func newResetCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "reset <name> [target...]",
+		Short: "配置物を無い状態へ戻す（FS-only teardown・名指し必須・--all 非対応）",
+		Long: "nput.<name> の配置物を無い状態へ戻す teardown。target 省略で全 entry、target 指定でその entry のみ撤去する。" +
+			"symlink は保守的不変条件（nput 管理・記録通りのみ）で除去し foreign は残す。copy target は削除する（データ損失リスクのため確認）。" +
+			"profile / 世代は触らない（FS-only）。名指し必須（--all 非対応）。" +
+			"--dryrun は副作用ゼロで削除対象を表示して exit する（confirm / flock なし）。",
+		Args: cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runReset(args[0], args[1:], flagDryrun)
+		},
+	}
+	cmd.Flags().BoolVar(&flagDryrun, "dryrun", false,
+		"副作用ゼロで削除対象（symlink / copy target）を表示して exit（confirm / flock なし・→ ADR-0021）")
+	return cmd
+}
+
+// runReset は eval 先取りで rootKind（→ profileDir）を確定し、engine.Reset を駆動する。
+// --dryrun は読み取り専用でプランを stdout に出して exit 0。非 dryrun は TTY 確認 / --yes を要求する。
+func runReset(name string, targets []string, dryrun bool) error {
+	ep, err := discoverEntrypoint(flagFile)
+	if err != nil {
+		return err
+	}
+	system, err := currentSystem()
+	if err != nil {
+		return err
+	}
+	rootKind, fixedRoot, err := evalRoot(ep, system, name)
+	if err != nil {
+		return err
+	}
+
+	// --dryrun: 副作用ゼロのプレビュー（flock / confirm なし・終了コードは対象有無に依らず 0・→ ADR-0021）。
+	if dryrun {
+		res, err := engine.Reset(engine.ResetOptions{
+			Name:         name,
+			RootKind:     rootKind,
+			FixedRoot:    fixedRoot,
+			RootOverride: flagRoot,
+			Targets:      targets,
+			DryRun:       true,
+		})
+		if err != nil {
+			return err
+		}
+		printResetPlan(res)
+		return nil
+	}
+
+	// 非 dryrun は破壊的操作。非 TTY かつ --yes 無しは即エラー停止する（ハングと誤削除を防ぐ・→ ADR-0025 §5）。
+	if !flagYes && !isInteractive() {
+		return errors.New("nput: 非対話環境では --yes なしの破壊的 reset を拒否します " +
+			"(refusing destructive reset without --yes in non-interactive context)")
+	}
+
+	// --yes 未指定（= TTY）のときだけ確認プロンプトを出す。プロンプトは算出済みプランを表示する。
+	var confirm func(*engine.ResetResult) (bool, error)
+	if !flagYes {
+		confirm = func(res *engine.ResetResult) (bool, error) {
+			reportResetTargets(res, name)
+			return promptYesNo("上記を削除します。続行しますか？")
+		}
+	}
+
+	res, err := engine.Reset(engine.ResetOptions{
+		Name:         name,
+		RootKind:     rootKind,
+		FixedRoot:    fixedRoot,
+		RootOverride: flagRoot,
+		Targets:      targets,
+		Confirm:      confirm,
+	})
+	if err != nil {
+		return err
+	}
+	if res.Aborted {
+		fmt.Fprintln(os.Stderr, "nput: reset を中止しました")
+		return nil
+	}
+	if !flagQuiet {
+		reportResetResult(res, name)
+	}
+	return nil
+}
+
+// printResetPlan は reset --dryrun の削除対象を stdout に出す（機械可読出力を専有・1 行 1 件・
+// → docs/spec.md ストリーム規律・ADR-0023）。--quiet 下でも抑制しない。
+func printResetPlan(res *engine.ResetResult) {
+	for _, t := range res.RemovedSymlinks {
+		fmt.Printf("remove-symlink\t%s\n", t)
+	}
+	for _, t := range res.RemovedCopies {
+		fmt.Printf("remove-copy\t%s\n", t)
+	}
+	for _, t := range res.KeptForeign {
+		fmt.Printf("keep-foreign\t%s\n", t)
+	}
+	if len(res.RemovedSymlinks)+len(res.RemovedCopies)+len(res.KeptForeign) == 0 {
+		fmt.Fprintln(os.Stderr, "nput: reset --dryrun: 削除対象はありません")
+	}
+}
+
+// reportResetTargets は確認プロンプト前に削除予定を stderr に出す（進捗扱い・stdout は機械可読専有）。
+func reportResetTargets(res *engine.ResetResult, name string) {
+	fmt.Fprintf(os.Stderr, "nput: reset %s 削除対象 (root=%s):\n", name, res.Root)
+	for _, t := range res.RemovedSymlinks {
+		fmt.Fprintf(os.Stderr, "  symlink %s\n", t)
+	}
+	for _, t := range res.RemovedCopies {
+		fmt.Fprintf(os.Stderr, "  copy    %s\n", t)
+	}
+	for _, t := range res.KeptForeign {
+		fmt.Fprintf(os.Stderr, "  keep    %s (foreign / 記録不一致のため残します)\n", t)
+	}
+	if len(res.RemovedSymlinks)+len(res.RemovedCopies) == 0 {
+		fmt.Fprintln(os.Stderr, "  （削除対象なし）")
+	}
+}
+
+// reportResetResult は実削除結果を stderr に出す（stdout は機械可読出力に専有・→ ADR-0023）。
+func reportResetResult(res *engine.ResetResult, name string) {
+	fmt.Fprintf(os.Stderr, "nput: reset %s 完了 (root=%s)\n", name, res.Root)
+	for _, t := range res.RemovedSymlinks {
+		fmt.Fprintf(os.Stderr, "  removed-symlink %s\n", t)
+	}
+	for _, t := range res.RemovedCopies {
+		fmt.Fprintf(os.Stderr, "  removed-copy    %s\n", t)
+	}
+	for _, t := range res.KeptForeign {
+		fmt.Fprintf(os.Stderr, "  kept            %s (foreign / 記録不一致)\n", t)
+	}
+	if len(res.RemovedSymlinks)+len(res.RemovedCopies) == 0 {
+		fmt.Fprintln(os.Stderr, "  no-op")
+	}
+}
+
+// isInteractive は stdin が TTY か（端末に接続されているか）を返す（→ ADR-0025 §5）。
+// stdlib のみで判定する（os.ModeCharDevice）。パイプ / リダイレクト / CI では false。
+func isInteractive() bool {
+	fi, err := os.Stdin.Stat()
+	if err != nil {
+		return false
+	}
+	return fi.Mode()&os.ModeCharDevice != 0
+}
+
+// promptYesNo は stdin から y/N を読み、yes 系の入力のときだけ true を返す（既定 No）。
+func promptYesNo(msg string) (bool, error) {
+	fmt.Fprintf(os.Stderr, "%s [y/N]: ", msg)
+	line, err := bufio.NewReader(os.Stdin).ReadString('\n')
+	if err != nil && err != io.EOF {
+		return false, err
+	}
+	switch strings.ToLower(strings.TrimSpace(line)) {
+	case "y", "yes":
+		return true, nil
+	default:
+		return false, nil
+	}
+}

--- a/internal/engine/dryrun_test.go
+++ b/internal/engine/dryrun_test.go
@@ -1,0 +1,77 @@
+package engine
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/yasunori0418/nput/internal/manifest"
+)
+
+// TestApplyDryRunNoSideEffects は apply --dryrun が plan を返すだけで FS / profileDir を一切
+// 変えないことを検証する（→ ADR-0006, ADR-0023）。
+func TestApplyDryRunNoSideEffects(t *testing.T) {
+	root := realTempDir(t)
+	state := realTempDir(t)
+	src := makeSrc(t, "sub/file")
+	lf := writeLinkFarm(t, homeManifest(storeEntry(src, "sub", ".link")))
+
+	res, err := Apply(Options{
+		LinkFarm:     lf,
+		Name:         "cfg",
+		RootKind:     manifest.RootKindHome,
+		RootOverride: root,
+		StateDir:     state,
+		DryRun:       true,
+	})
+	if err != nil {
+		t.Fatalf("Apply dryrun: %v", err)
+	}
+
+	if !res.DryRun {
+		t.Error("Result.DryRun = false, want true")
+	}
+	if got := res.Placed; len(got) != 1 || got[0] != ".link" {
+		t.Errorf("Placed = %v, want [.link]", got)
+	}
+	// symlink は張られない。
+	if _, err := os.Lstat(filepath.Join(root, ".link")); !os.IsNotExist(err) {
+		t.Errorf(".link should not be created in dryrun, lstat err = %v", err)
+	}
+	// profileDir も作られない（mkdir / flock を取らない）。
+	if _, err := os.Stat(res.ProfileDir); !os.IsNotExist(err) {
+		t.Errorf("profileDir should not be created in dryrun, stat err = %v", err)
+	}
+}
+
+// TestApplyDryRunConflict は target が通常ファイルで占有されているとき conflict を plan に載せ、
+// FS を変えないことを検証する（CLI が exit 2 を判定する・→ docs/spec.md 終了コード表）。
+func TestApplyDryRunConflict(t *testing.T) {
+	root := realTempDir(t)
+	state := realTempDir(t)
+	src := makeSrc(t, "sub/file")
+	lf := writeLinkFarm(t, homeManifest(storeEntry(src, "sub", ".link")))
+
+	// target を通常ファイルで占有する（symlink 上書き不可 → conflict）。
+	if err := os.WriteFile(filepath.Join(root, ".link"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := Apply(Options{
+		LinkFarm:     lf,
+		Name:         "cfg",
+		RootKind:     manifest.RootKindHome,
+		RootOverride: root,
+		StateDir:     state,
+		DryRun:       true,
+	})
+	if err != nil {
+		t.Fatalf("Apply dryrun: %v", err)
+	}
+	if len(res.Conflicts) == 0 {
+		t.Error("expected a conflict in dryrun plan, got none")
+	}
+	if len(res.Placed) != 0 {
+		t.Errorf("conflicting entry should not be planned for place, Placed = %v", res.Placed)
+	}
+}

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -58,6 +58,10 @@ type Options struct {
 	// Recopy は apply --recopy 修飾（config 内の全 copy target を src から無条件上書き再コピー・→ ADR-0020）。
 	// place-once を破る opt-in 経路。symlink 部の通常 apply（stale 除去 + 世代コミット）は不変。
 	Recopy bool
+	// DryRun は副作用ゼロの読み取り専用プレビュー（apply --dryrun・→ ADR-0006, ADR-0023）。
+	// true のとき planner を読み取り専用で回して plan を Result に詰めて return し、
+	// FS 書込・--set・flock・pending gcroot いずれも取らない。build（src 解決）はするが配置しない。
+	DryRun bool
 
 	// Build はロック内 build の差し替え（nil = opts.LinkFarm を既ビルド済みとして使う）。
 	Build BuildFunc
@@ -79,6 +83,8 @@ type Result struct {
 	Recopied   []string // --recopy で上書き再コピーした既存 copy target（→ ADR-0020）
 	Removed    []string // stale 除去した target
 	Skipped    bool     // try-lock 競合で skip した（NoWait 経路）
+	DryRun     bool     // 読み取り専用プレビュー（Placed 等は「これから配置する」予定・→ ADR-0023）
+	Conflicts  []string // dryrun で検出した conflict（"target: reason"・CLI が exit 2 判定に使う・→ ADR-0006）
 	// GenerationSkipped は project mode の世代スキップで新世代を積まなかった（--set を省いた）
 	// ことを表す。新 link-farm が前世代と同一のため commit せず、ドリフトした entry だけ
 	// lstat 修復した経路（→ ADR-0005, ADR-0017, docs/spec.md 世代スキップ）。
@@ -136,6 +142,13 @@ func Apply(opts Options) (*Result, error) {
 	}
 	a.profile = paths.Resolve(stateDir, opts.Name, rootKind, root, opts.RootOverride != "")
 	a.result.ProfileDir = a.profile.Dir
+
+	// 1.5 dryrun は副作用ゼロの読み取り専用短絡（→ ADR-0006, ADR-0023, docs/spec.md 実行フロー）。
+	//     profileDir 確定までは apply と共通だが、ここから先（mkdir / flock / 配置 / --set /
+	//     pending gcroot）は一切行わず、planner を read-only で回して plan を Result に詰めて返す。
+	if opts.DryRun {
+		return a.dryRun()
+	}
 
 	// 2. profileDir / backref を用意（flock は profileDir を開くため先に作る）。
 	if err := a.ensureProfileDir(); err != nil {
@@ -252,6 +265,54 @@ type applier struct {
 	profile  paths.Profile
 	root     string
 	result   *Result
+}
+
+// dryRun は apply --dryrun の読み取り専用短絡（→ ADR-0006, ADR-0023）。manifest を build で
+// 解決（src 解決のため build はするが配置しない・pending gcroot は張らない）し、前世代 manifest
+// と planner.Compute で place/replace/remove/conflict を算出して Result に詰めて返す。flock /
+// FS 書込 / --set は一切行わない。conflict があっても error にせず Result.Conflicts に載せ、
+// CLI が exit 2 を判定する（→ docs/spec.md 終了コード表）。
+func (a *applier) dryRun() (*Result, error) {
+	// build 経路（CLI）は manifest 未取得なので read-only build で src を解決する。
+	// CLI は dryrun では `nix build --no-link --print-out-paths`（gcroot なし）を差し込む。
+	if a.opts.Build != nil {
+		linkFarm, err := a.opts.Build(a.profile.Pending)
+		if err != nil {
+			return nil, err
+		}
+		m, err := manifest.Load(linkFarm)
+		if err != nil {
+			return nil, err
+		}
+		a.opts.LinkFarm = linkFarm
+		a.manifest = m
+	}
+
+	prev := a.loadPrevManifest()
+	plan, err := planner.Compute(prev, a.manifest, a.root, planner.OSFS)
+	if err != nil {
+		return nil, err
+	}
+	a.emitWarnings(plan.Warnings, a.opts.Recopy)
+
+	a.result.DryRun = true
+	for _, p := range plan.Place {
+		if p.Kind == planner.PlaceNew {
+			a.result.Placed = append(a.result.Placed, p.Entry.Target)
+		} else {
+			a.result.Replaced = append(a.result.Replaced, p.Entry.Target)
+		}
+	}
+	for _, c := range plan.Copies {
+		a.result.Copied = append(a.result.Copied, c.Entry.Target)
+	}
+	for _, r := range plan.Remove {
+		a.result.Removed = append(a.result.Removed, r.Entry.Target)
+	}
+	for _, c := range plan.Conflicts {
+		a.result.Conflicts = append(a.result.Conflicts, fmt.Sprintf("%s: %s", c.Entry.Target, c.Reason))
+	}
+	return a.result, nil
 }
 
 func (a *applier) resolveRoot(rootKind, fixedRoot string) (string, error) {

--- a/internal/engine/generations.go
+++ b/internal/engine/generations.go
@@ -176,7 +176,7 @@ func Rollback(opts RollbackOptions) (*RollbackResult, error) {
 	a := &applier{opts: Options{Warnf: warnf}, result: &Result{Root: root, ProfileDir: prof.Dir}}
 	a.profile = prof
 	a.root = root
-	a.emitWarnings(plan.Warnings, false) // rollback は recopy しない（copy foreign skip 抑制は無関係）
+	a.emitWarnings(plan.Warnings, false)
 	if err := a.place(plan.Place); err != nil {
 		return nil, err
 	}

--- a/internal/engine/reset.go
+++ b/internal/engine/reset.go
@@ -1,0 +1,212 @@
+package engine
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/yasunori0418/nput/internal/lock"
+	"github.com/yasunori0418/nput/internal/manifest"
+	"github.com/yasunori0418/nput/internal/planner"
+)
+
+// reset は配置物を無い状態へ戻す FS-only teardown（→ ADR-0020, ADR-0021, ADR-0025,
+// docs/spec.md「recopy・reset」）。
+//
+//   - symlink: stale 除去と同じ保守的不変条件（前世代 manifest が記録し、かつ現状もその記録通りの
+//     先を指す symlink のみ削除。foreign / 記録不一致は warning で残す）。planner.Compute（next=nil）+
+//     staleremove を再利用する（完成済みモジュール・→ planner, staleremove.go）。
+//   - copy target: 削除する（copy を消す唯一の明示手段・事前存在ファイルを消すリスクは CLI の確認で守る）。
+//   - profile / 世代は触らない。config が entry を残す限り次の apply で再配置される（transient）。
+//
+// 撤去対象 entry の源は **前世代 manifest（profileDir/profile が指す link-farm の manifest.json）**。
+// これが「nput が実際に配置した（記録した）真実」で、保守的不変条件の "recorded dest" と一致する
+// （config を build し直すと src ドリフト時に記録 dest とズレ誤判定するため、記録済み前世代を使う）。
+// rootKind 先取り eval（profileDir 確定）は CLI が担い、entries はこの前世代 manifest から読む。
+
+// ResetOptions は Reset の入力。Reset は build しない（前世代 manifest を読む）。
+type ResetOptions struct {
+	Name         string
+	RootKind     string
+	FixedRoot    string
+	RootOverride string
+	WorkDir      string
+	StateDir     string
+	Git          GitFunc
+
+	// Targets は撤去対象 target の絞り込み（root 相対・空 = 全 entry）。
+	// 前世代 manifest に存在しない target を指定するとエラーになる。
+	Targets []string
+	// DryRun は副作用ゼロのプレビュー（削除対象を算出して返すだけ・flock / confirm / FS 削除なし・→ ADR-0021）。
+	DryRun bool
+	// Confirm は削除実行前の確認コールバック（nil = 確認なしで実行・--yes 経路 / dryrun）。
+	// 算出済みプランを渡し、false を返すと中断する（Result.Aborted = true）。CLI が TTY プロンプトを担う。
+	Confirm func(*ResetResult) (bool, error)
+	// Warnf は warning の出力先（nil = stderr）。foreign symlink を残す等の可視化に使う。
+	Warnf func(format string, args ...any)
+}
+
+// ResetResult は Reset の結果（dryrun はプレビュー・実行時は実削除結果）。
+type ResetResult struct {
+	Root            string   // 解決後の絶対 root
+	ProfileDir      string   // 確定した profileDir
+	RemovedSymlinks []string // 削除した（dryrun は削除予定の）symlink target
+	RemovedCopies   []string // 削除した（dryrun は削除予定の）copy target
+	KeptForeign     []string // 保守的不変条件を満たさず残した symlink target（foreign / 記録不一致）
+	DryRun          bool     // 読み取り専用プレビューだった
+	Aborted         bool     // 確認プロンプトで中断した
+}
+
+// Reset は対象 entry の配置物を無い状態へ戻す。docs/spec.md「実行フロー」の非 build コマンド前段
+// （rootKind 先取り eval → root 解決 → profileDir 確定）を CLI と分担し、engine 側は profileDir 解決・
+// blocking flock・前世代 manifest 読み・保守的 symlink 除去 + copy 削除を所有する（→ ADR-0021, ADR-0024）。
+func Reset(opts ResetOptions) (*ResetResult, error) {
+	warnf := opts.Warnf
+	if warnf == nil {
+		warnf = func(format string, args ...any) {
+			fmt.Fprintf(os.Stderr, format+"\n", args...)
+		}
+	}
+
+	// 1. profileDir 確定（root 解決 → レイアウト・apply / rollback と共通の前段・→ ADR-0024）。
+	prof, root, err := ProfileFor(ProfileOptions{
+		Name: opts.Name, RootKind: opts.RootKind, FixedRoot: opts.FixedRoot,
+		RootOverride: opts.RootOverride, WorkDir: opts.WorkDir, StateDir: opts.StateDir, Git: opts.Git,
+	})
+	if err != nil {
+		return nil, err
+	}
+	res := &ResetResult{Root: root, ProfileDir: prof.Dir, DryRun: opts.DryRun}
+
+	// profile（前世代リンク）が無ければ一度も apply していない = 撤去対象ゼロの no-op。
+	if _, err := os.Stat(prof.Profile); err != nil {
+		if os.IsNotExist(err) {
+			return res, nil
+		}
+		return nil, fmt.Errorf("nput: profile を確認できません (%s): %w", prof.Profile, err)
+	}
+
+	// 2. 実行時は blocking flock で並行 apply / reset と直列化する（→ ADR-0013, ADR-0021）。
+	//    dryrun は読み取り専用なので flock を取らない。
+	if !opts.DryRun {
+		l, err := lock.Acquire(prof.Dir, true)
+		if err != nil {
+			return nil, fmt.Errorf("nput: flock の取得に失敗しました (%s): %w", prof.Dir, err)
+		}
+		defer func() { _ = l.Release() }()
+	}
+
+	// 3. 前世代 manifest（記録済みの真実）を読み、対象 entry を絞り込む。
+	prev, err := manifest.Load(prof.Profile)
+	if err != nil {
+		return nil, err
+	}
+	entries, err := selectResetEntries(prev.Entries, opts.Targets)
+	if err != nil {
+		return nil, err
+	}
+
+	// 4. symlink は保守的不変条件で除去するプランを planner で算出（next=nil で全対象が remove 候補）。
+	//    copy は planner が決して消さない領域なので分離して扱う。
+	var symEntries, copyEntries []manifest.Entry
+	for _, e := range entries {
+		if e.Method == manifest.MethodCopy {
+			copyEntries = append(copyEntries, e)
+		} else {
+			symEntries = append(symEntries, e)
+		}
+	}
+	symManifest := &manifest.Manifest{SchemaVersion: prev.SchemaVersion, Root: prev.Root, Entries: symEntries}
+	plan, err := planner.Compute(symManifest, nil, root, planner.OSFS)
+	if err != nil {
+		return nil, err
+	}
+
+	// 5. copy target のうち実在するものを削除候補にする（不在は no-op・→ docs/spec.md エラー仕様）。
+	copyTargets := make([]string, 0, len(copyEntries))
+	for _, e := range copyEntries {
+		targetAbs := filepath.Join(root, filepath.Clean(e.Target))
+		if _, err := os.Lstat(targetAbs); err == nil {
+			copyTargets = append(copyTargets, targetAbs)
+			res.RemovedCopies = append(res.RemovedCopies, e.Target)
+		} else if !os.IsNotExist(err) {
+			return nil, fmt.Errorf("nput: copy target を lstat できません (%s): %w", targetAbs, err)
+		}
+	}
+
+	// プレビュー（dryrun / confirm 表示）用に symlink 削除予定・残す foreign を詰める。
+	for _, a := range plan.Remove {
+		res.RemovedSymlinks = append(res.RemovedSymlinks, a.Entry.Target)
+	}
+	for _, w := range plan.Warnings {
+		if w.Kind == planner.WarnStaleMismatch || w.Kind == planner.WarnStaleNonSymlink {
+			res.KeptForeign = append(res.KeptForeign, w.Target)
+		}
+	}
+
+	// 6. dryrun は算出済みプランを返して終了（FS 削除・confirm なし・→ ADR-0021）。
+	if opts.DryRun {
+		return res, nil
+	}
+
+	// 7. 確認（データ損失リスク・→ ADR-0020, ADR-0025）。CLI が TTY プロンプト / --yes を担う。
+	if opts.Confirm != nil {
+		proceed, err := opts.Confirm(res)
+		if err != nil {
+			return nil, err
+		}
+		if !proceed {
+			res.Aborted = true
+			return res, nil
+		}
+	}
+
+	// 8. 実 FS に反映する。symlink は staleremove（plan 後ドリフト再検証つき）を再利用し、
+	//    copy target は削除する。残す foreign の warning を出す。
+	a := &applier{opts: Options{Warnf: warnf}, result: &Result{Root: root, ProfileDir: prof.Dir}}
+	a.profile = prof
+	a.root = root
+	a.emitWarnings(plan.Warnings, false)
+	if err := a.removeStale(plan.Remove); err != nil {
+		return nil, err
+	}
+	res.RemovedSymlinks = a.result.Removed // 実削除分（ドリフトで残ったものは除外）
+
+	removedCopies := make([]string, 0, len(copyTargets))
+	for i, targetAbs := range copyTargets {
+		if err := os.RemoveAll(targetAbs); err != nil {
+			return nil, fmt.Errorf("nput: copy target を削除できません (%s): %w", targetAbs, err)
+		}
+		removedCopies = append(removedCopies, res.RemovedCopies[i])
+	}
+	res.RemovedCopies = removedCopies
+
+	return res, nil
+}
+
+// selectResetEntries は前世代 manifest の entry を Targets で絞り込む（空 = 全 entry）。
+// 指定 target が前世代に存在しなければエラー（nput が配置していない target は撤去対象にならない）。
+func selectResetEntries(entries []manifest.Entry, targets []string) ([]manifest.Entry, error) {
+	if len(targets) == 0 {
+		return entries, nil
+	}
+	byTarget := make(map[string]manifest.Entry, len(entries))
+	for _, e := range entries {
+		byTarget[e.Target] = e
+	}
+	out := make([]manifest.Entry, 0, len(targets))
+	var unknown []string
+	for _, t := range targets {
+		key := filepath.Clean(t)
+		e, ok := byTarget[key]
+		if !ok {
+			unknown = append(unknown, t)
+			continue
+		}
+		out = append(out, e)
+	}
+	if len(unknown) > 0 {
+		return nil, fmt.Errorf("nput: reset 対象が前世代 manifest に見つかりません（nput が配置した target ではありません）: %v", unknown)
+	}
+	return out, nil
+}

--- a/internal/engine/reset_test.go
+++ b/internal/engine/reset_test.go
@@ -1,0 +1,211 @@
+package engine
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/yasunori0418/nput/internal/manifest"
+)
+
+// applyForReset は reset テストの前提として 1 世代を積む（prof.Profile が link-farm を指す）。
+// --root 上書き（RootOverride=root）で git に依存せず root を固定する。
+func applyForReset(t *testing.T, root, state string, m manifest.Manifest) {
+	t.Helper()
+	lf := writeLinkFarm(t, m)
+	if _, err := Apply(Options{
+		LinkFarm:     lf,
+		Name:         "cfg",
+		RootKind:     manifest.RootKindHome,
+		RootOverride: root,
+		StateDir:     state,
+		Commit:       fakeCommit(nil),
+	}); err != nil {
+		t.Fatalf("setup Apply: %v", err)
+	}
+}
+
+func resetOpts(root, state string, targets []string, dryrun bool, confirm func(*ResetResult) (bool, error)) ResetOptions {
+	return ResetOptions{
+		Name:         "cfg",
+		RootKind:     manifest.RootKindHome,
+		RootOverride: root,
+		StateDir:     state,
+		Targets:      targets,
+		DryRun:       dryrun,
+		Confirm:      confirm,
+	}
+}
+
+func TestResetRemovesSymlinkAndCopy(t *testing.T) {
+	root := realTempDir(t)
+	state := realTempDir(t)
+	symSrc := makeSrc(t, "sub/file")
+	copySrc := makeSrc(t, "data/x")
+
+	applyForReset(t, root, state, homeManifest(
+		storeEntry(symSrc, "sub", ".link"),
+		copyEntry(copySrc, "data", ".copied"),
+	))
+
+	linkAbs := filepath.Join(root, ".link")
+	copyAbs := filepath.Join(root, ".copied")
+	if fi, err := os.Lstat(linkAbs); err != nil || fi.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("setup: .link not a symlink: %v", err)
+	}
+	if _, err := os.Stat(copyAbs); err != nil {
+		t.Fatalf("setup: .copied missing: %v", err)
+	}
+
+	res, err := Reset(resetOpts(root, state, nil, false, nil))
+	if err != nil {
+		t.Fatalf("Reset: %v", err)
+	}
+
+	if _, err := os.Lstat(linkAbs); !os.IsNotExist(err) {
+		t.Errorf(".link should be removed, lstat err = %v", err)
+	}
+	if _, err := os.Lstat(copyAbs); !os.IsNotExist(err) {
+		t.Errorf(".copied should be removed, lstat err = %v", err)
+	}
+	if got := res.RemovedSymlinks; len(got) != 1 || got[0] != ".link" {
+		t.Errorf("RemovedSymlinks = %v, want [.link]", got)
+	}
+	if got := res.RemovedCopies; len(got) != 1 || got[0] != ".copied" {
+		t.Errorf("RemovedCopies = %v, want [.copied]", got)
+	}
+}
+
+func TestResetKeepsForeignSymlink(t *testing.T) {
+	root := realTempDir(t)
+	state := realTempDir(t)
+	symSrc := makeSrc(t, "sub/file")
+
+	applyForReset(t, root, state, homeManifest(storeEntry(symSrc, "sub", ".link")))
+
+	// 配置済み symlink を別の先へ差し替える（foreign / 記録不一致をシミュレート）。
+	linkAbs := filepath.Join(root, ".link")
+	if err := os.Remove(linkAbs); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("/somewhere/else", linkAbs); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := Reset(resetOpts(root, state, nil, false, nil))
+	if err != nil {
+		t.Fatalf("Reset: %v", err)
+	}
+
+	// 保守的不変条件を満たさないため残る。
+	if _, err := os.Lstat(linkAbs); err != nil {
+		t.Errorf("foreign symlink should be kept, lstat err = %v", err)
+	}
+	if len(res.RemovedSymlinks) != 0 {
+		t.Errorf("RemovedSymlinks = %v, want empty", res.RemovedSymlinks)
+	}
+	if got := res.KeptForeign; len(got) != 1 || got[0] != ".link" {
+		t.Errorf("KeptForeign = %v, want [.link]", got)
+	}
+}
+
+func TestResetDryRunNoSideEffects(t *testing.T) {
+	root := realTempDir(t)
+	state := realTempDir(t)
+	symSrc := makeSrc(t, "sub/file")
+	copySrc := makeSrc(t, "data/x")
+
+	applyForReset(t, root, state, homeManifest(
+		storeEntry(symSrc, "sub", ".link"),
+		copyEntry(copySrc, "data", ".copied"),
+	))
+
+	res, err := Reset(resetOpts(root, state, nil, true, nil))
+	if err != nil {
+		t.Fatalf("Reset dryrun: %v", err)
+	}
+	if !res.DryRun {
+		t.Error("Result.DryRun = false, want true")
+	}
+
+	// FS は不変（プレビューのみ）。
+	if _, err := os.Lstat(filepath.Join(root, ".link")); err != nil {
+		t.Errorf(".link should still exist after dryrun: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, ".copied")); err != nil {
+		t.Errorf(".copied should still exist after dryrun: %v", err)
+	}
+	// プランは削除予定を列挙する。
+	if len(res.RemovedSymlinks) != 1 || len(res.RemovedCopies) != 1 {
+		t.Errorf("dryrun plan = sym%v copy%v, want one each", res.RemovedSymlinks, res.RemovedCopies)
+	}
+}
+
+func TestResetTargetFilter(t *testing.T) {
+	root := realTempDir(t)
+	state := realTempDir(t)
+	src := makeSrc(t, "sub/file")
+
+	applyForReset(t, root, state, homeManifest(
+		storeEntry(src, "sub", ".a"),
+		storeEntry(src, "sub", ".b"),
+	))
+
+	if _, err := Reset(resetOpts(root, state, []string{".a"}, false, nil)); err != nil {
+		t.Fatalf("Reset: %v", err)
+	}
+
+	if _, err := os.Lstat(filepath.Join(root, ".a")); !os.IsNotExist(err) {
+		t.Errorf(".a should be removed, lstat err = %v", err)
+	}
+	if _, err := os.Lstat(filepath.Join(root, ".b")); err != nil {
+		t.Errorf(".b should remain (not targeted): %v", err)
+	}
+}
+
+func TestResetUnknownTargetErrors(t *testing.T) {
+	root := realTempDir(t)
+	state := realTempDir(t)
+	src := makeSrc(t, "sub/file")
+	applyForReset(t, root, state, homeManifest(storeEntry(src, "sub", ".a")))
+
+	_, err := Reset(resetOpts(root, state, []string{".nope"}, false, nil))
+	if err == nil {
+		t.Fatal("Reset with unknown target should error")
+	}
+}
+
+func TestResetNoProfileIsNoop(t *testing.T) {
+	root := realTempDir(t)
+	state := realTempDir(t)
+
+	// 一度も apply していない（profile 不在）→ no-op・エラーなし。
+	res, err := Reset(resetOpts(root, state, nil, false, nil))
+	if err != nil {
+		t.Fatalf("Reset no-profile: %v", err)
+	}
+	if len(res.RemovedSymlinks) != 0 || len(res.RemovedCopies) != 0 {
+		t.Errorf("expected no-op, got %+v", res)
+	}
+}
+
+func TestResetConfirmAbort(t *testing.T) {
+	root := realTempDir(t)
+	state := realTempDir(t)
+	src := makeSrc(t, "sub/file")
+	applyForReset(t, root, state, homeManifest(storeEntry(src, "sub", ".a")))
+
+	// confirm が false を返したら中断し FS は不変。
+	res, err := Reset(resetOpts(root, state, nil, false, func(*ResetResult) (bool, error) {
+		return false, nil
+	}))
+	if err != nil {
+		t.Fatalf("Reset: %v", err)
+	}
+	if !res.Aborted {
+		t.Error("Result.Aborted = false, want true")
+	}
+	if _, err := os.Lstat(filepath.Join(root, ".a")); err != nil {
+		t.Errorf(".a should remain after abort: %v", err)
+	}
+}


### PR DESCRIPTION
## 概要

issue #13 の縦切りスライス。`nput reset` と `--dryrun` を end-to-end で追加する。

- **engine（reset）**: `internal/engine/reset.go` 新規。前世代 manifest（記録済みの真実）を読み、`Targets` で絞り込んだ entry を撤去する。symlink は `planner.Compute(next=nil)` + staleremove を再利用して保守的不変条件で除去（foreign / 記録不一致は warning で残す）、copy target は削除する。profile / 世代は不変（FS-only）。実行時は profileDir 単位の blocking flock、dryrun は flock / confirm を取らない。
- **engine（dryrun）**: `Options.DryRun` で Apply を read-only に短絡。planner を回して place/replace/remove/conflict を `Result` に詰めて返すだけ（FS 書込・--set・flock・pending gcroot いずれも取らない）。
- **CLI**: `reset <name> [target...]`（名指し必須・--all 非対応）+ TTY 確認 / `--yes` / 非 TTY かつ `--yes` 無しは即エラー停止（exit 1）。`--dryrun` を apply / reset に追加。stdout はプラン専有・進捗 / warning は stderr。終了コード 0 / 1 / `apply --dryrun` conflict=2。

完成済み層（`planner.Compute` / `staleremove.go` / `copy.go`）は再実装せず再利用した。境界として #14（--all / root filters / gitignore）・#15（engine 副作用部）には触れていない。

なお先頭コミットは前提の build 修正: main HEAD は recopy 追加時に rollback 側の `emitWarnings` 呼び出しが未更新でコンパイル不能だったため、`recopy=false` を補った。

## 関連 issue

Closes #13

## docs / ADR 影響

なし。本スライスは docs/spec.md・ADR-0020/0021/0023/0024/0025 で先行確定済みの仕様の実装で、新たな方針転換はない。
