### PR TITLE
fix(engine): rollback の emitWarnings 引数不足と test 整形崩れを解消

### DIFF
--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -126,6 +126,7 @@ func makeROSrc(t *testing.T, subpath, content string) string {
 	}
 	return src
 }
+
 // --- tests -----------------------------------------------------------------
 
 func TestApplyFirstPlacementProjectMode(t *testing.T) {

--- a/internal/engine/generations.go
+++ b/internal/engine/generations.go
@@ -176,7 +176,7 @@ func Rollback(opts RollbackOptions) (*RollbackResult, error) {
 	a := &applier{opts: Options{Warnf: warnf}, result: &Result{Root: root, ProfileDir: prof.Dir}}
 	a.profile = prof
 	a.root = root
-	a.emitWarnings(plan.Warnings)
+	a.emitWarnings(plan.Warnings, false) // rollback は recopy しない（copy foreign skip 抑制は無関係）
 	if err := a.place(plan.Place); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## 概要

直近マージの #29（\`emitWarnings\` へ \`recopy bool\` 引数を追加）で、\`generations.go\` の Rollback 内 \`a.emitWarnings(plan.Warnings)\` の呼び出し側が引数不足のまま残り、\`internal/engine\` がコンパイル不能になっていた。あわせて \`engine_test.go\` の gofmt 崩れ（空行不足）で treefmt check も落ちていた。\`nix flake check\` を green に戻す最小 hotfix。

- \`generations.go:179\` — \`a.emitWarnings(plan.Warnings, false)\` に修正（rollback は recopy しないため \`false\`）
- \`engine_test.go\` — gofmt 整形

確認: \`go build\` / \`go vet\` / \`gofmt -l\` clean、\`nix flake check\` → all checks passed。

## 関連 issue

なし

## docs / ADR 影響

なし（API・配置動作・方針に変更なし。シグネチャ変更の追従漏れ修正のみ）