### PR TITLE
ci: nput を cachix yasunori0418 に投入する cachix-push を追加

### DIFF
--- a/.github/workflows/cachix-push.yml
+++ b/.github/workflows/cachix-push.yml
@@ -1,0 +1,41 @@
+name: Cachix Push
+
+on:
+  push:
+    branches:
+      - main
+    # nput バイナリの内容を決める入力（nix 定義 + Go ソース）の変更時のみ投入する。
+    paths:
+      - "**.nix"
+      - "**.go"
+      - "go.mod"
+      - "go.sum"
+      - "flake.lock"
+      - "dev/flake.lock"
+  workflow_dispatch:
+
+jobs:
+  build-and-push:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            system: x86_64-linux
+          - os: ubuntu-24.04-arm
+            system: aarch64-linux
+          - os: macos-latest
+            system: aarch64-darwin
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Setup Nix
+        uses: ./.github/actions/setup-nix
+        with:
+          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+
+      # nput は単一パッケージなので os マトリクスで各 system をネイティブビルドするだけ。
+      # cachix-action が authToken 指定でビルド生成パスを自動 push する（cachix yasunori0418）。
+      - name: Build and push nput (${{ matrix.system }})
+        run: nix build ".#packages.${{ matrix.system }}.nput" --print-build-logs

--- a/docs/adr/0028-cachix-push-on-main-os-matrix.md
+++ b/docs/adr/0028-cachix-push-on-main-os-matrix.md
@@ -1,0 +1,45 @@
+# ADR-0028: cachix push を main push の os マトリクスで実装する（ADR-0012 §4 の実装補足）
+
+- ステータス: 採用
+- 日付: 2026-06-20
+- 関連: ADR-0012（§4 キャッシュ投入）, ADR-0027（CI 実装補足）, ADR-0011（stdlib-only Go）
+- 参照: `~/src/github.com/yasunori0418/nur-packages` の `.github/workflows/cachix-push.yml`
+
+## 背景
+
+ADR-0012 §4 は「tag push 時に matrix（x86_64-linux / aarch64-linux / aarch64-darwin）で `nix build .#nput` し cachix `yasunori0418` に投入する」と決めていたが、実装フェーズで2点を見直した。
+
+- **トリガ**: nput は flake input として消費される CLI で、consumer の CI / ローカルが「最新 main の `nput` を実ビルドせずキャッシュから引く」恩恵が大きい。tag push のみだとリリース間の main 変更がキャッシュされない。
+- **ワークフロー構成**: 参照元 nur-packages は多数パッケージのため「未キャッシュのものだけ選別する `ci-matrix` app + plan / collect / build-and-push の3段」を組むが、nput は**実質1パッケージ**なので過剰。
+
+## 決定
+
+### 1. トリガは push:main + `paths` + `workflow_dispatch`
+
+- main への push のうち、nput バイナリの内容を決める入力（`**.nix` / `**.go` / `go.mod` / `go.sum` / `flake.lock` / `dev/flake.lock`）が変わったときに投入する。docs 等だけの変更では走らせない。
+- 手動投入は `workflow_dispatch`。
+- ADR-0012 §4 の「tag push」からの変更。tag リリースに紐づけず、main の最新を常時キャッシュする方針に改める。
+
+### 2. 構成は test.yml と同じ os×system マトリクスの単純ビルド
+
+- `ubuntu-latest`=x86_64-linux / `ubuntu-24.04-arm`=aarch64-linux / `macos-latest`=aarch64-darwin の3環境で `nix build .#packages.<system>.nput` をネイティブ実行する。
+- 投入は `.github/actions/setup-nix`（cachix `yasunori0418`）の `cachix-action` が authToken 指定でビルド生成パスを自動 push する経路に任せる（明示 push ステップは置かない）。
+- nur-packages の `ci-matrix` 選別機構（plan / collect）は採らない。単一パッケージで選別の利得が無く、複雑性に見合わない。
+
+## 根拠
+
+- **main push 投入**: nput は配置エンジンの CLI で consumer 側 activation / CI が実体を要する。最新 main を都度キャッシュすれば consumer のビルド時間と再現性が改善する。
+- **単純マトリクス**: 1パッケージでは「未キャッシュ選別」のジョブ往復コストの方が高い。`cachix-action` の重複 push スキップ（store パスのハッシュ一致分はスキップ）で十分。
+- **fork PR の secrets**: 本ワークフローは push:main / workflow_dispatch 起動で fork PR からは走らないため、`CACHIX_AUTH_TOKEN` 不在問題は生じない（投入は本リポジトリ権限下のみ）。
+
+## 影響
+
+- `.github/workflows/cachix-push.yml` を追加。
+- `docs/design.md`「CI 実行」に cachix push の段落を補足。
+- ADR-0012 §4 は supersede しない（投入対象とキャッシュ名は維持し、トリガと構成のみ実装で具体化）。
+
+## 棄却した代替案
+
+- **tag push のみ（ADR-0012 §4 原案）**: リリース間の main 変更がキャッシュされず、開発中の consumer が実ビルドを強いられる。
+- **nur-packages の ci-matrix 選別を踏襲**: 多パッケージ前提の機構で、単一パッケージの nput には過剰。
+- **`nix-access-token` を setup-nix に追加**: nput は public repo / public flake input で `github_access_token` で足り、現時点で不要。private fetch が要る段で別途追加する。

--- a/docs/design.md
+++ b/docs/design.md
@@ -418,6 +418,8 @@ NixOS VM テスト（`runNixOSTest`）はモジュール経路を実装する段
 
 **CI 実行**（→ ADR-0012, ADR-0027）: 上記のうち `nix flake check` 集約分（lib の nix-unit / namaka、engine の Go ユニット + tmpdir、treefmt / go-vet / golangci-lint）を GitHub Actions で **os×system の3環境マトリクス**（`ubuntu-latest`=x86_64-linux / `ubuntu-24.04-arm`=aarch64-linux / `macos-latest`=aarch64-darwin）に対し実行する。x86_64-darwin は GitHub ホストの標準 x86_64 macOS ランナーが乏しいため CI 対象外（perSystem 定義には残す）。トリガは `pull_request` + `workflow_dispatch`（push トリガは採らない・PR ゲート前提）。`pull_request` は `paths` フィルタで nix / Go / CI 定義（`**.nix` / `**.go` / `go.mod` / `go.sum` / `flake.lock` / `dev/flake.lock` / `.github/**`）の変更時のみ実行し、docs のみの変更では回さない（workflow 単位で全 job 共通）。nix は `.github/actions/setup-nix` composite（`cachix/install-nix-action` + cachix `yasunori0418`、各 SHA pin）で導入。go-vet / golangci-lint の check は `CGO_ENABLED=0` のピュア Go で評価する（cgo 未使用・ADR-0011）。E2E は同 composite を使う `ubuntu-latest` の別ジョブ（サンドボックス外）。
 
+**キャッシュ投入（cachix push）**（→ ADR-0012 §4, ADR-0028）: `nput` バイナリを cachix `yasunori0418` に投入する `cachix-push` workflow を別途置く。`main` への push のうち nix / Go 入力（`**.nix` / `**.go` / `go.mod` / `go.sum` / `flake.lock` / `dev/flake.lock`）が変わったとき + `workflow_dispatch` で起動し、flake-check と同じ os×system 3環境マトリクスで `nix build .#packages.<system>.nput` をネイティブビルドする。投入は `setup-nix` の `cachix-action`（authToken 指定）の自動 push に任せる。tag push ではなく main 追従でキャッシュする（ADR-0028）。
+
 ---
 
 ## 設計上の判断

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,22 @@
 {
   description = "Place fetched git repositories at arbitrary paths via symlink or copy.";
 
+  # nput 自体を clone して nix develop / build / flake check する際に cachix からビルド済み
+  # バイナリを引くための設定（trusted-user / accept-flake-config 前提）。flake の nixConfig は
+  # input に伝播しないため、nput を flake input として消費する側のキャッシュ取得には効かない。
+  nixConfig = {
+    extra-substituters = [
+      "https://cache.nixos.org/"
+      "https://nix-community.cachix.org"
+      "https://yasunori0418.cachix.org"
+    ];
+    extra-trusted-public-keys = [
+      "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
+      "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
+      "yasunori0418.cachix.org-1:mC1j+M5A6063OHaOB5bH2nS0BiCW/BJsSRiOWjLeV9o="
+    ];
+  };
+
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-parts = {


### PR DESCRIPTION
## 概要

`nput` バイナリを cachix `yasunori0418` に投入する `cachix-push` workflow を追加する（ADR-0012 §4 の実装）。`../nur-packages/.github/workflows/cachix-push.yml` を参考にしつつ、nput は単一パッケージなので選別機構（ci-matrix / plan / collect）は捨て、test.yml と同じ os×system マトリクスの単純ビルドにした。

## 変更

- **`.github/workflows/cachix-push.yml`**: `push:main`（nix/Go 入力変更時の `paths`）+ `workflow_dispatch`。3環境マトリクス（x86_64-linux / aarch64-linux / aarch64-darwin）で `nix build .#packages.<system>.nput`。投入は `setup-nix` の `cachix-action`(authToken) の自動 push。
- **`flake.nix`**: `nixConfig`（extra-substituters / extra-trusted-public-keys に cache.nixos.org / nix-community / `yasunori0418`）を追加。nput を直接 clone して `nix develop`/`build`/`flake check` する際のキャッシュ取得用。
- **`docs/adr/0028`**: 実装決定（main-push os マトリクス・tag push から変更・ci-matrix 不採用）を記録。ADR-0012 §4 を supersede せず補足。
- **`docs/design.md`**: 「キャッシュ投入（cachix push）」段落を追記。

## 留意点

- トリガを ADR-0012 §4 の **tag push → main push** に変更（最新 main を常時キャッシュ）。
- `flake.nix` の `nixConfig` は **flake input には伝播しない**ため、nput を input として消費する側のキャッシュ取得には効かない（CI は `cachix-action` が runner 側で substituter 設定するので別途ヒット）。
- `secrets.CACHIX_AUTH_TOKEN` 前提。push:main / workflow_dispatch 起動なので fork PR からは走らず token 不在問題は生じない。

issue #19 / 親 PRD #8 / ADR-0012 §4