### PR TITLE
test(cli): テストヘルパの未チェック Close() を errcheck 対応

### DIFF
--- a/cmd/nput/apply_test.go
+++ b/cmd/nput/apply_test.go
@@ -45,7 +45,7 @@ func captureStdout(t *testing.T, f func()) string {
 		done <- string(b)
 	}()
 	f()
-	w.Close()
+	_ = w.Close()
 	os.Stdout = old
 	return <-done
 }

--- a/cmd/nput/reset_test.go
+++ b/cmd/nput/reset_test.go
@@ -137,10 +137,10 @@ func withStdin(t *testing.T, input string) func() {
 	}
 	go func() {
 		_, _ = io.WriteString(w, input)
-		w.Close()
+		_ = w.Close()
 	}()
 	os.Stdin = r
-	return func() { os.Stdin = old; r.Close() }
+	return func() { os.Stdin = old; _ = r.Close() }
 }
 
 // captureOutErr は f 実行中の stdout / stderr を捕捉して返す（ストリーム規律の検証用）。
@@ -160,8 +160,8 @@ func captureOutErr(t *testing.T, f func()) (stdout, stderr string) {
 	go func() { b, _ := io.ReadAll(rOut); outCh <- string(b) }()
 	go func() { b, _ := io.ReadAll(rErr); errCh <- string(b) }()
 	f()
-	wOut.Close()
-	wErr.Close()
+	_ = wOut.Close()
+	_ = wErr.Close()
 	os.Stdout, os.Stderr = oldOut, oldErr
 	return <-outCh, <-errCh
 }


### PR DESCRIPTION
## 背景

PR #37 / #38 マージ後の再レビューで `nix flake check` を回したところ、**golangci-lint (errcheck) が失敗**していた。両 PR で追加したテストヘルパの `Close()` 戻り値が未チェックだったため。`go vet` / `go test` / `gofmt` は通るが golangci-lint は別ゲートで、ローカル検証から漏れていた。

```
cmd/nput/apply_test.go:48:9: Error return value of `w.Close` is not checked (errcheck)
cmd/nput/reset_test.go:140 / :143 / :163 / :164  同上
```

## 変更

テストヘルパ（`captureStdout` / `withStdin` / `captureOutErr`）の `Close()` 呼び出しを明示的に `_ =` で破棄。

## テスト

- `nix flake check` **all checks passed**（golangci-lint 含む 6 checks green）を確認
- `go test ./...` 117 passed

Refs #8