### PR TITLE
ci: flake check を nix/Go/CI 定義の変更時のみ実行（paths フィルタ）

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,17 @@ name: Test
 on:
   workflow_dispatch:
   pull_request:
+    # nix / Go / CI 定義の変更時のみ実行する。docs のみの変更で flake check を回さない。
+    # paths は workflow 単位（全 job 共通）。手動再実行は workflow_dispatch で担保。
+    paths:
+      - "**.nix"
+      - "**.go"
+      - "go.mod"
+      - "go.sum"
+      - "flake.lock"
+      - "dev/flake.lock"
+      - ".github/workflows/**"
+      - ".github/actions/**"
 
 jobs:
   flake-check:


### PR DESCRIPTION
## 概要

docs のみの修正でも `nix flake check`（3環境マトリクス）が走っていた（例: PR #41）。これは不要なので、`pull_request` トリガに `paths` フィルタを追加し、**nix / Go / CI 定義の変更時のみ**実行するようにする。

## 変更

`.github/workflows/test.yml` の `on.pull_request` に `paths` を追加:

- `**.nix` / `**.go`
- `go.mod` / `go.sum`
- `flake.lock` / `dev/flake.lock`
- `.github/workflows/**` / `.github/actions/**`

## 補足

- `paths` は **workflow 単位**（全 job 共通）。flake-check / 今後追加の e2e job も同条件でゲートされる。
- 手動再実行は `workflow_dispatch` で担保（docs-only PR で意図的に回したい場合）。
- トリガ方針は ADR-0027 §2 に準拠。paths フィルタの記述は別 docs PR で追記する。

issue #19 / 親 PRD #8