### PR TITLE
feat(modules): home-manager モジュール統合（common.nix + home-manager.nix）

### DIFF
--- a/cmd/nput/apply.go
+++ b/cmd/nput/apply.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"sort"
 
 	"github.com/spf13/cobra"
@@ -44,12 +45,53 @@ func newApplyCmd() *cobra.Command {
 		"config 内の全 copy target を src から無条件上書き再コピー（ローカル編集は破棄・→ ADR-0020）")
 	cmd.Flags().BoolVar(&flagDryrun, "dryrun", false,
 		"副作用ゼロで place/replace/remove/conflict/no-op を表示（conflict 検出時 exit 2・→ ADR-0006）")
+	cmd.Flags().StringVar(&flagManifest, "manifest", "",
+		"ビルド済み manifest（link-farm パス）を直接適用する（entrypoint 発見・nix eval/build を行わない・module activation 用）")
 	return cmd
+}
+
+// runApplyManifest は --manifest で渡されたビルド済み link-farm を engine へ直接適用する
+// （module activation 経路）。entrypoint 発見・rootKind 先取り eval・nix build は行わず、
+// rootKind は manifest.json から engine が読む（HM モジュールは homeRoot を pin するため home）。
+// engine.Apply の Build=nil 経路（既ビルド済み LinkFarm）を CLI から駆動する（→ engine.Options）。
+func runApplyManifest(name string) error {
+	linkFarm, err := filepath.Abs(flagManifest)
+	if err != nil {
+		return fmt.Errorf("nput: --manifest のパスを解決できません (%s): %w", flagManifest, err)
+	}
+
+	res, err := engine.Apply(engine.Options{
+		Name:         name,
+		LinkFarm:     linkFarm,
+		RootOverride: flagRoot,
+		NoWait:       flagNoWait,
+		Recopy:       flagRecopy,
+	})
+	if err != nil {
+		if errors.Is(err, engine.ErrSkipped) {
+			if !flagQuiet {
+				fmt.Fprintln(os.Stderr, "nput: 別の apply が進行中のためスキップしました（手動で nput apply を実行してください）")
+			}
+			return nil
+		}
+		return err
+	}
+
+	if !flagQuiet {
+		reportResult(res, name)
+	}
+	return nil
 }
 
 // runApply は docs/spec.md「実行フロー」を駆動する:
 // entrypoint 発見 → rootKind 先取り eval → engine.Apply（flock → ロック内 build → 配置 → --set → .pending 削除）。
+// --manifest 指定時は entrypoint 発見・nix eval/build を行わず、ビルド済み link-farm を engine へ直接渡す
+// （module activation 経路・→ docs/spec.md「モジュール別動作仕様」・ADR-0003, ADR-0007）。
 func runApply(name string) error {
+	if flagManifest != "" {
+		return runApplyManifest(name)
+	}
+
 	ep, err := discoverEntrypoint(flagFile)
 	if err != nil {
 		return err

--- a/cmd/nput/apply.go
+++ b/cmd/nput/apply.go
@@ -46,7 +46,7 @@ func newApplyCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&flagDryrun, "dryrun", false,
 		"副作用ゼロで place/replace/remove/conflict/no-op を表示（conflict 検出時 exit 2・→ ADR-0006）")
 	cmd.Flags().StringVar(&flagManifest, "manifest", "",
-		"ビルド済み manifest（link-farm パス）を直接適用する（entrypoint 発見・nix eval/build を行わない・module activation 用）")
+		"ビルド済み manifest（link-farm パス）を直接適用する（host/module activation seam・entrypoint 発見・nix eval/build を行わない・→ ADR-0026）")
 	return cmd
 }
 
@@ -89,6 +89,11 @@ func runApplyManifest(name string) error {
 // （module activation 経路・→ docs/spec.md「モジュール別動作仕様」・ADR-0003, ADR-0007）。
 func runApply(name string) error {
 	if flagManifest != "" {
+		// --manifest は取得元を link-farm に固定するため、entrypoint 発見系フラグとは
+		// 意味が衝突する（位置引数 name は profile 選択として直交し両立する・→ ADR-0026）。
+		if flagFile != "" {
+			return errors.New("nput: --manifest と -f は併用できません（--manifest はビルド済み link-farm を取得元に固定します）")
+		}
 		return runApplyManifest(name)
 	}
 

--- a/cmd/nput/main.go
+++ b/cmd/nput/main.go
@@ -30,6 +30,7 @@ var (
 	flagProjectRoot bool   // --project-root: apply --all の修飾。projectRoot の config のみ適用
 	flagHomeRoot    bool   // --home-root: apply --all の修飾。homeRoot の config のみ適用
 	flagSystemRoot  bool   // --system-root: apply --all の修飾。systemRoot の config のみ適用（将来 seam）
+	flagManifest    string // --manifest: ビルド済み manifest（link-farm）を直接適用（module activation 用）
 )
 
 // exitError は cobra RunE が返す、特定の終了コードを伴うエラー（→ docs/spec.md 終了コード表）。

--- a/flake.lock
+++ b/flake.lock
@@ -40,6 +40,26 @@
         "type": "github"
       }
     },
+    "home-manager": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781615165,
+        "narHash": "sha256-CFF4fNNfr2GZSx1xJhBNBi7VMj8OtOqZGOV+fiBSbzw=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "34dd288e65012954cf7170658e0e6a61255b0327",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
     "namaka": {
       "inputs": {
         "haumea": [
@@ -126,6 +146,7 @@
       "inputs": {
         "flake-parts": "flake-parts",
         "haumea": "haumea",
+        "home-manager": "home-manager",
         "namaka": "namaka",
         "nix-unit": "nix-unit",
         "nixpkgs": "nixpkgs",

--- a/flake.nix
+++ b/flake.nix
@@ -13,6 +13,13 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
+    # HM モジュール統合の評価テスト専用（→ Issue #17・checks.hm-module）。
+    # lib/ は home-manager に依存しない（→ ADR-0006）。本 input は checks でのみ使う。
+    home-manager = {
+      url = "github:nix-community/home-manager";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
     # lib 評価テスト（→ ADR-0006, ADR-0012）。
     nix-unit = {
       url = "github:nix-community/nix-unit";
@@ -159,6 +166,59 @@
               nput = nputLib;
             };
           }) (pkgs.runCommandLocal "nput-namaka-snapshots" { } "touch \"$out\"");
+
+          # HM モジュール統合の評価アサート（→ Issue #17 AC・NixOS VM / 実 activate は #19 E2E）。
+          # standalone な homeManagerConfiguration を評価し、(1) activation が home.file へ翻訳せず
+          # `nput apply --manifest` で engine を起動する配線であること、(2) 渡す manifest が
+          # root=homeRoot を pin すること、(3) nput.entries が manifest に流れることをアサートする。
+          # 実 activate（nix-env --set・FS 配置）は build sandbox では行えないため E2E（#19）へ回す。
+          checks.hm-module =
+            let
+              # store hash 揺れを避ける fake な flake-input 相当（nix-unit / namaka と同じ test double）。
+              fakeSrc = {
+                outPath = "/nix/store/00000000000000000000000000000000-fake-src";
+              };
+              hm = inputs.home-manager.lib.homeManagerConfiguration {
+                inherit pkgs;
+                modules = [
+                  ./modules/home-manager.nix
+                  {
+                    # ラッパー（flake.homeManagerModules.default）と同じく pin 版 nput を注入する。
+                    _module.args.nputPackage = config.packages.nput;
+                    home.username = "nput-test";
+                    home.homeDirectory = "/home/nput-test";
+                    home.stateVersion = "24.05";
+                    nput.enable = true;
+                    nput.entries.".claude/skills/nix" = {
+                      src = fakeSrc;
+                      subpath = "skills/nix";
+                    };
+                  }
+                ];
+              };
+              # home.activation の dag entry の生スクリプト。
+              activationScript = pkgs.writeText "nput-activation" hm.config.home.activation.nput.data;
+            in
+            pkgs.runCommandLocal "nput-hm-module-check" { } ''
+              script=${activationScript}
+
+              # (1) home.file へ翻訳せず engine を --manifest 経路で起動する配線であること。
+              grep -q 'apply --manifest /nix/store/' "$script" \
+                || { echo "FAIL: activation が nput apply --manifest を起動していません"; cat "$script"; exit 1; }
+
+              # (2) 渡す manifest が root=homeRoot を pin していること（mkManifest が記録）。
+              manifest=$(grep -oE '/nix/store/[a-z0-9]+-nput-manifest' "$script" | head -n1)
+              test -n "$manifest" || { echo "FAIL: manifest の store パスを抽出できません"; cat "$script"; exit 1; }
+              test -f "$manifest/manifest.json" || { echo "FAIL: $manifest/manifest.json がありません"; exit 1; }
+              grep -q '"rootKind":"home"' "$manifest/manifest.json" \
+                || { echo "FAIL: manifest が homeRoot を pin していません"; cat "$manifest/manifest.json"; exit 1; }
+
+              # (3) nput.entries が manifest に流れていること（target = 属性キー）。
+              grep -q '".claude/skills/nix"' "$manifest/manifest.json" \
+                || { echo "FAIL: nput.entries が manifest に反映されていません"; cat "$manifest/manifest.json"; exit 1; }
+
+              touch "$out"
+            '';
         };
       flake = {
         lib = nputLib;
@@ -179,7 +239,15 @@
           };
         });
 
-        homeManagerModules.default = ./modules/home-manager.nix;
+        # HM モジュール本体（modules/home-manager.nix）は engine をキックするのに pin 版 nput
+        # CLI を要する。利用者システムの packages.nput を _module.args として注入する薄い
+        # ラッパーで包む（利用者は import するだけ・→ ADR-0007, modules/home-manager.nix）。
+        homeManagerModules.default =
+          { pkgs, ... }:
+          {
+            imports = [ ./modules/home-manager.nix ];
+            _module.args.nputPackage = inputs.self.packages.${pkgs.stdenv.hostPlatform.system}.nput;
+          };
         nixosModules.default = ./modules/nixos.nix;
         darwinModules.default = ./modules/nix-darwin.nix;
       };

--- a/modules/common.nix
+++ b/modules/common.nix
@@ -1,0 +1,41 @@
+# 全モジュール共通の nput オプション定義（→ ADR-0003, ADR-0007, ADR-0010, ADR-0014）。
+#
+# HM / NixOS / nix-darwin が import する共通の options。配置ロジックは持たず、
+# 「何を・どこへ・どう置くか」のデータ（entries）だけを宣言させる。各モジュールは
+# 自分の性質で root を pin する（HM → homeRoot）ため、利用者は root を再指定しない。
+#
+# entry submodule の型は lib/types.nix と共有する（mkManifest の evalModules と同一の
+# entriesType）。これにより未知キー（タイポ・旧名）は strict submodule で eval エラーに
+# なり、検査の二重定義を避ける（→ ADR-0010, docs/spec.md「モジュールオプション仕様」）。
+#
+# > HM モジュール経由は MVP で単一 nput.entries = 1 profile（固定名 default）に限り、
+# > role 分離（複数 profile）はできない。役割分離が要るユーザーは standalone CLI 経路
+# > （entrypoint の nput.<name>）を使う。複数 profile 化は将来 seam（→ ADR-0024, ADR-0025）。
+{ lib, ... }:
+let
+  nputTypes = import ../lib/types.nix lib;
+in
+{
+  options.nput = {
+    enable = lib.mkEnableOption "nput（フェッチ済み git リポジトリの symlink / copy 配置）";
+
+    entries = lib.mkOption {
+      type = nputTypes.entriesType;
+      default = { };
+      example = lib.literalExpression ''
+        {
+          # 属性キー = root 相対 target（識別子・→ ADR-0014）
+          ".claude/skills/nix" = {
+            src = inputs.claude-skills;
+            subpath = "skills/nix";
+          };
+        }
+      '';
+      description = ''
+        配置定義の attrset。属性キー = 配置先 target（識別子）で、各値は entry submodule
+        （src / subpath / target / method）。型は lib/types.nix と共有し、未知キーは eval
+        エラーになる（→ docs/spec.md「entries スキーマ仕様」）。
+      '';
+    };
+  };
+}

--- a/modules/home-manager.nix
+++ b/modules/home-manager.nix
@@ -1,1 +1,51 @@
-{ ... }: { }
+# home-manager モジュール: home.activation から nput エンジンを起動する薄い配線
+# （→ ADR-0002, ADR-0003, ADR-0007, docs/spec.md「モジュール別動作仕様」）。
+#
+# 配置ロジックは持たず、home.file / systemd.tmpfiles へは翻訳しない。配置・stale 除去は
+# 全層共通の nput エンジンが所有する（→ ADR-0003）。本モジュールは
+#   1. root = homeRoot を pin（利用者は root を再指定しない・→ ADR-0007）、
+#   2. nput.entries から link-farm（manifest.json + GC アンカー）を mkManifest でビルド、
+#   3. home.activation でその link-farm を `nput apply --manifest` に渡してエンジンを起動
+# するだけに徹する。
+#
+# 世代は nput 自前 profile（内部機構・前世代マニフェスト + stale 追跡）に乗る。MVP は固定名
+# `default` の単一 profile（<state>/nix/profiles/nput/default）で role 分離は不可。ユーザー
+# 向け rollback は host（home-manager --rollback）に一本化し、`nput rollback` は公開しない
+# （host rollback は旧 config を再 activate して nput を再 kick することで FS を自動収束させる）
+# （→ ADR-0002, ADR-0024, ADR-0025）。
+#
+# nputPackage（pin 版 nput CLI）は flake.nix の homeManagerModules.default 配線が
+# _module.args として注入する（→ flake.nix）。nputLib は lib/ を直接 import する
+# （nixpkgs.lib のみ依存・home-manager に依存しない・→ ADR-0006）。
+{
+  config,
+  lib,
+  pkgs,
+  nputPackage,
+  ...
+}:
+let
+  cfg = config.nput;
+  nputLib = import ../lib;
+
+  # nput.entries から link-farm derivation（manifest.json + symlink farm）を生成する。
+  # root は homeRoot を pin（実体 $HOME の解決は engine 実行時・marker は eval 時に展開しない）。
+  manifest = nputLib.mkManifest {
+    inherit pkgs;
+    root = nputLib.homeRoot;
+    entries = cfg.entries;
+  };
+in
+{
+  imports = [ ./common.nix ];
+
+  config = lib.mkIf cfg.enable {
+    # home.activation から engine を起動する。ビルド済み link-farm を --manifest で渡すため
+    # activation 内で nix eval/build は行わない（entrypoint 経路ではない）。writeBoundary 後に
+    # 走らせ、home.file の symlink 配置と順序衝突しないようにする。`run` は home-manager の
+    # activation ヘルパで --dry-run（DRY_RUN_CMD）を尊重する。
+    home.activation.nput = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+      run ${lib.getExe nputPackage} apply --manifest ${manifest}
+    '';
+  };
+}

--- a/tests/nix-unit.nix
+++ b/tests/nix-unit.nix
@@ -250,6 +250,31 @@ in
     expectedError.msg = "src";
   };
 
+  # modules/common.nix が共有する entriesType（attrsOf (submodule entryModule)）を
+  # evalModules で直接検査する。common.nix は同じ lib/types.nix の entriesType を使うため、
+  # 未知キー（タイポ・旧名）はモジュール経路でも strict submodule で eval エラーになる
+  # （→ AC「common.nix の entry submodule が lib/types.nix と共有され未知キーが eval エラー」・ADR-0010, ADR-0014）。
+  testSharedEntriesTypeUnknownKey = {
+    expr =
+      let
+        t = import ../lib/types.nix lib;
+        evaluated = lib.evalModules {
+          modules = [
+            { options.entries = lib.mkOption { type = t.entriesType; }; }
+            {
+              entries.".config/x" = {
+                src = fakeSrc;
+                bogus = true; # 未知キー
+              };
+            }
+          ];
+        };
+      in
+      evaluated.config.entries;
+    expectedError.type = "ThrownError";
+    expectedError.msg = "bogus";
+  };
+
   # ---- listFilesInSrc（→ ADR-0009, ADR-0023, ADR-0024）-----------------------
   # store パス src で readDir 互換の { filename = fileType; } を返す。型文字列が
   # regular / directory / symlink で builtins.readDir と同形式（subpath 省略 = ルート全体）。


### PR DESCRIPTION
## 概要

home-manager モジュール統合を end-to-end で実装する。`imports = [ nput.homeManagerModules.default ]` し `nput.enable = true; nput.entries = {...}` するだけで `home-manager switch` 時に nput engine が配置する（`home.file` / `systemd.tmpfiles` へ翻訳せず engine 経路）。

実装中に「モジュール activation の engine kick 方法が docs 未規定」という計画外仕様が判明したため、**設計・仕様の確定（ADR-0026 ほか）は別 PR #35 に分離**した。本 PR は #35 の計画に基づく**実装専用**。

主な実装:
- **cmd/nput**: `apply --manifest <link-farm>`（ビルド済み link-farm を engine へ直接適用・entrypoint 発見/eval/build なし）+ `-f` 併用 error
- **modules/common.nix**: 共通 `options.nput { enable; entries }`（entry 型は `lib/types.nix` の `entriesType` 共有・未知キーは eval エラー）
- **modules/home-manager.nix**: `homeRoot` pin → `mkManifest` で link-farm → `home.activation` から `apply --manifest` で kick。MVP は固定名 `default` の単一 profile、rollback は host 一本化
- **flake.nix**: `homeManagerModules.default`（pin 版 nput CLI 注入ラッパー）、評価専用 `home-manager` input、`checks.hm-module`
- **tests/nix-unit.nix**: 共有 `entriesType` 未知キー検査
- **internal/engine**: `main` が既にビルド不可だった pre-existing 修正（`emitWarnings` 引数 + gofmt）を同梱

検証: `nix flake check` 全 pass / `go test ./...` 65 pass / `apply --manifest` の手動 smoke（temp HOME へ symlink 配置 + `…/nput/default` に世代コミット、`-f` 併用 error）確認。

## 関連 issue

Closes #17
Refs #35（設計・仕様確定: ADR-0026）

## docs / ADR 影響

本 PR には **docs 変更を含まない**（docs / ADR は #35 へ分離済み）。
- ADR-0026（`apply --manifest` の engine kick 契約）+ spec / design / CONTEXT / ADR-0003・0007 の更新は **#35**。
- 本 PR の実装は #35 の計画に準拠。コード内コメント・`--help` は ADR-0026 を参照。