### PR TITLE
docs: add English glossary

### DIFF
--- a/docs/glossary.ja.md
+++ b/docs/glossary.ja.md
@@ -1,0 +1,105 @@
+# 用語集（日本語版）
+
+nput の正準（canonical）英語用語を日本語で対訳したもの。README・コードコメント・コマンド出力で概念に言及するときは、ここで定義した **canonical 用語**（見出しの英語表記）を使い、列挙した別名を避けて、プロジェクト全体で表記をそろえる。正準の綴り自体は英語版 `docs/glossary.md` が一次（authoritative）の参照先。
+
+各エントリは canonical な綴りを 1 つ固定する。定義は意図的に短い。詳細な根拠は `docs/spec.md`（仕様書）と `docs/adr/`（設計判断）を参照する。英語版（一次）は `docs/glossary.md` にある。
+
+## 配置の中心抽象
+
+### placement primitive
+nput のコア。`root` 相対の `target` に Nix store のパスを配置する純粋関数。モジュール抽象の裏に隠さず、ユーザーが直接合成して使う。
+- **Avoid**: 「placement framework（配置フレームワーク）」「configuration management（設定管理）」（nput は設定を生成しない）。
+
+### engine
+配置（ネイティブなファイルシステム操作）と stale 除去の両方を一手に所有する配置コア。`manifest.json` を入力に取り、`nix`（profile）と `git`（toplevel）のみを叩く。**nput CLI** が駆動する Go ライブラリとして実装される。config ごとに bash スクリプトを生成しない。ここでの「ライブラリ」は `internal/` 配下のバイナリ内部の層分離を指し、公開 import 可能な再利用モジュールではない——安定面は `manifest.json` 契約に閉じる。エンジンは stdlib-only。
+- **Avoid**: 「per-config generated bash script（config ごとに生成される bash スクリプト）」「per-layer placement logic（層ごとの配置ロジック）」「a single flat implementation fused with the CLI（CLI と一体の平らな単一実装）」「importing the engine as a public Go module（engine を公開 Go モジュールとして import する）」。
+
+### nput CLI
+ユーザーが直接触れる一次 UX。`PATH` 上の `packages.nput` バイナリ。**entrypoint** を発見し、内部で `nix build` / `eval` を回して named manifest を取得し、エンジンに配置させる。サブコマンドは `apply [<name>]`・`apply --all`・`rollback`・`list-generations`・`gitignore`・`init`。
+- **Avoid**: config ごとの `nix run .#x` ラッパーを一次 UX と説明すること、`apply` を「常に entrypoint を build する」と説明すること（ビルド済み link-farm は `--manifest` で適用できる）。
+
+### entrypoint
+nput CLI が読む Nix の config ファイル。`flake.nix` / `shell.nix` / `default.nix` のいずれか。`nput.<name>` に named manifest を公開する。config は依然として Nix で書かれ、`nix build` で評価される。
+- **Avoid**: 「nput が CWD から config の内容を発見する」と説明すること——発見するのは entrypoint *ファイル* であり、config は Nix 評価で確定する。
+
+### module
+standalone・home-manager・将来の NixOS モジュール・devShell の `shellHook` といった統合層。エンジンを起動する配線（wiring）に徹し、自身ではファイルを配置せず、`home.file` や `systemd.tmpfiles` へ翻訳することもない。
+- **Avoid**: 「the module places files（モジュールがファイルを配置する）」「the module translates to native mechanisms（モジュールがネイティブ機構へ翻訳する）」。
+
+## 配置の入出力
+
+### entry / entries
+配置定義。`entries` は **target** をキーとする attrset で、各値が entry（`{ src; subpath?; target?; method?; }`）。属性キーが識別子であり、既定の `target` を与える。手動の `name` フィールドは持たない。識別子の一意性は Nix の attrset キーで native に担保される。
+- **Avoid**: 「file entry（ファイルエントリ）」（配置元はディレクトリのこともある）、entry に `name` フィールドを持たせること、`entries` を `{ name; … }` のリストと呼ぶこと（旧形）。
+
+### src
+**entry** の配置元（どの store パス / リポジトリか）。デフォルトは Nix ストアへの **store link**。out-of-store は明示マーカーで opt-in する。**subpath** とは直交する別概念であり、`src` を `source` の短縮形と読まない。
+- **Avoid**: **subpath** と混同すること、`source` と呼ぶこと。
+
+### subpath
+**entry** で **src** 内のどのパスを取り出すかを選ぶ相対パス。file / dir 両対応。デフォルト `"."`。リポジトリ全体を選ぶ canonical な方法は **subpath を省略**すること（`subpath = "."` は明示形）。
+- **Avoid**: 旧名 `source` / `dir` を使うこと、**src** と混同すること、「全体を表すには専用のトークン / marker が要る」と考えること（省略で表せる）。
+
+### target
+**entry** の配置先。**root** からの相対パスで指定する。`entries` の属性キーが既定の `target` であり、entry の identity（stale 除去の diff キーであり、一意性のキー）でもある。
+
+### root
+配置の基準パス。公開 API の `root` 引数で**明示的に**選ぶ（**暗黙のデフォルトは持たない**）。型は `string`（絶対パス・評価時に固定）と `marker`（実行時に解決）の union。マーカーは **projectRoot** / **homeRoot** / **systemRoot**。
+- **Avoid**: 「`$HOME` is fixed（`$HOME` 固定）」「defaults to home mode（既定は home mode）」「the default when `root` is omitted（`root` 省略時の既定）」と説明すること、マーカーを「パス文字列を返す糖衣（sugar）」と説明すること（実行時解決の種別であって、評価時にパスへ展開しない）。
+
+## 配置モード
+
+### home mode
+**root** = `$HOME` の配置モード。`homeRoot` マーカーで明示選択する。standalone も home-manager 等の module もこのモードを使う。世代を毎回コミットし、`--rollback` をユーザーに公開する。
+- **Avoid**: 「standalone-only（standalone 専用）」「the default when `root` is omitted（`root` 省略時の既定）」と説明すること。
+
+### project mode
+**root** = プロジェクトルートの配置モード。`projectRoot` マーカーで選ぶ。配置物は **ephemeral placement**（コミットしない）であり、世代・rollback はユーザーに公開しない。root は git toplevel に解決される。
+- **Avoid**: 「relative to CWD（CWD 相対）」「relative to the config file（設定ファイル相対）」と説明すること。
+
+### system mode
+**root** = `/` の配置モード。`systemRoot` マーカーで選ぶ。distro 構想（root = `/`）に使う。
+
+### projectRoot
+**project mode** を選ぶ root マーカー。実行時に git toplevel を **root** に解決する（`--root` で上書き可）。`homeRoot` / `systemRoot` と並ぶ root マーカーの一つで、`mkOutOfStoreSymlink` と同じ「マーカーを渡して挙動を opt-in する」パターンに従う。
+- **Avoid**: 設定ファイルの場所を指すと解釈すること。
+
+### homeRoot
+**home mode** を選ぶ root マーカー。実行時に `$HOME` を **root** に解決する。従来は暗黙だった `$HOME` の既定を明示マーカーへ昇格したもの。
+
+### systemRoot
+**system mode**（root = `/`）を選ぶ root マーカー。ADR-0004 が「将来の絶対パス文字列 seam」と呼んでいたものを第一級のマーカーへ昇格したもの。
+
+### ephemeral placement
+**project mode** における配置物の性質。クローンごとに再生成される前提で、プロジェクトにコミットされない。ゆえに activation は git 状態に干渉しない。
+- **Avoid**: 「vendoring」や「成果物をコミットする配置」と混同すること。
+
+## 配置の種別
+
+### store link
+コア・デフォルトの配置。配置先が Nix store パスである symlink。再現性を担保するデフォルト経路。「unification（統一）」とは、ストアをデフォルト / コアにし、out-of-store を明示的な例外へ降格することを意味する。
+- **Avoid**: out-of-store symlink と混同すること、「copy（コピー）」と呼ぶこと。
+
+### out-of-store symlink
+ローカルの絶対パスへのライブ symlink。`nput.lib.mkOutOfStoreSymlink "/abs/path"` でのみ opt-in する（開発中の dotfiles をライブ編集する用途）。明示的な退避路（escape hatch）であり、第一級機能ではない。
+- **Avoid**: デフォルト挙動として扱うこと、`src` の型による暗黙の分岐で生み出すこと。
+
+## 状態管理
+
+### generation
+rollback の単位。nput 自身の Nix profile（`nix-env --profile <dir>` 式）に乗せて管理する。コミット（`--set`）・rollback・任意世代への切替・一覧・間引きはすべて `nix-env --profile <dir>` 系で統一され、store GC のみ `nix-collect-garbage` を使う。
+- **Avoid**: 「stateless スクリプト」前提で語ること（初期方針からは覆っている）、新 `nix profile` CLI で管理すること（profile-manifest を要求し、`nix-env --set` 製の profile では動かない）。
+
+### store manifest
+「nput が何を配置したか」を記録する世代由来のデータ。実体は link-farm derivation 内の `manifest.json`（`schemaVersion` を持つ）で、Nix（`lib.mkManifest`）が生成し Go エンジンが読む——Nix↔Go の契約。エンジンの保守的な stale 除去（記録通りを指す nput 管理 symlink だけを削除し、ユーザーの実ファイルには決して触れない）を支える。
+
+### method
+配置の種別を選ぶ entry のフィールド（旧名 `mode` からの改名）。unix の file mode との誤読を避けるために改名した。
+- **Avoid**: 旧名 `mode`。
+
+## Flagged ambiguities
+
+- **「symlink」単独では曖昧**。必ず **store link** か **out-of-store symlink** のどちらかに寄せる。デフォルトの store link 自体も symlink として実現されるため、裸の語では種別を識別できない。
+- **「unification（統一）」は「removal（廃止）」ではない**。store link の統一は out-of-store を削除しない。デフォルトから降格し、明示的な関数の裏に隔離するだけ。
+- **`src` と `subpath` は別概念**。`src` = どの物（store パス / リポジトリ）、`subpath` = その中のどのパス。名前は似ているが直交する概念。旧名 `source`（= 現在の `subpath`）は使わない。
+- **「standalone」は配置モードではなく起動形態**。standalone（CLI を直接叩くこと）は配置モード（home / project / system）と直交する。モードは `root` マーカーが決める。

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,0 +1,105 @@
+# Glossary
+
+Canonical English terms for nput. This is the authoritative spelling reference for README text, code comments, and command output. When a concept appears in prose or output, use the **canonical term** defined here and avoid the listed alternatives so wording stays consistent across the project.
+
+Each entry fixes one canonical spelling. Definitions are intentionally short; for full rationale see `docs/spec.md` (specification) and `docs/adr/` (design decisions). The Japanese-language counterpart lives in `CONTEXT.md`.
+
+## Core placement abstraction
+
+### placement primitive
+The core of nput: a pure function that places a Nix store path at a `root`-relative `target`. It is not hidden behind a module abstraction — users compose it directly.
+- **Avoid**: "placement framework", "configuration management" (nput does not generate configuration).
+
+### engine
+The placement core that owns both placement (native filesystem operations) and stale removal. It takes `manifest.json` as input, invokes only `nix` (profile) and `git` (toplevel), and is implemented as a Go library driven by the **nput CLI**. It does not generate a bash script per config. "Library" here means internal in-binary layering under `internal/`, not a publicly importable, reusable module — the stable surface is the `manifest.json` contract. The engine is stdlib-only.
+- **Avoid**: "per-config generated bash script", "per-layer placement logic", "a single flat implementation fused with the CLI", "importing the engine as a public Go module".
+
+### nput CLI
+The primary user-facing UX; the `packages.nput` binary on `PATH`. It discovers an **entrypoint**, runs `nix build` / `eval` internally to obtain a named manifest, and has the engine place it. Subcommands include `apply [<name>]`, `apply --all`, `rollback`, `list-generations`, `gitignore`, and `init`.
+- **Avoid**: describing a per-config `nix run .#x` wrapper as the primary UX; describing `apply` as "always builds the entrypoint" (a built link-farm can be applied with `--manifest`).
+
+### entrypoint
+The Nix config file the nput CLI reads: one of `flake.nix`, `shell.nix`, or `default.nix`. It exposes a named manifest under `nput.<name>`. The config is still written in Nix and evaluated by `nix build`.
+- **Avoid**: saying "nput discovers the config contents from the CWD" — it discovers the entrypoint *file*; the config is fixed by Nix evaluation.
+
+### module
+An integration layer such as standalone, home-manager, a future NixOS module, or a devShell `shellHook`. It is purely the wiring that kicks the engine; it never places files itself and never translates to `home.file` or `systemd.tmpfiles`.
+- **Avoid**: "the module places files", "the module translates to native mechanisms".
+
+## Placement input and output
+
+### entry / entries
+A placement definition. `entries` is an attrset keyed by `target`, where each value is an entry (`{ src; subpath?; target?; method?; }`). The attribute key is the identifier and supplies the default `target`. There is no manual `name` field; key uniqueness is guaranteed natively by Nix attrset keys.
+- **Avoid**: "file entry" (the source may be a directory); giving an entry a `name` field; calling `entries` a list of `{ name; … }` (the old form).
+
+### src
+The placement source of an **entry** (which store path or repository). The default is a **store link** into the Nix store; out-of-store is opt-in via an explicit marker. It is orthogonal to **subpath**; do not read `src` as an abbreviation of `source`.
+- **Avoid**: confusing it with **subpath**; calling it `source`.
+
+### subpath
+The relative path selecting which path inside **src** to take, for an **entry**. Works for both files and directories; default `"."`. Omitting `subpath` is the canonical way to select the whole repository (`subpath = "."` is the explicit form).
+- **Avoid**: the old names `source` / `dir`; confusing it with **src**; assuming a dedicated token/marker is needed for "whole repo" (omission expresses it).
+
+### target
+The placement destination of an **entry**, specified as a path relative to **root**. The `entries` attribute key is the default `target` and is also the entry's identity (the diff key for stale removal, and its uniqueness key).
+
+### root
+The base path for placement. Chosen explicitly via the `root` argument of the public API (there is **no implicit default**). Its type is a union of `string` (absolute path, fixed at evaluation time) and `marker` (resolved at runtime). The markers are **projectRoot**, **homeRoot**, and **systemRoot**.
+- **Avoid**: "`$HOME` is fixed", "defaults to home mode", "the default when `root` is omitted"; describing a marker as "sugar that returns a path string" (it is a runtime-resolution kind, not expanded to a path at evaluation time).
+
+## Placement modes
+
+### home mode
+The placement mode where **root** = `$HOME`, selected explicitly with the `homeRoot` marker. Used by both standalone and modules such as home-manager. It commits a generation each time and exposes `--rollback` to the user.
+- **Avoid**: "standalone-only", "the default when `root` is omitted".
+
+### project mode
+The placement mode where **root** = the project root, selected with the `projectRoot` marker. Its placements are **ephemeral placement** (not committed); generations and rollback are not exposed to the user. The root resolves to the git toplevel.
+- **Avoid**: "relative to CWD", "relative to the config file".
+
+### system mode
+The placement mode where **root** = `/`, selected with the `systemRoot` marker. Used for the distro concept (root = `/`).
+
+### projectRoot
+The root marker selecting **project mode**. At runtime it resolves the git toplevel as **root** (overridable with `--root`). One of the root markers alongside `homeRoot` / `systemRoot`, following the same "pass a marker to opt into behavior" pattern as `mkOutOfStoreSymlink`.
+- **Avoid**: interpreting it as pointing to the config file location.
+
+### homeRoot
+The root marker selecting **home mode**. At runtime it resolves `$HOME` as **root**. It promotes the previously implicit `$HOME` default into an explicit marker.
+
+### systemRoot
+The root marker selecting **system mode** (root = `/`). Promotes what ADR-0004 called a "future absolute-path string seam" into a first-class marker.
+
+### ephemeral placement
+The nature of placements in **project mode**: regenerated on each clone and never committed to the project, so activation never touches git state.
+- **Avoid**: confusing it with "vendoring" or "placement that commits artifacts".
+
+## Placement kinds
+
+### store link
+The core, default placement: a symlink whose destination is a Nix store path. The default path that guarantees reproducibility. "Unification" means making the store the default/core and demoting out-of-store to an explicit exception.
+- **Avoid**: confusing it with out-of-store symlink; calling it a "copy".
+
+### out-of-store symlink
+A live symlink to a local absolute path, opted into only via `nput.lib.mkOutOfStoreSymlink "/abs/path"` (for live editing of dotfiles under development). An explicit escape hatch, not a first-class feature.
+- **Avoid**: treating it as default behavior; producing it via implicit branching on the type of `src`.
+
+## State management
+
+### generation
+The unit of rollback, managed on nput's own Nix profile (the `nix-env --profile <dir>` style). Commit (`--set`), rollback, switching to an arbitrary generation, listing, and pruning are all unified under the `nix-env --profile <dir>` family; only store GC uses `nix-collect-garbage`.
+- **Avoid**: narrating it under a "stateless script" premise (reversed since the initial direction); managing it with the new `nix profile` CLI (which requires a profile-manifest and does not work on `nix-env --set` profiles).
+
+### store manifest
+The generation-derived record of "what nput placed". Concretely the `manifest.json` (carrying a `schemaVersion`) inside the link-farm derivation, generated by Nix (`lib.mkManifest`) and read by the Go engine — the Nix↔Go contract. It underpins the engine's conservative stale removal (it deletes only nput-managed symlinks that point where the record says, and never touches the user's real files).
+
+### method
+The entry field that selects the placement kind (renamed from the old `mode`). Renamed to avoid misreading it as a unix file mode.
+- **Avoid**: the old name `mode`.
+
+## Flagged ambiguities
+
+- **"symlink" alone is ambiguous.** Always disambiguate to either **store link** or **out-of-store symlink**. The default store link is itself realized as a symlink, so the bare word does not identify the kind.
+- **"unification" is not "removal".** Store-link unification does not delete out-of-store; it demotes it from the default and isolates it behind an explicit function.
+- **`src` and `subpath` are distinct.** `src` = which thing (store path / repository); `subpath` = which path inside it. Similar names, orthogonal concepts. Do not use the old name `source` (= today's `subpath`).
+- **"standalone" is a launch form, not a placement mode.** Standalone (invoking the CLI directly) is orthogonal to placement mode (home / project / system); the mode is decided by the `root` marker.

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -2,7 +2,7 @@
 
 Canonical English terms for nput. This is the authoritative spelling reference for README text, code comments, and command output. When a concept appears in prose or output, use the **canonical term** defined here and avoid the listed alternatives so wording stays consistent across the project.
 
-Each entry fixes one canonical spelling. Definitions are intentionally short; for full rationale see `docs/spec.md` (specification) and `docs/adr/` (design decisions). The Japanese-language counterpart lives in `CONTEXT.md`.
+Each entry fixes one canonical spelling. Definitions are intentionally short; for full rationale see `docs/spec.md` (specification) and `docs/adr/` (design decisions). The Japanese-language counterpart lives in `docs/glossary.ja.md`.
 
 ## Core placement abstraction
 


### PR DESCRIPTION
## 概要

README / コメント / 出力の表記基準となる canonical 英語用語集 `docs/glossary.md` を新規追加する。CONTEXT.md の括弧英語訳から canonical 用語を抽出し、各語に簡潔な英語定義と正規表記（1 語に固定）、避けるべき同義語を付けた。表記揺れの防止が目的。

主要語を網羅: placement primitive / engine / nput CLI / entrypoint / module / entry・entries / src / subpath / target / root / home・project・system mode / projectRoot・homeRoot・systemRoot / ephemeral placement / store link / out-of-store symlink / generation / store manifest / method。

英語版と同じ用語網羅・同構造の日本語対訳版 `docs/glossary.ja.md` を追加し、両ファイルを相互リンクした（canonical 英語用語は見出しに残し、定義・Avoid を日本語化）。

## 関連 issue

Closes #55

## docs / ADR 影響

- concept / design / spec: 更新なし（新規 glossary の追加のみ）
- ADR: 追加なし（既存 ADR の方針を英語表記基準として固定するもので、新たな方針転換は含まない）
- CONTEXT.md は読み取り専用として変更していない