### PR TITLE
feat(flake): nput output を flake-parts module 化し flakeModules.default を公開

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -68,6 +68,10 @@
       imports = [
         inputs.treefmt-nix.flakeModule
         inputs.nix-unit.modules.flake.default
+        # nput output を perSystem へ集約する flake-parts module（→ ADR-0029）。
+        # 循環参照回避のため、公開（flake.flakeModules.default）も import も同一パスを参照する。
+        # self.flakeModules.default 経由の self-import にはしない（ADR 決定4）。
+        ./modules/flake-parts.nix
       ];
       inherit systems;
       perSystem =
@@ -119,6 +123,22 @@
             meta = {
               description = "Place fetched git repositories at arbitrary paths via symlink or copy.";
               mainProgram = "nput";
+            };
+          };
+
+          # ドッグフーディング用の project mode config（→ Issue #7・AC e2e 経路・ADR-0029）。
+          # `nput apply default` で git toplevel 配下の .nput-example/docs に本 repo（self）の
+          # docs を store-symlink 配置する最小 example。flake-parts module（imports）が
+          # perSystem.nput.default を flake.nput.<system>.default へ転置する。pkgs は perSystem
+          # 由来になり packages.nput と一貫する（legacyPackages.${system} 直書きの二重解決が消える）。
+          # `nput.<system>.<name>` は標準 flake output ではないため `nix flake check` で
+          # `warning: unknown flake output 'nput'`（exit 0・想定内）が残る（→ docs/spec.md, ADR-0029 影響節）。
+          nput.default = nputLib.mkManifest {
+            inherit pkgs;
+            root = nputLib.projectRoot;
+            entries.".nput-example/docs" = {
+              src = inputs.self;
+              subpath = "docs";
             };
           };
 
@@ -258,21 +278,10 @@
           default = inputs.self.templates.project;
         };
 
-        # ドッグフーディング用の project mode config（→ Issue #7・AC e2e 経路）。
-        # `nput apply default` で git toplevel 配下の .nput-example/docs に
-        # 本 repo（self）の docs を store-symlink 配置する最小 example。
-        # `nput.<system>.<name>` は標準 flake output ではないため `nix flake check` で
-        # `warning: unknown flake output 'nput'`（exit 0・想定内）が出る（→ docs/spec.md）。
-        nput = inputs.nixpkgs.lib.genAttrs systems (system: {
-          default = nputLib.mkManifest {
-            pkgs = inputs.nixpkgs.legacyPackages.${system};
-            root = nputLib.projectRoot;
-            entries.".nput-example/docs" = {
-              src = inputs.self;
-              subpath = "docs";
-            };
-          };
-        });
+        # flake-parts module を consumer 向けに公開する（→ ADR-0029）。flake-parts を使う repo は
+        # `imports = [ inputs.nput.flakeModules.default ]` してから `perSystem.nput.<name> = ...` を書ける。
+        # 循環参照回避のため、公開も import（上の imports）も同一パスを参照する（ADR 決定4）。
+        flakeModules.default = ./modules/flake-parts.nix;
 
         # HM モジュール本体（modules/home-manager.nix）は engine をキックするのに pin 版 nput
         # CLI を要する。利用者システムの packages.nput を _module.args として注入する薄い

--- a/modules/flake-parts.nix
+++ b/modules/flake-parts.nix
@@ -1,0 +1,45 @@
+# flake-parts module: perSystem.nput.<name> を flake.nput.<system>.<name> へ転置する（→ ADR-0029）。
+# flake-parts 公式の mkTransposedPerSystemModule（packages / legacyPackages と同じ転置機構）を流用し、
+# 自前の mkPerSystemOption + transposition は手書きしない（ADR-0029 残作業1）。
+#
+# option は lazyAttrsOf package。consumer は perSystem で
+#   nput.<name> = inputs.nput.lib.mkManifest { inherit pkgs; root = ...; entries = { ... }; };
+# と書く。転置先 flake.nput.<system>.<name> は CLI が `nix build .#nput.<system>.<name>` で叩く
+# build 可能な derivation でなければならない（mkManifest の結果＝derivation を格納する・ADR 決定2）。
+#
+# module は純粋な transposition のみ。mkManifest やマーカー群を perSystem 引数に注入しない
+# （ADR 決定5）。consumer は同じ input の nput.lib を直接参照する。
+{ lib, flake-parts-lib, ... }:
+let
+  inherit (lib)
+    mkOption
+    types
+    ;
+  inherit (flake-parts-lib)
+    mkTransposedPerSystemModule
+    ;
+in
+mkTransposedPerSystemModule {
+  name = "nput";
+  option = mkOption {
+    type = types.lazyAttrsOf types.package;
+    default = { };
+    description = ''
+      nput の named manifest（`nput.lib.mkManifest` の結果＝derivation）を公開する属性集合（→ ADR-0007, ADR-0029）。
+
+      `perSystem.nput.<name>` に宣言すると top-level の `flake.nput.<system>.<name>` へ自動転置され、
+      CLI が `nix build .#nput.<system>.<name>` で叩く build 可能な derivation になる。
+
+      ```nix
+      perSystem = { pkgs, ... }: {
+        nput.default = inputs.nput.lib.mkManifest {
+          inherit pkgs;
+          root = inputs.nput.lib.projectRoot;
+          entries.".config/foo" = { src = inputs.foo; subpath = "."; };
+        };
+      };
+      ```
+    '';
+  };
+  file = ./flake-parts.nix;
+}


### PR DESCRIPTION
## 概要

dogfood 用 `nput.<system>.<name>` output を flake-parts のモジュールシステムに組み込む（→ Issue #26・ADR-0029）。

これまで top-level の `flake` ブロックで `genAttrs systems (system: ...)` を使い `inputs.nixpkgs.legacyPackages.${system}` を直書きして `mkManifest` の `pkgs` を組み立てていた。これを廃し、`perSystem.nput.default` に集約することで perSystem と同一の `pkgs` を使う（`packages.nput` と一貫・将来の overlay / config も追従）。

実装:

- `modules/flake-parts.nix` を新規追加。flake-parts 公式ヘルパー `mkTransposedPerSystemModule { name = "nput"; option = lazyAttrsOf package; file = ...; }` で `perSystem.nput.<name>` → `flake.nput.<system>.<name>` の純粋な transposition のみを行う（mkManifest / マーカーは perSystem 引数に注入しない・ADR 決定5）。
- `flake.nix` の `imports` に `./modules/flake-parts.nix` を追加し、dogfood 定義を `perSystem.nput.default = nputLib.mkManifest { inherit pkgs; ... }` へ移行。top-level `flake.nput` 直書きを削除。
- `flake.flakeModules.default = ./modules/flake-parts.nix;` を公開。consumer（flake-parts 利用者）が `imports = [ inputs.nput.flakeModules.default ]` してから `perSystem.nput.<name>` を書ける。循環参照回避のため公開も import も同一パス参照（`self.flakeModules.default` 経由にはしない・ADR 決定4）。

本 PR で解消するのは **「pkgs 二重解決」** と **「dogfood 定義の perSystem 集約」** の 2 点のみ。`nix flake check` の `warning: unknown flake output 'nput'` は nix 本体が known-output を hardcode しているため transposition しても残る（exit 0・無害・ADR-0029 影響節 / ADR-0015）。warning 除去は upstream flake-schemas 待ちの別件。

## 関連 issue

Closes #26 / Refs ADR-0029

## docs / ADR 影響

なし（design.md・spec.md・ADR-0029 は既存 PR で更新済み。本 PR は実装のみで docs は触らない）。

## 動作確認

- `nix flake check` → exit 0（`warning: unknown flake output 'nput'` は想定どおり残存）。
- `nix build .#nput.aarch64-darwin.default` → 転置先 derivation のビルド成功（`/nix/store/...-nput-manifest`）。
- consumer 視点: 別 flake-parts eval で `imports = [ flakeModules.default ]` + `perSystem.nput.default = pkgs.hello` → `flake.nput.<system>.default` へ正しく transpose されることを確認。
