### PR TITLE
test(cli): reset の CLI 結線テスト追加 + Go .gitignore 整備

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,37 @@
+# ---- Go ----
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# nput バイナリ（`go build` / `go build ./...` がリポジトリ直下に生成する）
+/nput
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool
+*.out
+coverage.txt
+coverage.html
+
+# Go workspace file
+go.work
+go.work.sum
+
+# Dependency directories（vendoring する場合はコメントアウト）
+# vendor/
+
+# ---- Nix ----
+# nix build の out-link
+/result
+result-*
+
+# ---- Project ----
 .agents/
 .claude/skills/*
 
 # nput ドッグフーディング配置物（nput apply default で生成・→ Issue #7）
 /.nput-example/
-
-# nix build の out-link
-/result

--- a/cmd/nput/reset.go
+++ b/cmd/nput/reset.go
@@ -64,15 +64,15 @@ func runReset(name string, targets []string, dryrun bool) error {
 		return nil
 	}
 
-	// 非 dryrun は破壊的操作。非 TTY かつ --yes 無しは即エラー停止する（ハングと誤削除を防ぐ・→ ADR-0025 §5）。
-	if !flagYes && !isInteractive() {
-		return errors.New("nput: 非対話環境では --yes なしの破壊的 reset を拒否します " +
-			"(refusing destructive reset without --yes in non-interactive context)")
+	// 非 dryrun は破壊的操作。確認方針（スキップ / プロンプト / 拒否）を --yes と TTY 状態から決める。
+	needPrompt, err := confirmPolicy(flagYes, isInteractive())
+	if err != nil {
+		return err
 	}
 
-	// --yes 未指定（= TTY）のときだけ確認プロンプトを出す。プロンプトは算出済みプランを表示する。
+	// プロンプトが要るときだけ confirm を渡す。プロンプトは算出済みプランを表示する。
 	var confirm func(*engine.ResetResult) (bool, error)
-	if !flagYes {
+	if needPrompt {
 		confirm = func(res *engine.ResetResult) (bool, error) {
 			reportResetTargets(res, name)
 			return promptYesNo("上記を削除します。続行しますか？")
@@ -149,6 +149,23 @@ func reportResetResult(res *engine.ResetResult, name string) {
 	if len(res.RemovedSymlinks)+len(res.RemovedCopies) == 0 {
 		fmt.Fprintln(os.Stderr, "  no-op")
 	}
+}
+
+// confirmPolicy は破壊的 reset の確認方針を --yes と TTY 状態から決める（→ ADR-0025 §5）。
+//   - --yes: 確認スキップ（needPrompt=false・err=nil）
+//   - --yes 無し + 対話環境: 確認プロンプト要求（needPrompt=true）
+//   - --yes 無し + 非対話環境: ハング / 空入力誤削除を防ぐため即エラー（refuse）
+//
+// runReset から isInteractive() の結果を渡して使う（nix 非依存で単体テスト可能な seam）。
+func confirmPolicy(yes, interactive bool) (needPrompt bool, err error) {
+	if yes {
+		return false, nil
+	}
+	if !interactive {
+		return false, errors.New("nput: 非対話環境では --yes なしの破壊的 reset を拒否します " +
+			"(refusing destructive reset without --yes in non-interactive context)")
+	}
+	return true, nil
 }
 
 // isInteractive は stdin が TTY か（端末に接続されているか）を返す（→ ADR-0025 §5）。

--- a/cmd/nput/reset_test.go
+++ b/cmd/nput/reset_test.go
@@ -1,0 +1,167 @@
+package main
+
+import (
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/yasunori0418/nput/internal/engine"
+)
+
+// confirmPolicy は --yes / TTY 状態から確認方針を決める（→ ADR-0025 §5）。
+// 非対話 + --yes 無しの破壊的 reset 拒否（#13 AC-5）の回帰防止。
+func TestConfirmPolicy(t *testing.T) {
+	cases := []struct {
+		name        string
+		yes         bool
+		interactive bool
+		wantPrompt  bool
+		wantErr     bool
+	}{
+		{"--yes はスキップ（非対話でも）", true, false, false, false},
+		{"--yes はスキップ（対話でも）", true, true, false, false},
+		{"対話 + --yes 無しはプロンプト", false, true, true, false},
+		{"非対話 + --yes 無しは拒否", false, false, false, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			gotPrompt, err := confirmPolicy(c.yes, c.interactive)
+			if (err != nil) != c.wantErr {
+				t.Fatalf("err = %v, wantErr = %v", err, c.wantErr)
+			}
+			if gotPrompt != c.wantPrompt {
+				t.Errorf("needPrompt = %v, want %v", gotPrompt, c.wantPrompt)
+			}
+		})
+	}
+}
+
+// promptYesNo は yes 系入力のときだけ true を返す（既定 No）。stdin を差し替えて検証する。
+func TestPromptYesNo(t *testing.T) {
+	cases := []struct {
+		input string
+		want  bool
+	}{
+		{"y\n", true},
+		{"yes\n", true},
+		{"Y\n", true},
+		{"YES\n", true},
+		{"n\n", false},
+		{"\n", false},      // 既定 No
+		{"maybe\n", false}, // 不明な入力は No
+		{"", false},        // EOF（パイプ閉じ）も No
+	}
+	for _, c := range cases {
+		t.Run(strings.TrimSpace(c.input)+"->"+boolStr(c.want), func(t *testing.T) {
+			restore := withStdin(t, c.input)
+			defer restore()
+			got, err := promptYesNo("続行しますか？")
+			if err != nil {
+				t.Fatalf("promptYesNo err = %v", err)
+			}
+			if got != c.want {
+				t.Errorf("promptYesNo(%q) = %v, want %v", c.input, got, c.want)
+			}
+		})
+	}
+}
+
+// isInteractive はパイプ / リダイレクト stdin では false を返す（非 TTY 経路・→ ADR-0025 §5）。
+// TTY=true 経路は実端末が要るため CI では検証できず、false 経路のみ検証する。
+func TestIsInteractiveNonTTY(t *testing.T) {
+	restore := withStdin(t, "")
+	defer restore()
+	if isInteractive() {
+		t.Error("パイプ stdin では isInteractive() は false であるべき")
+	}
+}
+
+// reset の出力ストリーム規律（#13 AC-9）: dryrun plan は stdout 専有、
+// 削除予定 / 結果レポートは stderr。
+func TestResetOutputStreams(t *testing.T) {
+	res := &engine.ResetResult{
+		Root:            "/root",
+		RemovedSymlinks: []string{"/root/a"},
+		RemovedCopies:   []string{"/root/b"},
+		KeptForeign:     []string{"/root/c"},
+	}
+
+	t.Run("printResetPlan は stdout 専有", func(t *testing.T) {
+		out, errOut := captureOutErr(t, func() { printResetPlan(res) })
+		if !strings.Contains(out, "remove-symlink\t/root/a") ||
+			!strings.Contains(out, "remove-copy\t/root/b") ||
+			!strings.Contains(out, "keep-foreign\t/root/c") {
+			t.Errorf("plan が stdout に出ていない: %q", out)
+		}
+		if errOut != "" {
+			t.Errorf("plan で stderr に出力があるべきでない: %q", errOut)
+		}
+	})
+
+	t.Run("reportResetResult は stderr 専有", func(t *testing.T) {
+		out, errOut := captureOutErr(t, func() { reportResetResult(res, "name") })
+		if out != "" {
+			t.Errorf("レポートが stdout を汚している: %q", out)
+		}
+		if !strings.Contains(errOut, "removed-symlink") || !strings.Contains(errOut, "/root/a") {
+			t.Errorf("レポートが stderr に出ていない: %q", errOut)
+		}
+	})
+
+	t.Run("reportResetTargets は stderr 専有", func(t *testing.T) {
+		out, errOut := captureOutErr(t, func() { reportResetTargets(res, "name") })
+		if out != "" {
+			t.Errorf("確認表示が stdout を汚している: %q", out)
+		}
+		if !strings.Contains(errOut, "削除対象") {
+			t.Errorf("確認表示が stderr に出ていない: %q", errOut)
+		}
+	})
+}
+
+func boolStr(b bool) string {
+	if b {
+		return "true"
+	}
+	return "false"
+}
+
+// withStdin は os.Stdin を input を返すパイプに差し替え、復元する関数を返す。
+func withStdin(t *testing.T, input string) func() {
+	t.Helper()
+	old := os.Stdin
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	go func() {
+		_, _ = io.WriteString(w, input)
+		w.Close()
+	}()
+	os.Stdin = r
+	return func() { os.Stdin = old; r.Close() }
+}
+
+// captureOutErr は f 実行中の stdout / stderr を捕捉して返す（ストリーム規律の検証用）。
+func captureOutErr(t *testing.T, f func()) (stdout, stderr string) {
+	t.Helper()
+	oldOut, oldErr := os.Stdout, os.Stderr
+	rOut, wOut, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	rErr, wErr, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stdout, os.Stderr = wOut, wErr
+	outCh, errCh := make(chan string, 1), make(chan string, 1)
+	go func() { b, _ := io.ReadAll(rOut); outCh <- string(b) }()
+	go func() { b, _ := io.ReadAll(rErr); errCh <- string(b) }()
+	f()
+	wOut.Close()
+	wErr.Close()
+	os.Stdout, os.Stderr = oldOut, oldErr
+	return <-outCh, <-errCh
+}

--- a/flake.nix
+++ b/flake.nix
@@ -188,6 +188,9 @@
                     home.username = "nput-test";
                     home.homeDirectory = "/home/nput-test";
                     home.stateVersion = "24.05";
+                    # nixpkgs=unstable と HM=master の release 文字列ずれによる無害な
+                    # warning を抑制する（packages は nixpkgs follows で一致・→ #17 レビュー）。
+                    home.enableNixpkgsReleaseCheck = false;
                     nput.enable = true;
                     nput.entries.".claude/skills/nix" = {
                       src = fakeSrc;


### PR DESCRIPTION
## 背景

Wave 1 (#8) レビューの follow-up（軽微指摘 3 件）。`apply --all --dryrun` の重大欠陥修正は別 PR #37。

## 変更

### 1. reset の CLI 層テスト追加（#13 関連）
レビューで「CLI 層（cmd/nput）の結線テストが薄い」と指摘した点を補う。確認方針判定を `confirmPolicy` に切り出し（nix 非依存の seam）、以下を回帰テスト:
- `confirmPolicy`: `--yes` スキップ / 対話プロンプト / **非対話 + `--yes` 無し拒否（AC-5）**
- `promptYesNo`: y/yes/Y/YES=true・空/不明/EOF=false（既定 No）
- `isInteractive`: パイプ stdin で false（非 TTY 経路）
- 出力ストリーム規律（AC-9）: `printResetPlan` は stdout 専有・`reportReset*` は stderr 専有

### 2. Go 標準 .gitignore 整備
`go build` がリポジトリ直下に生成する `nput` バイナリが未 ignore でコミット候補に乗っていた。Go 標準テンプレート + extensionless な `/nput` + `result-*` を追加。既存のプロジェクト固有エントリは維持。

### 3. hm-module check の無害な nixpkgs release warning 抑制（#17 関連）
nixpkgs=unstable と home-manager=master の release 文字列ずれで出ていた version mismatch warning を、`checks.hm-module` のテスト config で `home.enableNixpkgsReleaseCheck = false` を設定して抑制（packages は follows で一致・実害なし）。プロジェクトの nixos-unstable 方針は維持。

## テスト
- `go test ./...` 全 pass（cmd は 30 tests）
- `go vet` / `gofmt -l` クリーン
- `/nput` の ignore を `git check-ignore` で確認
- `nix build .#checks.<system>.hm-module` 成功・version warning 消失を確認

Refs #8 #13 #17