### PR TITLE
fix(cli): apply --all --dryrun が dryrun を無視し実 apply していたのを修正

### DIFF
--- a/cmd/nput/apply.go
+++ b/cmd/nput/apply.go
@@ -230,6 +230,13 @@ func runApplyAll() error {
 		return nil
 	}
 
+	// 2.5 --dryrun は副作用ゼロのプレビュー（flock / --set / pending gcroot を取らず build だけ
+	//     read-only で回す）。選んだ各 config の plan を stdout へ集約し、終了コードは
+	//     error(1) > conflict(2) > 0 の優先で決める（→ docs/spec.md・ADR-0024）。
+	if flagDryrun {
+		return runApplyAllDryRun(ep, system, selected, roots)
+	}
+
 	// 3. 各 config を独立に適用する。一部失敗しても続行し、失敗を集約する（各 config は独立 atomic）。
 	var failures, skipped, applied int
 	for _, name := range selected {
@@ -265,6 +272,50 @@ func runApplyAll() error {
 		return nil
 	}
 	return &exitCodeError{code: code, msg: fmt.Sprintf("nput: apply --all: %d 件の config が失敗しました", failures)}
+}
+
+// runApplyAllDryRun は apply --all --dryrun を駆動する。選んだ各 config を読み取り専用で build し
+// plan を stdout へ集約出力する（FS 書込・flock・--set・pending gcroot いずれも取らない・→ ADR-0023）。
+// 終了コードは error(1) > conflict(2) > 0 の優先（→ docs/spec.md・ADR-0024）で決め、empty msg の
+// exitError で運ぶ（単体 apply --dryrun の conflict=2 と対称・main は code だけで終了する）。
+func runApplyAllDryRun(ep *entrypoint, system string, selected []string, roots map[string]rootInfo) error {
+	code := aggregateDryRun(selected, func(name string) (*engine.Result, error) {
+		ri := roots[name]
+		return engine.Apply(engine.Options{
+			Name:         name,
+			RootKind:     ri.RootKind,
+			FixedRoot:    ri.Root,
+			RootOverride: flagRoot,
+			Recopy:       flagRecopy,
+			DryRun:       true,
+			Build:        dryBuildFunc(ep, system, name),
+		})
+	})
+	if code == 0 {
+		return nil
+	}
+	return &exitError{code: code}
+}
+
+// aggregateDryRun は selected 各 config を applyDry で読み取り専用に回し、plan を stdout へ出して
+// error / conflict を集約し終了コードを返す（apply 実体を注入してテスト可能にする seam）。
+// 一部 config の build / eval 失敗（error）は握り潰さず stderr に出して続行し、最終コードへ反映する。
+func aggregateDryRun(selected []string, applyDry func(name string) (*engine.Result, error)) int {
+	var anyError, anyConflict bool
+	for _, name := range selected {
+		res, err := applyDry(name)
+		if err != nil {
+			anyError = true
+			// 部分失敗は握り潰さず stderr に出して続行する（→ docs/spec.md「一部失敗しても続行」）。
+			fmt.Fprintf(os.Stderr, "nput: apply %s --dryrun に失敗しました: %v\n", name, err)
+			continue
+		}
+		printApplyPlan(res)
+		if len(res.Conflicts) > 0 {
+			anyConflict = true
+		}
+	}
+	return applyAllExitCode(anyError, anyConflict)
 }
 
 // applyAllExitCode は apply --all の終了コードを priority error(1) > conflict(2) > 0 で決める

--- a/cmd/nput/apply_test.go
+++ b/cmd/nput/apply_test.go
@@ -1,6 +1,13 @@
 package main
 
-import "testing"
+import (
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/yasunori0418/nput/internal/engine"
+)
 
 // applyAllExitCode は priority error(1) > conflict(2) > 0（単純な最大値ではない・→ ADR-0024）。
 func TestApplyAllExitCode(t *testing.T) {
@@ -18,6 +25,83 @@ func TestApplyAllExitCode(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			if got := applyAllExitCode(c.anyError, c.anyConf); got != c.want {
 				t.Errorf("applyAllExitCode(%v, %v) = %d, want %d", c.anyError, c.anyConf, got, c.want)
+			}
+		})
+	}
+}
+
+// captureStdout は f 実行中の stdout を捕捉して返す（dryrun plan が stdout 専有か検証する）。
+func captureStdout(t *testing.T, f func()) string {
+	t.Helper()
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stdout = w
+	done := make(chan string, 1)
+	go func() {
+		b, _ := io.ReadAll(r)
+		done <- string(b)
+	}()
+	f()
+	w.Close()
+	os.Stdout = old
+	return <-done
+}
+
+// aggregateDryRun の集約終了コードと plan 出力（stdout 専有）を、apply 実体を注入して
+// nix 無しで検証する。これが #14 AC-4「error(1) > conflict(2) > 0」の実経路の回帰防止。
+func TestAggregateDryRun(t *testing.T) {
+	clean := func(name string) (*engine.Result, error) {
+		return &engine.Result{Placed: []string{"/p/" + name}}, nil
+	}
+	conflict := func(name string) (*engine.Result, error) {
+		return &engine.Result{Conflicts: []string{"/c/" + name}}, nil
+	}
+	fail := func(name string) (*engine.Result, error) {
+		return nil, io.EOF
+	}
+
+	cases := []struct {
+		name     string
+		apply    func(string) (*engine.Result, error)
+		selected []string
+		wantCode int
+	}{
+		{"all clean → 0", clean, []string{"a", "b"}, 0},
+		{"conflict → 2", func(n string) (*engine.Result, error) {
+			if n == "b" {
+				return conflict(n)
+			}
+			return clean(n)
+		}, []string{"a", "b"}, 2},
+		{"error → 1", func(n string) (*engine.Result, error) {
+			if n == "b" {
+				return fail(n)
+			}
+			return clean(n)
+		}, []string{"a", "b"}, 1},
+		{"error wins over conflict → 1", func(n string) (*engine.Result, error) {
+			switch n {
+			case "a":
+				return conflict(n)
+			case "b":
+				return fail(n)
+			}
+			return clean(n)
+		}, []string{"a", "b", "c"}, 1},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			var got int
+			out := captureStdout(t, func() { got = aggregateDryRun(c.selected, c.apply) })
+			if got != c.wantCode {
+				t.Errorf("aggregateDryRun code = %d, want %d", got, c.wantCode)
+			}
+			// 成功 config の plan は stdout に出る（機械可読出力を専有・→ ADR-0023）。
+			if strings.Contains(c.name, "all clean") && !strings.Contains(out, "place\t/p/a") {
+				t.Errorf("stdout に plan が出ていない: %q", out)
 			}
 		})
 	}


### PR DESCRIPTION
## 背景

Wave 1 (#8) のレビュー中に発見した重大欠陥の修正。

`nput apply --all --dryrun` が `--dryrun` を無視し、副作用ゼロのプレビューのつもりが**全 config に対し実 apply（flock 取得・`--out-link` gcroot 作成・FS 配置・`nix-env --set` 世代コミット）を実行していた**。CI の事前 gate として使うと意図せず本番適用される footgun。

原因: `newApplyCmd` の RunE が `--all` を最優先で `runApplyAll()` に分岐するが、`runApplyAll` は `flagDryrun` を一切参照していなかった。`applyAllExitCode`（error(1) > conflict(2) > 0 の優先）ヘルパと単体テストは存在したが、dryrun 経路自体が未配線で常に `conflict=false` 固定で呼ばれていた。

これは issue #14 の受け入れ基準4「`apply --all --dryrun` の終了コードが error(1) > conflict(2) > 0 の優先で決まる」未充足、および `docs/spec.md:279` / PRD User Story 54 との乖離。

## 変更

- `runApplyAll` に `flagDryrun` 分岐を追加。各 config を `DryRun:true` + `dryBuildFunc`（`--no-link --print-out-paths`・gcroot なし）で read-only に build し、plan を stdout へ集約、終了コードを `error(1) > conflict(2) > 0` の優先で決める。
- 集約ロジックを `aggregateDryRun` に分離し、apply 実体を注入して nix 無しで終了コード優先と stdout 専有出力を検証する回帰テスト `TestAggregateDryRun` を追加。
- 終了コードは単体 `apply --dryrun` の conflict=2 と対称に empty-msg の `exitError` で運ぶ（main が code だけで終了）。

## テスト

- `go test ./...` 98 passed
- `go vet ./...` / `gofmt -l` クリーン

Refs #8 #14