### PR TITLE
docs: translate source comments to English (godoc form)

### DIFF
--- a/cmd/nput/apply.go
+++ b/cmd/nput/apply.go
@@ -13,7 +13,7 @@ import (
 	"github.com/yasunori0418/nput/internal/manifest"
 )
 
-var flagApplyAll bool // --all: nput.* を辞書順に全適用（root filter で絞り込み可）
+var flagApplyAll bool // --all: apply all of nput.* in lexical order (narrowable by root filter)
 
 func newApplyCmd() *cobra.Command {
 	cmd := &cobra.Command{
@@ -50,10 +50,10 @@ func newApplyCmd() *cobra.Command {
 	return cmd
 }
 
-// runApplyManifest は --manifest で渡されたビルド済み link-farm を engine へ直接適用する
-// （module activation 経路）。entrypoint 発見・rootKind 先取り eval・nix build は行わず、
-// rootKind は manifest.json から engine が読む（HM モジュールは homeRoot を pin するため home）。
-// engine.Apply の Build=nil 経路（既ビルド済み LinkFarm）を CLI から駆動する（→ engine.Options）。
+// runApplyManifest applies the pre-built link-farm passed via --manifest directly to the engine
+// (the module activation path). It does no entrypoint discovery, no rootKind pre-resolution eval,
+// and no nix build; the engine reads rootKind from manifest.json (an HM module pins homeRoot, so home).
+// It drives engine.Apply's Build=nil path (a pre-built LinkFarm) from the CLI (→ engine.Options).
 func runApplyManifest(name string) error {
 	linkFarm, err := filepath.Abs(flagManifest)
 	if err != nil {
@@ -83,14 +83,14 @@ func runApplyManifest(name string) error {
 	return nil
 }
 
-// runApply は docs/spec.md「実行フロー」を駆動する:
-// entrypoint 発見 → rootKind 先取り eval → engine.Apply（flock → ロック内 build → 配置 → --set → .pending 削除）。
-// --manifest 指定時は entrypoint 発見・nix eval/build を行わず、ビルド済み link-farm を engine へ直接渡す
-// （module activation 経路・→ docs/spec.md「モジュール別動作仕様」・ADR-0003, ADR-0007）。
+// runApply drives the "execution flow" in docs/spec.md:
+// entrypoint discovery → rootKind pre-resolution eval → engine.Apply (flock → in-lock build → place → --set → remove .pending).
+// When --manifest is given it does no entrypoint discovery and no nix eval/build, passing the pre-built link-farm
+// directly to the engine (the module activation path; → docs/spec.md "per-module behavior spec", ADR-0003, ADR-0007).
 func runApply(name string) error {
 	if flagManifest != "" {
-		// --manifest は取得元を link-farm に固定するため、entrypoint 発見系フラグとは
-		// 意味が衝突する（位置引数 name は profile 選択として直交し両立する・→ ADR-0026）。
+		// --manifest fixes the source to a link-farm, so it conflicts in meaning with the
+		// entrypoint discovery flags (the positional name is orthogonal as a profile selector and coexists; → ADR-0026).
 		if flagFile != "" {
 			return errors.New("nput: --manifest cannot be combined with -f (--manifest fixes the source to a pre-built link-farm)")
 		}
@@ -106,13 +106,13 @@ func runApply(name string) error {
 		return err
 	}
 
-	// 1. rootKind を build 前に先取りする（profileDir 確定 → flock → build の順を成立させる・→ ADR-0023）。
+	// 1. Pre-resolve rootKind before build (to establish the order profileDir resolution → flock → build; → ADR-0023).
 	rootKind, fixedRoot, err := evalRoot(ep, system, name)
 	if err != nil {
 		return err
 	}
 
-	// 1.5 --dryrun は副作用ゼロのプレビュー（flock / pending gcroot を取らず build だけ read-only で回す・→ ADR-0023）。
+	// 1.5 --dryrun is a side-effect-free preview (takes no flock / pending gcroot; runs only build read-only; → ADR-0023).
 	if flagDryrun {
 		res, err := engine.Apply(engine.Options{
 			Name:         name,
@@ -127,18 +127,18 @@ func runApply(name string) error {
 			return err
 		}
 		printApplyPlan(res)
-		// conflict があれば exit 2（CI の事前 gate・→ docs/spec.md 終了コード表）。
+		// exit 2 if there are conflicts (a pre-gate for CI; → docs/spec.md exit code table).
 		if len(res.Conflicts) > 0 {
 			return &exitError{code: 2}
 		}
 		return nil
 	}
 
-	// 2. engine を駆動する（flock 取得・ロック内 build・配置・コミット・.pending 削除は engine が所有）。
+	// 2. Drive the engine (flock acquisition, in-lock build, placement, commit, and .pending removal are owned by the engine).
 	res, err := applyOne(ep, system, name, rootKind, fixedRoot)
 	if err != nil {
 		if errors.Is(err, engine.ErrSkipped) {
-			// try-lock skip は正常スキップ（exit 0・→ docs/spec.md 終了コード表）。
+			// A try-lock skip is a normal skip (exit 0; → docs/spec.md exit code table).
 			if flagVerbose {
 				fmt.Fprintln(os.Stderr, "nput: skipped because another apply is in progress (run nput apply manually)")
 			}
@@ -153,9 +153,9 @@ func runApply(name string) error {
 	return nil
 }
 
-// printApplyPlan は apply --dryrun のプランを stdout に出す（機械可読出力を専有・1 行 1 アクション・
-// → docs/spec.md ストリーム規律・ADR-0023, ADR-0024）。成功時沈黙でも抑制しない（stdout 専有原則・→ ADR-0031）。
-// conflict 行も plan の一部として stdout に載せ、終了コード（exit 2）が機械判別を補う。
+// printApplyPlan prints the apply --dryrun plan to stdout (it owns the machine-readable output; one action per line;
+// → docs/spec.md stream discipline, ADR-0023, ADR-0024). It is not suppressed even under silent-on-success (the stdout-ownership principle; → ADR-0031).
+// conflict lines are also put on stdout as part of the plan, with the exit code (exit 2) complementing machine discrimination.
 func printApplyPlan(res *engine.Result) {
 	for _, t := range res.Placed {
 		fmt.Printf("place\t%s\n", t)
@@ -174,8 +174,8 @@ func printApplyPlan(res *engine.Result) {
 	}
 }
 
-// applyOne は 1 config に engine.Apply を回す（runApply / runApplyAll が共有）。rootKind / fixedRoot は
-// 単体は evalRoot 先取り、--all は一括 eval（evalAllRoots）から渡す。build だけは config ごとに行う。
+// applyOne runs engine.Apply for one config (shared by runApply / runApplyAll). rootKind / fixedRoot
+// come from evalRoot pre-resolution for the single case and from the batch eval (evalAllRoots) for --all. Only build is done per config.
 func applyOne(ep *entrypoint, system, name, rootKind, fixedRoot string) (*engine.Result, error) {
 	return engine.Apply(engine.Options{
 		Name:         name,
@@ -188,9 +188,9 @@ func applyOne(ep *entrypoint, system, name, rootKind, fixedRoot string) (*engine
 	})
 }
 
-// runApplyAll は entrypoint の nput.* を辞書順に全適用する（→ docs/spec.md 実行フロー・ADR-0016, ADR-0024）。
-// rootKind は 1 回の一括 eval で取り（プロセス起動を N→1）、build は atomic 性のため config ごと。
-// 一部失敗しても残りを続行し、最後に集約表示・1 つでも失敗なら非ゼロ終了する。
+// runApplyAll applies all of the entrypoint's nput.* in lexical order (→ docs/spec.md execution flow, ADR-0016, ADR-0024).
+// rootKind is taken in a single batch eval (collapsing process launches N→1); build is per config for atomicity.
+// It continues with the rest on a partial failure, shows an aggregate at the end, and exits non-zero if any one fails.
 func runApplyAll() error {
 	filter, err := selectedRootFilter()
 	if err != nil {
@@ -205,13 +205,13 @@ func runApplyAll() error {
 		return err
 	}
 
-	// 1. rootKind を 1 回の一括 eval で取得する（config 名→rootInfo マップ・→ ADR-0024）。
+	// 1. Get rootKind in a single batch eval (config name → rootInfo map; → ADR-0024).
 	roots, err := evalAllRoots(ep, system)
 	if err != nil {
 		return err
 	}
 
-	// 2. 辞書順に並べ、root filter（--project-root 等）が指定されていれば該当モードだけに絞る。
+	// 2. Sort lexically and, if a root filter (--project-root etc.) is given, narrow to that mode only.
 	names := make([]string, 0, len(roots))
 	for name := range roots {
 		names = append(names, name)
@@ -230,14 +230,14 @@ func runApplyAll() error {
 		return nil
 	}
 
-	// 2.5 --dryrun は副作用ゼロのプレビュー（flock / --set / pending gcroot を取らず build だけ
-	//     read-only で回す）。選んだ各 config の plan を stdout へ集約し、終了コードは
-	//     error(1) > conflict(2) > 0 の優先で決める（→ docs/spec.md・ADR-0024）。
+	// 2.5 --dryrun is a side-effect-free preview (takes no flock / --set / pending gcroot; runs only build
+	//     read-only). It aggregates each selected config's plan to stdout and decides the exit code by
+	//     priority error(1) > conflict(2) > 0 (→ docs/spec.md, ADR-0024).
 	if flagDryrun {
 		return runApplyAllDryRun(ep, system, selected, roots)
 	}
 
-	// 3. 各 config を独立に適用する。一部失敗しても続行し、失敗を集約する（各 config は独立 atomic）。
+	// 3. Apply each config independently. Continue on partial failure and aggregate failures (each config is independently atomic).
 	var failures, skipped, applied int
 	for _, name := range selected {
 		ri := roots[name]
@@ -251,7 +251,7 @@ func runApplyAll() error {
 				continue
 			}
 			failures++
-			// 部分失敗は握り潰さず stderr に出して続行する（→ docs/spec.md「一部失敗しても続行」）。
+			// Do not swallow partial failures; print to stderr and continue (→ docs/spec.md "continue on partial failure").
 			fmt.Fprintf(os.Stderr, "nput: apply %s failed: %v\n", name, err)
 			continue
 		}
@@ -261,12 +261,12 @@ func runApplyAll() error {
 		}
 	}
 
-	// 4. 集約表示と終了コード（error(1) > conflict(2) > 0 の優先・→ docs/spec.md・ADR-0024）。
+	// 4. Aggregate report and exit code (priority error(1) > conflict(2) > 0; → docs/spec.md, ADR-0024).
 	if flagVerbose {
 		fmt.Fprintf(os.Stderr, "nput: apply --all done (applied %d / skipped %d / failed %d / selected %d)\n",
 			applied, skipped, failures, len(selected))
 	}
-	// conflict(2) は --dryrun（#13）の読み取り専用経路でのみ生じる。非 dryrun の --all は error/0 のみ。
+	// conflict(2) arises only on the --dryrun (#13) read-only path. Non-dryrun --all yields only error/0.
 	code := applyAllExitCode(failures > 0, false)
 	if code == 0 {
 		return nil
@@ -274,10 +274,10 @@ func runApplyAll() error {
 	return &exitCodeError{code: code, msg: fmt.Sprintf("nput: apply --all: %d config(s) failed", failures)}
 }
 
-// runApplyAllDryRun は apply --all --dryrun を駆動する。選んだ各 config を読み取り専用で build し
-// plan を stdout へ集約出力する（FS 書込・flock・--set・pending gcroot いずれも取らない・→ ADR-0023）。
-// 終了コードは error(1) > conflict(2) > 0 の優先（→ docs/spec.md・ADR-0024）で決め、empty msg の
-// exitError で運ぶ（単体 apply --dryrun の conflict=2 と対称・main は code だけで終了する）。
+// runApplyAllDryRun drives apply --all --dryrun. It builds each selected config read-only and
+// aggregates the plan to stdout (taking none of FS writes / flock / --set / pending gcroot; → ADR-0023).
+// It decides the exit code by priority error(1) > conflict(2) > 0 (→ docs/spec.md, ADR-0024) and carries it in an
+// empty-msg exitError (symmetric with the single apply --dryrun conflict=2; main exits with the code alone).
 func runApplyAllDryRun(ep *entrypoint, system string, selected []string, roots map[string]rootInfo) error {
 	code := aggregateDryRun(selected, func(name string) (*engine.Result, error) {
 		ri := roots[name]
@@ -297,16 +297,16 @@ func runApplyAllDryRun(ep *entrypoint, system string, selected []string, roots m
 	return &exitError{code: code}
 }
 
-// aggregateDryRun は selected 各 config を applyDry で読み取り専用に回し、plan を stdout へ出して
-// error / conflict を集約し終了コードを返す（apply 実体を注入してテスト可能にする seam）。
-// 一部 config の build / eval 失敗（error）は握り潰さず stderr に出して続行し、最終コードへ反映する。
+// aggregateDryRun runs each selected config read-only via applyDry, prints the plan to stdout,
+// aggregates error / conflict, and returns the exit code (a seam that injects the apply implementation for testability).
+// It does not swallow a config's build / eval failure (error); it prints to stderr, continues, and reflects it in the final code.
 func aggregateDryRun(selected []string, applyDry func(name string) (*engine.Result, error)) int {
 	var anyError, anyConflict bool
 	for _, name := range selected {
 		res, err := applyDry(name)
 		if err != nil {
 			anyError = true
-			// 部分失敗は握り潰さず stderr に出して続行する（→ docs/spec.md「一部失敗しても続行」）。
+			// Do not swallow partial failures; print to stderr and continue (→ docs/spec.md "continue on partial failure").
 			fmt.Fprintf(os.Stderr, "nput: apply %s --dryrun failed: %v\n", name, err)
 			continue
 		}
@@ -318,9 +318,9 @@ func aggregateDryRun(selected []string, applyDry func(name string) (*engine.Resu
 	return applyAllExitCode(anyError, anyConflict)
 }
 
-// applyAllExitCode は apply --all の終了コードを priority error(1) > conflict(2) > 0 で決める
-// （→ docs/spec.md「出力ストリームと終了コード」・ADR-0024）。単純な最大値（2 > 1）は採らない
-// （conflict が深刻な eval / engine error を CI で隠すため）。conflict は --dryrun 経路でのみ生じる。
+// applyAllExitCode decides apply --all's exit code by priority error(1) > conflict(2) > 0
+// (→ docs/spec.md "output streams and exit codes", ADR-0024). It does not take the plain maximum (2 > 1)
+// (because a conflict would hide serious eval / engine errors in CI). conflict arises only on the --dryrun path.
 func applyAllExitCode(anyError, anyConflict bool) int {
 	switch {
 	case anyError:
@@ -332,8 +332,8 @@ func applyAllExitCode(anyError, anyConflict bool) int {
 	}
 }
 
-// selectedRootFilter は --project-root / --home-root / --system-root から root モードフィルタを返す
-// （未指定は ""・複数指定はエラー・→ ADR-0017）。返り値は manifest.RootKind* 文字列。
+// selectedRootFilter returns the root mode filter from --project-root / --home-root / --system-root
+// (none gives ""; specifying more than one is an error; → ADR-0017). The return value is a manifest.RootKind* string.
 func selectedRootFilter() (string, error) {
 	var modes []string
 	if flagProjectRoot {
@@ -354,8 +354,8 @@ func selectedRootFilter() (string, error) {
 	return modes[0], nil
 }
 
-// ensureNoRootFilter は root filter が --all 以外で使われたときにエラーにする
-// （フィルタは --all の修飾で、名指し apply では <name> が 1 config を pin するため無意味・→ ADR-0017）。
+// ensureNoRootFilter errors when a root filter is used outside --all
+// (the filter is a modifier for --all; in a named apply <name> pins a single config, so it is meaningless; → ADR-0017).
 func ensureNoRootFilter(modifier string) error {
 	if flagProjectRoot || flagHomeRoot || flagSystemRoot {
 		return fmt.Errorf("nput: --project-root / --home-root / --system-root are modifiers for %s", modifier)
@@ -363,7 +363,7 @@ func ensureNoRootFilter(modifier string) error {
 	return nil
 }
 
-// reportResult は配置レポートを stderr に出す（stdout は機械可読出力に専有・→ ADR-0023）。
+// reportResult prints the placement report to stderr (stdout is reserved for machine-readable output; → ADR-0023).
 func reportResult(res *engine.Result, name string) {
 	fmt.Fprintf(os.Stderr, "nput: apply %s done (root=%s)\n", name, res.Root)
 	for _, t := range res.Placed {

--- a/cmd/nput/apply_test.go
+++ b/cmd/nput/apply_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/yasunori0418/nput/internal/engine"
 )
 
-// applyAllExitCode は priority error(1) > conflict(2) > 0（単純な最大値ではない・→ ADR-0024）。
+// applyAllExitCode follows priority error(1) > conflict(2) > 0 (not the plain maximum; → ADR-0024).
 func TestApplyAllExitCode(t *testing.T) {
 	cases := []struct {
 		name              string
@@ -19,7 +19,7 @@ func TestApplyAllExitCode(t *testing.T) {
 		{"none", false, false, 0},
 		{"error only", true, false, 1},
 		{"conflict only", false, true, 2},
-		{"error wins over conflict", true, true, 1}, // 最大値なら 2 だが error を隠さない
+		{"error wins over conflict", true, true, 1}, // the maximum would be 2, but do not hide error
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -30,7 +30,7 @@ func TestApplyAllExitCode(t *testing.T) {
 	}
 }
 
-// captureStdout は f 実行中の stdout を捕捉して返す（dryrun plan が stdout 専有か検証する）。
+// captureStdout captures and returns stdout produced while f runs (verifies that the dryrun plan owns stdout).
 func captureStdout(t *testing.T, f func()) string {
 	t.Helper()
 	old := os.Stdout
@@ -50,8 +50,8 @@ func captureStdout(t *testing.T, f func()) string {
 	return <-done
 }
 
-// aggregateDryRun の集約終了コードと plan 出力（stdout 専有）を、apply 実体を注入して
-// nix 無しで検証する。これが #14 AC-4「error(1) > conflict(2) > 0」の実経路の回帰防止。
+// Verifies aggregateDryRun's aggregate exit code and plan output (stdout ownership) by injecting the apply
+// implementation, without nix. This is the regression guard for the real path of #14 AC-4 "error(1) > conflict(2) > 0".
 func TestAggregateDryRun(t *testing.T) {
 	clean := func(name string) (*engine.Result, error) {
 		return &engine.Result{Placed: []string{"/p/" + name}}, nil
@@ -99,7 +99,7 @@ func TestAggregateDryRun(t *testing.T) {
 			if got != c.wantCode {
 				t.Errorf("aggregateDryRun code = %d, want %d", got, c.wantCode)
 			}
-			// 成功 config の plan は stdout に出る（機械可読出力を専有・→ ADR-0023）。
+			// A successful config's plan goes to stdout (owns the machine-readable output; → ADR-0023).
 			if strings.Contains(c.name, "all clean") && !strings.Contains(out, "place\t/p/a") {
 				t.Errorf("stdout に plan が出ていない: %q", out)
 			}

--- a/cmd/nput/gitignore.go
+++ b/cmd/nput/gitignore.go
@@ -37,8 +37,8 @@ func newGitignoreCmd() *cobra.Command {
 	return cmd
 }
 
-// runGitignore は単体 config の配置 target を列挙する。project mode 限定で、
-// 非 project config（home / fixed）を指定したらエラー停止する（アンカー形式が git toplevel を前提とするため・→ ADR-0023）。
+// runGitignore lists a single config's placement targets. project mode only;
+// it errors out if a non-project config (home / fixed) is given (because the anchor form presupposes the git toplevel; → ADR-0023).
 func runGitignore(name string) error {
 	ep, err := discoverEntrypoint(flagFile)
 	if err != nil {
@@ -49,7 +49,7 @@ func runGitignore(name string) error {
 		return err
 	}
 
-	// rootKind 先取り eval で project mode を確認する（build より先に安価に弾く）。
+	// Confirm project mode via rootKind pre-resolution eval (rejecting cheaply before build).
 	rootKind, _, err := evalRoot(ep, system, name)
 	if err != nil {
 		return err
@@ -66,9 +66,9 @@ func runGitignore(name string) error {
 	return nil
 }
 
-// runGitignoreAll は projectRoot の全 config の target をソート + 重複除去して列挙する
-// （repo の .gitignore は 1 つなので一括列挙が自然・→ docs/spec.md・ADR-0018）。
-// 非 project config は対象から除外する（--all は projectRoot の config のみ拾う）。
+// runGitignoreAll lists the targets of all projectRoot configs, sorted and de-duplicated
+// (a repo has a single .gitignore, so listing them together is natural; → docs/spec.md, ADR-0018).
+// Non-project configs are excluded (--all picks up only projectRoot configs).
 func runGitignoreAll() error {
 	ep, err := discoverEntrypoint(flagFile)
 	if err != nil {
@@ -104,8 +104,8 @@ func runGitignoreAll() error {
 	return nil
 }
 
-// configTargets は config をビルドして manifest.json を読み、配置 target を列挙する
-// （method を区別せず全 entry・→ ADR-0019）。
+// configTargets builds the config, reads manifest.json, and lists the placement targets
+// (all entries regardless of method; → ADR-0019).
 func configTargets(ep *entrypoint, system, name string) ([]string, error) {
 	store, err := buildManifestStorePath(ep, system, name)
 	if err != nil {
@@ -122,7 +122,7 @@ func configTargets(ep *entrypoint, system, name string) ([]string, error) {
 	return targets, nil
 }
 
-// dedupeSorted はソート + 重複除去する（--all の一括列挙用）。
+// dedupeSorted sorts and de-duplicates (for --all's combined listing).
 func dedupeSorted(in []string) []string {
 	sort.Strings(in)
 	out := in[:0]
@@ -136,16 +136,16 @@ func dedupeSorted(in []string) []string {
 	return out
 }
 
-// printGitignore は target を /-anchor 形式（先頭 /・末尾 / なし）で stdout へ 1 行 1 件出力する
-// （→ docs/spec.md・ADR-0013）。stdout 専有原則のためパイプ安全（`nput gitignore <name> >> .gitignore`）。
+// printGitignore prints targets to stdout in /-anchor form (leading /, no trailing /), one per line
+// (→ docs/spec.md, ADR-0013). It is pipe-safe by the stdout-ownership principle (`nput gitignore <name> >> .gitignore`).
 func printGitignore(targets []string) {
 	for _, t := range targets {
 		fmt.Println(gitignoreAnchor(t))
 	}
 }
 
-// gitignoreAnchor は root 相対 target を /-anchor 形式に整える。target は eval で絶対パス / 末尾 / を
-// 持たないが、防御的に整形する（→ ADR-0013: 先頭 / でアンカー・ディレクトリ / ファイルとも末尾 / なし）。
+// gitignoreAnchor normalizes a root-relative target into /-anchor form. By eval the target has no absolute path
+// and no trailing /, but it normalizes defensively (→ ADR-0013: anchor with a leading /, no trailing / for either directory or file).
 func gitignoreAnchor(target string) string {
 	t := strings.TrimSuffix(target, "/")
 	t = strings.TrimPrefix(t, "/")

--- a/cmd/nput/gitignore_test.go
+++ b/cmd/nput/gitignore_test.go
@@ -5,12 +5,12 @@ import (
 	"testing"
 )
 
-// gitignoreAnchor は root 相対 target を /-anchor 形式（先頭 /・末尾 / なし）に整える（→ ADR-0013）。
+// gitignoreAnchor normalizes a root-relative target into /-anchor form (leading /, no trailing /; → ADR-0013).
 func TestGitignoreAnchor(t *testing.T) {
 	cases := map[string]string{
 		".claude/skills/nix": "/.claude/skills/nix",
 		".config/nvim":       "/.config/nvim",
-		"dir/":               "/dir", // 末尾 / は付けない
+		"dir/":               "/dir", // no trailing / is added
 		"/already/anchored":  "/already/anchored",
 		"file.txt":           "/file.txt",
 	}

--- a/cmd/nput/init.go
+++ b/cmd/nput/init.go
@@ -11,11 +11,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// defaultTemplateRef は init が展開するテンプレの固定 flake ref（registry 非依存・ハードコード・
-// → ADR-0007）。NPUT_TEMPLATE_REF 環境変数があれば上書きする（E2E / fork 利用者の逃げ道・→ 計画 Q3）。
+// defaultTemplateRef is the fixed flake ref of the template that init expands (registry-independent, hardcoded;
+// → ADR-0007). The NPUT_TEMPLATE_REF environment variable overrides it (an escape hatch for E2E / fork users; → plan Q3).
 const defaultTemplateRef = "github:yasunori0418/nput"
 
-// initTemplates は init が受理するテンプレ名（flake.templates の output 名と一致）。
+// initTemplates is the template names that init accepts (matching the output names in flake.templates).
 var initTemplates = []string{"standalone", "project"}
 
 func newInitCmd() *cobra.Command {
@@ -36,8 +36,8 @@ func newInitCmd() *cobra.Command {
 	}
 }
 
-// runInit はテンプレ名を検証し `nix flake init -t <ref>#<template>` を CWD で実行する。
-// 新規 flake 生成のため entrypoint 探索（discoverEntrypoint）は通さない（→ 計画 8）。
+// runInit validates the template name and runs `nix flake init -t <ref>#<template>` in the CWD.
+// Because it generates a new flake, it does not go through entrypoint discovery (discoverEntrypoint; → plan 8).
 func runInit(template string) error {
 	if !isValidTemplate(template) {
 		return fmt.Errorf("nput: unknown template: %q (valid values: %s)", template, strings.Join(initTemplates, " / "))
@@ -53,8 +53,8 @@ func runInit(template string) error {
 		fmt.Fprintf(os.Stderr, "nput: + nix %s\n", strings.Join(args, " "))
 	}
 
-	// stderr を捕捉する。nix flake init は作成ファイル一覧を stderr に出すため、成功時はそれを転送し、
-	// 失敗時は experimental 未有効を分類して案内、他は生 stderr を添える（apply 系と UX 一貫・→ 計画 Q6）。
+	// Capture stderr. nix flake init prints the list of created files to stderr, so on success forward it,
+	// and on failure classify and guide the experimental-not-enabled case, attaching raw stderr otherwise (UX consistent with apply; → plan Q6).
 	cmd := exec.Command("nix", args...)
 	var stderr bytes.Buffer
 	cmd.Stdout = os.Stdout
@@ -63,20 +63,20 @@ func runInit(template string) error {
 		return nixError(args, stderr.String(), err)
 	}
 
-	// 成功時は捕捉した作成ファイル一覧（nix の出力）を stderr へ転送する。
+	// On success, forward the captured list of created files (nix's output) to stderr.
 	if s := stderr.String(); s != "" {
 		fmt.Fprint(os.Stderr, s)
 	}
 	return nil
 }
 
-// isValidTemplate はテンプレ名が受理対象かを返す。
+// isValidTemplate reports whether the template name is accepted.
 func isValidTemplate(template string) bool {
 	return slices.Contains(initTemplates, template)
 }
 
-// flakeInitArgs は `nix flake init` の argv を組む純関数（→ 計画 6・unit test 対象）。
-// ref#template の installable で展開元テンプレを指す。
+// flakeInitArgs is a pure function that builds the argv for `nix flake init` (→ plan 6; a unit-test target).
+// It points to the source template via the ref#template installable.
 func flakeInitArgs(template, ref string) []string {
 	return []string{"flake", "init", "-t", ref + "#" + template}
 }

--- a/cmd/nput/init_test.go
+++ b/cmd/nput/init_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-// flakeInitArgs は `nix flake init -t <ref>#<template>` の argv を組む（→ 計画 6）。
+// flakeInitArgs builds the argv for `nix flake init -t <ref>#<template>` (→ plan 6).
 func TestFlakeInitArgs(t *testing.T) {
 	cases := []struct {
 		name     string
@@ -41,7 +41,7 @@ func TestFlakeInitArgs(t *testing.T) {
 	}
 }
 
-// isValidTemplate は受理するテンプレ名のみ true（不正値は拒否して exit 1 経路へ）。
+// isValidTemplate is true only for accepted template names (rejects invalid values, sending them to the exit 1 path).
 func TestIsValidTemplate(t *testing.T) {
 	valid := []string{"standalone", "project"}
 	for _, v := range valid {

--- a/cmd/nput/list-generations.go
+++ b/cmd/nput/list-generations.go
@@ -37,7 +37,7 @@ func newListGenerationsCmd() *cobra.Command {
 	return cmd
 }
 
-// runListGenerations は eval 先取りで rootKind を確認（home mode 限定）し、profileDir を確定して世代一覧を出す。
+// runListGenerations confirms rootKind via eval pre-resolution (home mode only), resolves profileDir, and lists generations.
 func runListGenerations(name string) error {
 	ep, err := discoverEntrypoint(flagFile)
 	if err != nil {
@@ -73,9 +73,9 @@ func runListGenerations(name string) error {
 	return nil
 }
 
-// runListAllGenerations は <state>/nix/profiles/nput 直下の home profile（直下に profile リンクを持つ
-// <name> ディレクトリ）を走査して各 config の世代を一覧する。entrypoint eval は不要（ディスク走査のみ）。
-// roothash 系列（project / fixed / --root）は <roothash>/<name> 構造で直下に profile を持たないため自然に除外される。
+// runListAllGenerations scans the home profiles directly under <state>/nix/profiles/nput (the <name>
+// directories that hold a profile link directly under them) and lists each config's generations. No entrypoint eval is needed (disk scan only).
+// The roothash family (project / fixed / --root) has a <roothash>/<name> structure with no profile directly under it, so it is naturally excluded.
 func runListAllGenerations() error {
 	stateDir, err := paths.StateDir()
 	if err != nil {
@@ -85,7 +85,7 @@ func runListAllGenerations() error {
 	dents, err := os.ReadDir(base)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil // profile 未作成 = 一覧ゼロ。
+			return nil // no profile created yet = empty listing.
 		}
 		return fmt.Errorf("nput: cannot read the profile base (%s): %w", base, err)
 	}
@@ -97,7 +97,7 @@ func runListAllGenerations() error {
 		}
 		prof := paths.Resolve(stateDir, d.Name(), manifest.RootKindHome, "", false)
 		if _, err := os.Lstat(prof.Profile); err != nil {
-			continue // 直下に profile が無い = roothash 系列 / 空ディレクトリ。
+			continue // no profile directly under it = roothash family / empty directory.
 		}
 		names = append(names, d.Name())
 	}
@@ -118,7 +118,7 @@ func runListAllGenerations() error {
 	return nil
 }
 
-// printGenerations は世代一覧を stdout に出す（読み取りコマンドの一次出力・→ ADR-0023）。
+// printGenerations prints the generation list to stdout (the primary output of a read-only command; → ADR-0023).
 func printGenerations(gens []engine.Generation) {
 	for _, g := range gens {
 		marker := ""

--- a/cmd/nput/main.go
+++ b/cmd/nput/main.go
@@ -1,10 +1,10 @@
-// Command nput は配置エンジン（internal/engine）を駆動する一次 UX の CLI（→ ADR-0007, ADR-0011）。
+// Command nput is the primary-UX CLI that drives the placement engine (internal/engine) (→ ADR-0007, ADR-0011).
 //
-// 本スライス（#7）のスコープは project mode の `nput apply [<name>]` を flake entrypoint で
-// end-to-end に通すことに絞る。実行順は docs/spec.md「実行フロー」の
-// 「eval 先行（rootKind） → flock → ロック内 build → 配置 → --set → .pending 削除」に従い、
-// flock〜build〜配置〜commit は engine が所有し、CLI は entrypoint 発見・nix eval/build の
-// オーケストレーションを担う（→ ADR-0023, ADR-0025）。
+// This slice (#7) is scoped to getting project mode's `nput apply [<name>]` end-to-end through a flake
+// entrypoint. The execution order follows docs/spec.md "execution flow":
+// "eval first (rootKind) → flock → in-lock build → place → --set → remove .pending"; the engine owns
+// flock through build, placement, and commit, while the CLI handles the orchestration of entrypoint
+// discovery and nix eval/build (→ ADR-0023, ADR-0025).
 package main
 
 import (
@@ -17,24 +17,24 @@ import (
 	"github.com/yasunori0418/nput/internal/manifest"
 )
 
-// グローバルフラグ（→ docs/spec.md「グローバルフラグ」）。
+// Global flags (→ docs/spec.md "global flags").
 var (
-	flagFile        string // -f/--file: entrypoint 明示
-	flagRoot        string // --root: 解決 root の明示上書き
-	flagNoWait      bool   // --no-wait: flock 競合時に待たず skip（shellHook 用）
-	flagVerbose     bool   // -v/--verbose: 配置レポート（サマリ + per-target 行）を出力（既定は成功時沈黙・→ ADR-0031）
-	flagDebug       bool   // --debug: 内部実行する nix コマンドを stderr に開示（→ ADR-0031）
-	flagRecopy      bool   // --recopy: apply 修飾。全 copy target を src から無条件上書き再コピー
-	flagYes         bool   // -y/--yes: reset の確認プロンプトをスキップ（スクリプト / CI 用）
-	flagDryrun      bool   // --dryrun: apply / reset 修飾。副作用ゼロで plan を表示
-	flagProjectRoot bool   // --project-root: apply --all の修飾。projectRoot の config のみ適用
-	flagHomeRoot    bool   // --home-root: apply --all の修飾。homeRoot の config のみ適用
-	flagSystemRoot  bool   // --system-root: apply --all の修飾。systemRoot の config のみ適用（将来 seam）
-	flagManifest    string // --manifest: ビルド済み manifest（link-farm）を直接適用（module activation 用）
+	flagFile        string // -f/--file: specify the entrypoint explicitly
+	flagRoot        string // --root: explicitly override the resolved root
+	flagNoWait      bool   // --no-wait: skip without waiting on flock contention (for shellHook)
+	flagVerbose     bool   // -v/--verbose: print the placement report (summary + per-target lines); silent on success by default (→ ADR-0031)
+	flagDebug       bool   // --debug: disclose the internally run nix commands on stderr (→ ADR-0031)
+	flagRecopy      bool   // --recopy: apply modifier; unconditionally re-copy every copy target from src, overwriting
+	flagYes         bool   // -y/--yes: skip reset's confirmation prompt (for scripts / CI)
+	flagDryrun      bool   // --dryrun: apply / reset modifier; show the plan with zero side effects
+	flagProjectRoot bool   // --project-root: apply --all modifier; apply only projectRoot configs
+	flagHomeRoot    bool   // --home-root: apply --all modifier; apply only homeRoot configs
+	flagSystemRoot  bool   // --system-root: apply --all modifier; apply only systemRoot configs (future seam)
+	flagManifest    string // --manifest: apply a pre-built manifest (link-farm) directly (for module activation)
 )
 
-// exitError は cobra RunE が返す、特定の終了コードを伴うエラー（→ docs/spec.md 終了コード表）。
-// apply --dryrun の conflict は exit 2。msg が空なら main は追加出力せず code だけで終了する。
+// exitError is an error carrying a specific exit code that cobra RunE returns (→ docs/spec.md exit code table).
+// apply --dryrun's conflict is exit 2. If msg is empty, main exits with the code alone and emits no extra output.
 type exitError struct {
 	code int
 	msg  string
@@ -42,7 +42,7 @@ type exitError struct {
 
 func (e *exitError) Error() string { return e.msg }
 
-// rootCmdLong は --help で内部実行する nix コマンドを開示する（透明性・選択的に手で実行可能・→ ADR-0007）。
+// rootCmdLong discloses the internally run nix commands in --help (for transparency; selectively runnable by hand; → ADR-0007).
 const rootCmdLong = `nput places fetched git repositories at arbitrary paths in your environment via symlink or copy.
 It does not generate configuration (configuration is written in Nix and evaluated by nix build).
 
@@ -64,7 +64,7 @@ func newRootCmd() *cobra.Command {
 		Use:   "nput",
 		Short: "Place fetched git repositories at arbitrary paths via symlink or copy.",
 		Long:  rootCmdLong,
-		// エラーは main で 1 度だけ出すため cobra の usage/error 自動表示は抑制する。
+		// Errors are printed exactly once in main, so suppress cobra's automatic usage/error display.
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
@@ -88,10 +88,10 @@ func newRootCmd() *cobra.Command {
 	return root
 }
 
-// exitCodeX は終了コードを運ぶエラーが満たすインターフェース（apply --all の集約終了コード等）。
+// exitCodeX is the interface satisfied by errors that carry an exit code (such as apply --all's aggregate exit code).
 type exitCodeX interface{ ExitCode() int }
 
-// exitCodeError は終了コードを明示的に運ぶエラー（→ docs/spec.md「終了コード」）。
+// exitCodeError is an error that explicitly carries an exit code (→ docs/spec.md "exit codes").
 type exitCodeError struct {
 	code int
 	msg  string
@@ -102,8 +102,8 @@ func (e *exitCodeError) ExitCode() int { return e.code }
 
 func main() {
 	if err := newRootCmd().Execute(); err != nil {
-		// 終了コードを伴うエラー（apply --dryrun conflict=2 等）は code だけで終了する
-		// （plan は既に stdout に出力済み・→ docs/spec.md 終了コード表）。
+		// An error carrying an exit code (such as apply --dryrun conflict=2) exits with the code alone
+		// (the plan was already written to stdout; → docs/spec.md exit code table).
 		var ee *exitError
 		if errors.As(err, &ee) {
 			if ee.msg != "" {
@@ -113,14 +113,14 @@ func main() {
 		}
 
 		fmt.Fprintln(os.Stderr, err)
-		// CLI/flake pin 間の schemaVersion skew は engine が拒否する（→ manifest.validate）。
-		// 上位で検知して原因と解消策を補う（→ docs/spec.md「manifest.json スキーマ」）。
+		// The engine rejects a schemaVersion skew between the CLI and the flake pin (→ manifest.validate).
+		// Detect it at the top level and supplement the cause and the fix (→ docs/spec.md "manifest.json schema").
 		if errors.Is(err, manifest.ErrSchemaVersionUnsupported) {
 			fmt.Fprintln(os.Stderr, "\nnput: the nput version pinned by the CLI (engine) and by the flake may be out of sync.\n"+
 				"  The flake's nput input is generating a manifest newer than the CLI.\n"+
 				"  Update the CLI, or lower the flake's nput input to match the CLI so both versions align.")
 		}
-		// 終了コードを運ぶエラー（apply --all の集約等）はその code で終了する（→ docs/spec.md・ADR-0024）。
+		// An error carrying an exit code (such as apply --all's aggregate) exits with that code (→ docs/spec.md, ADR-0024).
 		var ec exitCodeX
 		if errors.As(err, &ec) {
 			os.Exit(ec.ExitCode())

--- a/cmd/nput/nix.go
+++ b/cmd/nput/nix.go
@@ -12,15 +12,15 @@ import (
 	"strings"
 )
 
-// entrypoint は発見した flake entrypoint。本スライスは flake.nix のみ対応する
-// （legacy shell.nix / default.nix は将来スライス・→ ADR-0007, ADR-0023 §4）。
+// entrypoint is a discovered flake entrypoint. This slice supports only flake.nix
+// (legacy shell.nix / default.nix are a future slice; → ADR-0007, ADR-0023 §4).
 type entrypoint struct {
-	// flakeRef は `nix build`/`nix eval` に渡す flake ref（flake.nix を含むディレクトリの絶対パス）。
+	// flakeRef is the flake ref passed to `nix build`/`nix eval` (the absolute path of the directory containing flake.nix).
 	flakeRef string
 }
 
-// discoverEntrypoint は -f 明示 → CWD 自動探索の順で entrypoint を発見する
-// （→ docs/spec.md「entrypoint の発見」）。本スライスは flake.nix のみ受理する。
+// discoverEntrypoint discovers the entrypoint in the order -f explicit → CWD autodiscovery
+// (→ docs/spec.md "entrypoint discovery"). This slice accepts only flake.nix.
 func discoverEntrypoint(fileFlag string) (*entrypoint, error) {
 	if fileFlag != "" {
 		abs, err := filepath.Abs(fileFlag)
@@ -52,7 +52,7 @@ func discoverEntrypoint(fileFlag string) (*entrypoint, error) {
 	if fileExists(filepath.Join(cwd, "flake.nix")) {
 		return &entrypoint{flakeRef: cwd}, nil
 	}
-	// legacy entrypoint を見つけたら未対応である旨を明示して停止する。
+	// If a legacy entrypoint is found, stop and make clear it is unsupported.
 	for _, legacy := range []string{"shell.nix", "default.nix"} {
 		if fileExists(filepath.Join(cwd, legacy)) {
 			return nil, fmt.Errorf("nput: %s is not supported in this slice (only flake.nix is supported; pass a flake with -f)", legacy)
@@ -66,8 +66,8 @@ func fileExists(p string) bool {
 	return err == nil
 }
 
-// currentSystem は実行環境の nix system 名（例: aarch64-darwin）を返す。
-// flake は `nput.<system>.<name>` で system 次元を持つため CLI が現行 system を差し込む（→ ADR-0007）。
+// currentSystem returns the nix system name of the runtime environment (e.g. aarch64-darwin).
+// Because the flake has a system dimension in `nput.<system>.<name>`, the CLI injects the current system (→ ADR-0007).
 func currentSystem() (string, error) {
 	var arch string
 	switch runtime.GOARCH {
@@ -86,28 +86,28 @@ func currentSystem() (string, error) {
 	}
 }
 
-// installable は `nix build`/`nix eval` に渡す `<flakeRef>#nput.<system>.<name>` を組む。
+// installable builds the `<flakeRef>#nput.<system>.<name>` passed to `nix build`/`nix eval`.
 func (e *entrypoint) installable(system, name string) string {
 	return fmt.Sprintf("%s#nput.%s.%s", e.flakeRef, system, name)
 }
 
-// namespace は config 名を伴わない `<flakeRef>#nput.<system>`（config 集合）を組む。
-// apply --all / gitignore --all の一括 eval（config 名→rootKind マップ）に使う（→ ADR-0024）。
+// namespace builds `<flakeRef>#nput.<system>` (the config set) without a config name.
+// It is used for the batch eval of apply --all / gitignore --all (config name → rootKind map; → ADR-0024).
 func (e *entrypoint) namespace(system string) string {
 	return fmt.Sprintf("%s#nput.%s", e.flakeRef, system)
 }
 
-// rootInfo は config 1 件の root 情報（一括 eval の値）。fixed のときのみ Root を持つ。
+// rootInfo is one config's root info (the value from the batch eval). It has Root only when fixed.
 type rootInfo struct {
 	RootKind string `json:"rootKind"`
 	Root     string `json:"root"`
 }
 
-// evalAllRoots は `apply --all` / `gitignore --all` 用に config 名→rootInfo マップを
-// 1 回の `nix eval` で取得する（eval プロセス起動を N→1 に固定・→ docs/spec.md 実行フロー・ADR-0024）。
-// build はせず passthru の rootKind（+ fixed の root）だけを読む安価な eval。
+// evalAllRoots gets the config name → rootInfo map for `apply --all` / `gitignore --all`
+// in a single `nix eval` (fixing eval process launches at N→1; → docs/spec.md execution flow, ADR-0024).
+// It is a cheap eval that does no build and reads only the passthru rootKind (+ root for fixed).
 func evalAllRoots(e *entrypoint, system string) (map[string]rootInfo, error) {
-	// nput.<system> 配下の各 config から rootKind（+ fixed なら root）だけを抜き出す。
+	// Extract only rootKind (+ root if fixed) from each config under nput.<system>.
 	apply := `cs: builtins.mapAttrs (_: c: { rootKind = c.rootKind; } // (if c ? root then { root = c.root; } else {})) cs`
 	out, err := runNixCapture("eval", e.namespace(system), "--apply", apply, "--json")
 	if err != nil {
@@ -120,9 +120,9 @@ func evalAllRoots(e *entrypoint, system string) (map[string]rootInfo, error) {
 	return roots, nil
 }
 
-// buildManifestStorePath は config をビルドして link-farm の store パスを返す（read-only 経路）。
-// gitignore は配置をしないため out-link gcroot を張らず `--no-link --print-out-paths` で store パスだけ得る。
-// 進捗は stderr、store パスは stdout に出る（→ docs/spec.md 出力ストリーム規律）。
+// buildManifestStorePath builds the config and returns the link-farm's store path (a read-only path).
+// Because gitignore does no placement, it gets only the store path via `--no-link --print-out-paths` without laying down an out-link gcroot.
+// Progress goes to stderr and the store path to stdout (→ docs/spec.md output stream discipline).
 func buildManifestStorePath(e *entrypoint, system, name string) (string, error) {
 	out, err := runNixCapture("build", e.installable(system, name), "--no-link", "--print-out-paths")
 	if err != nil {
@@ -135,8 +135,8 @@ func buildManifestStorePath(e *entrypoint, system, name string) (string, error) 
 	return store, nil
 }
 
-// evalRoot は build 前に rootKind（+ fixed root のときは絶対パス）を安価な nix eval で先取りする
-// （→ docs/spec.md 実行フロー 1・ADR-0023）。これで profileDir を確定し flock → build の順を成立させる。
+// evalRoot pre-resolves rootKind (+ the absolute path when fixed root) via a cheap nix eval before build
+// (→ docs/spec.md execution flow 1, ADR-0023). This resolves profileDir and establishes the order flock → build.
 func evalRoot(e *entrypoint, system, name string) (rootKind, fixedRoot string, err error) {
 	inst := e.installable(system, name)
 	out, err := runNixCapture("eval", inst+".rootKind", "--raw")
@@ -154,8 +154,8 @@ func evalRoot(e *entrypoint, system, name string) (rootKind, fixedRoot string, e
 	return rootKind, fixedRoot, nil
 }
 
-// buildFunc は engine に注入する build コールバックを返す（→ engine.BuildFunc）。
-// ロック内で `nix build <installable> --out-link <pending>` を実行し、out-link を読んで store path を返す。
+// buildFunc returns the build callback injected into the engine (→ engine.BuildFunc).
+// Inside the lock it runs `nix build <installable> --out-link <pending>`, reads the out-link, and returns the store path.
 func buildFunc(e *entrypoint, system, name string) func(pending string) (string, error) {
 	inst := e.installable(system, name)
 	return func(pending string) (string, error) {
@@ -170,9 +170,9 @@ func buildFunc(e *entrypoint, system, name string) func(pending string) (string,
 	}
 }
 
-// dryBuildFunc は --dryrun 用の build コールバックを返す（→ engine.BuildFunc）。通常 build と違い
-// `nix build --no-link --print-out-paths` で **gcroot（out-link）を張らずに** link-farm の store path を
-// 得る（dryrun は副作用ゼロ・pending out-link を作らない・→ ADR-0011, ADR-0023）。pending 引数は使わない。
+// dryBuildFunc returns the build callback for --dryrun (→ engine.BuildFunc). Unlike a normal build,
+// it gets the link-farm's store path via `nix build --no-link --print-out-paths` **without laying down a gcroot (out-link)**
+// (dryrun is side-effect-free and creates no pending out-link; → ADR-0011, ADR-0023). The pending argument is unused.
 func dryBuildFunc(e *entrypoint, system, name string) func(pending string) (string, error) {
 	inst := e.installable(system, name)
 	return func(string) (string, error) {
@@ -184,13 +184,13 @@ func dryBuildFunc(e *entrypoint, system, name string) func(pending string) (stri
 		if store == "" {
 			return "", fmt.Errorf("nput: nix build --print-out-paths was empty (%s)", inst)
 		}
-		// --print-out-paths は複数行を返し得る（multi-output）。link-farm は単一 output なので最終行を採る。
+		// --print-out-paths may return multiple lines (multi-output). The link-farm is a single output, so take the last line.
 		lines := strings.Split(store, "\n")
 		return strings.TrimSpace(lines[len(lines)-1]), nil
 	}
 }
 
-// runNixCapture は nix の stdout を捕捉して返す（eval 等の機械可読出力用）。
+// runNixCapture captures and returns nix's stdout (for machine-readable output such as eval).
 func runNixCapture(args ...string) (string, error) {
 	if flagDebug {
 		fmt.Fprintf(os.Stderr, "nput: + nix %s\n", strings.Join(args, " "))
@@ -205,8 +205,8 @@ func runNixCapture(args ...string) (string, error) {
 	return stdout.String(), nil
 }
 
-// runNixStream は nix の出力を stderr へ流す（build 進捗用。stdout は機械可読出力に専有・→ ADR-0023）。
-// build 前に eval が成功している＝nix-command/flakes は有効化済みなので experimental 検出は不要。
+// runNixStream streams nix's output to stderr (for build progress; stdout is reserved for machine-readable output; → ADR-0023).
+// eval succeeded before build = nix-command/flakes are already enabled, so experimental detection is unnecessary.
 func runNixStream(args ...string) error {
 	if flagDebug {
 		fmt.Fprintf(os.Stderr, "nput: + nix %s\n", strings.Join(args, " "))
@@ -220,8 +220,8 @@ func runNixStream(args ...string) error {
 	return nil
 }
 
-// nixError は nix の失敗を分類する。experimental-features 未有効は前提条件を案内し、
-// それ以外は生の nix stderr を握り潰さず添えて返す（→ ADR-0025 §1）。
+// nixError classifies a nix failure. For experimental-features not enabled it guides the prerequisites,
+// and otherwise it returns the raw nix stderr attached without swallowing it (→ ADR-0025 §1).
 func nixError(args []string, stderr string, runErr error) error {
 	if isExperimentalDisabled(stderr) {
 		return experimentalGuidance(stderr)
@@ -233,15 +233,15 @@ func nixError(args []string, stderr string, runErr error) error {
 	return fmt.Errorf("nput: nix %s failed:\n%s", args[0], trimmed)
 }
 
-// isExperimentalDisabled は nix-command / flakes 未有効エラーを検出する（→ ADR-0025 §1）。
+// isExperimentalDisabled detects the nix-command / flakes not-enabled error (→ ADR-0025 §1).
 func isExperimentalDisabled(stderr string) bool {
 	return strings.Contains(stderr, "experimental Nix feature") ||
 		strings.Contains(stderr, "experimental-features") ||
 		(strings.Contains(stderr, "flakes") && strings.Contains(stderr, "disabled"))
 }
 
-// experimentalGuidance は前提条件と有効化方法を案内するエラーを組む（生の nix エラーも添える）。
-// CLI は --extra-experimental-features を自動付与しない（環境設定を黙って上書きしない・→ ADR-0025 §1）。
+// experimentalGuidance builds an error that guides the prerequisites and how to enable them (attaching the raw nix error too).
+// The CLI does not add --extra-experimental-features automatically (it will not silently override environment settings; → ADR-0025 §1).
 func experimentalGuidance(stderr string) error {
 	return fmt.Errorf(`nput: nix's experimental-features are not enabled.
 This command internally uses `+"`nix eval`"+` / `+"`nix build`"+` (the new CLI) and flakes,
@@ -259,8 +259,8 @@ Original nix error:
 %s`, strings.TrimSpace(stderr))
 }
 
-// wrapEvalErr は eval の失敗のうち「nput.<name> が無い」ケースを分かりやすくする
-// （experimental 等はそのまま）（→ docs/spec.md エラー仕様）。
+// wrapEvalErr makes the "nput.<name> does not exist" case of an eval failure clearer
+// (experimental etc. are passed through as-is) (→ docs/spec.md error spec).
 func wrapEvalErr(err error, system, name string) error {
 	msg := err.Error()
 	if strings.Contains(msg, "does not provide attribute") ||
@@ -270,7 +270,7 @@ func wrapEvalErr(err error, system, name string) error {
 	return err
 }
 
-// wrapEvalAllErr は一括 eval の失敗のうち「nput.<system> が無い」ケースを分かりやすくする。
+// wrapEvalAllErr makes the "nput.<system> does not exist" case of a batch eval failure clearer.
 func wrapEvalAllErr(err error, system string) error {
 	msg := err.Error()
 	if strings.Contains(msg, "does not provide attribute") ||

--- a/cmd/nput/reset.go
+++ b/cmd/nput/reset.go
@@ -31,8 +31,8 @@ func newResetCmd() *cobra.Command {
 	return cmd
 }
 
-// runReset は eval 先取りで rootKind（→ profileDir）を確定し、engine.Reset を駆動する。
-// --dryrun は読み取り専用でプランを stdout に出して exit 0。非 dryrun は TTY 確認 / --yes を要求する。
+// runReset resolves rootKind (→ profileDir) via eval pre-resolution and drives engine.Reset.
+// --dryrun prints the plan read-only to stdout and exits 0. Non-dryrun requires TTY confirmation / --yes.
 func runReset(name string, targets []string, dryrun bool) error {
 	ep, err := discoverEntrypoint(flagFile)
 	if err != nil {
@@ -47,7 +47,7 @@ func runReset(name string, targets []string, dryrun bool) error {
 		return err
 	}
 
-	// --dryrun: 副作用ゼロのプレビュー（flock / confirm なし・終了コードは対象有無に依らず 0・→ ADR-0021）。
+	// --dryrun: a side-effect-free preview (no flock / confirm; exit code is 0 regardless of whether there are targets; → ADR-0021).
 	if dryrun {
 		res, err := engine.Reset(engine.ResetOptions{
 			Name:         name,
@@ -64,13 +64,13 @@ func runReset(name string, targets []string, dryrun bool) error {
 		return nil
 	}
 
-	// 非 dryrun は破壊的操作。確認方針（スキップ / プロンプト / 拒否）を --yes と TTY 状態から決める。
+	// Non-dryrun is a destructive operation. Decide the confirmation policy (skip / prompt / refuse) from --yes and TTY state.
 	needPrompt, err := confirmPolicy(flagYes, isInteractive())
 	if err != nil {
 		return err
 	}
 
-	// プロンプトが要るときだけ confirm を渡す。プロンプトは算出済みプランを表示する。
+	// Pass confirm only when a prompt is needed. The prompt shows the computed plan.
 	var confirm func(*engine.ResetResult) (bool, error)
 	if needPrompt {
 		confirm = func(res *engine.ResetResult) (bool, error) {
@@ -100,8 +100,8 @@ func runReset(name string, targets []string, dryrun bool) error {
 	return nil
 }
 
-// printResetPlan は reset --dryrun の削除対象を stdout に出す（機械可読出力を専有・1 行 1 件・
-// → docs/spec.md ストリーム規律・ADR-0023）。成功時沈黙でも抑制しない（stdout 専有原則・→ ADR-0031）。
+// printResetPlan prints reset --dryrun's removal targets to stdout (it owns the machine-readable output; one per line;
+// → docs/spec.md stream discipline, ADR-0023). It is not suppressed even under silent-on-success (the stdout-ownership principle; → ADR-0031).
 func printResetPlan(res *engine.ResetResult) {
 	for _, t := range res.RemovedSymlinks {
 		fmt.Printf("remove-symlink\t%s\n", t)
@@ -117,7 +117,7 @@ func printResetPlan(res *engine.ResetResult) {
 	}
 }
 
-// reportResetTargets は確認プロンプト前に削除予定を stderr に出す（進捗扱い・stdout は機械可読専有）。
+// reportResetTargets prints the planned removals to stderr before the confirmation prompt (treated as progress; stdout is reserved for machine-readable output).
 func reportResetTargets(res *engine.ResetResult, name string) {
 	fmt.Fprintf(os.Stderr, "nput: reset %s removal targets (root=%s):\n", name, res.Root)
 	for _, t := range res.RemovedSymlinks {
@@ -134,7 +134,7 @@ func reportResetTargets(res *engine.ResetResult, name string) {
 	}
 }
 
-// reportResetResult は実削除結果を stderr に出す（stdout は機械可読出力に専有・→ ADR-0023）。
+// reportResetResult prints the actual removal result to stderr (stdout is reserved for machine-readable output; → ADR-0023).
 func reportResetResult(res *engine.ResetResult, name string) {
 	fmt.Fprintf(os.Stderr, "nput: reset %s done (root=%s)\n", name, res.Root)
 	for _, t := range res.RemovedSymlinks {
@@ -151,12 +151,12 @@ func reportResetResult(res *engine.ResetResult, name string) {
 	}
 }
 
-// confirmPolicy は破壊的 reset の確認方針を --yes と TTY 状態から決める（→ ADR-0025 §5）。
-//   - --yes: 確認スキップ（needPrompt=false・err=nil）
-//   - --yes 無し + 対話環境: 確認プロンプト要求（needPrompt=true）
-//   - --yes 無し + 非対話環境: ハング / 空入力誤削除を防ぐため即エラー（refuse）
+// confirmPolicy decides the confirmation policy for a destructive reset from --yes and TTY state (→ ADR-0025 §5).
+//   - --yes: skip confirmation (needPrompt=false, err=nil)
+//   - no --yes + interactive environment: require a confirmation prompt (needPrompt=true)
+//   - no --yes + non-interactive environment: error immediately to prevent a hang / accidental deletion on empty input (refuse)
 //
-// runReset から isInteractive() の結果を渡して使う（nix 非依存で単体テスト可能な seam）。
+// runReset passes in the result of isInteractive() to use it (a nix-independent, unit-testable seam).
 func confirmPolicy(yes, interactive bool) (needPrompt bool, err error) {
 	if yes {
 		return false, nil
@@ -167,8 +167,8 @@ func confirmPolicy(yes, interactive bool) (needPrompt bool, err error) {
 	return true, nil
 }
 
-// isInteractive は stdin が TTY か（端末に接続されているか）を返す（→ ADR-0025 §5）。
-// stdlib のみで判定する（os.ModeCharDevice）。パイプ / リダイレクト / CI では false。
+// isInteractive returns whether stdin is a TTY (attached to a terminal) (→ ADR-0025 §5).
+// It decides using stdlib only (os.ModeCharDevice). false under pipe / redirect / CI.
 func isInteractive() bool {
 	fi, err := os.Stdin.Stat()
 	if err != nil {
@@ -177,7 +177,7 @@ func isInteractive() bool {
 	return fi.Mode()&os.ModeCharDevice != 0
 }
 
-// promptYesNo は stdin から y/N を読み、yes 系の入力のときだけ true を返す（既定 No）。
+// promptYesNo reads y/N from stdin and returns true only for yes-type input (default No).
 func promptYesNo(msg string) (bool, error) {
 	fmt.Fprintf(os.Stderr, "%s [y/N]: ", msg)
 	line, err := bufio.NewReader(os.Stdin).ReadString('\n')

--- a/cmd/nput/reset_test.go
+++ b/cmd/nput/reset_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/yasunori0418/nput/internal/engine"
 )
 
-// confirmPolicy は --yes / TTY 状態から確認方針を決める（→ ADR-0025 §5）。
-// 非対話 + --yes 無しの破壊的 reset 拒否（#13 AC-5）の回帰防止。
+// confirmPolicy decides the confirmation policy from --yes / TTY state (→ ADR-0025 §5).
+// Regression guard for refusing a destructive reset when non-interactive without --yes (#13 AC-5).
 func TestConfirmPolicy(t *testing.T) {
 	cases := []struct {
 		name        string
@@ -37,7 +37,7 @@ func TestConfirmPolicy(t *testing.T) {
 	}
 }
 
-// promptYesNo は yes 系入力のときだけ true を返す（既定 No）。stdin を差し替えて検証する。
+// promptYesNo returns true only for yes-type input (default No). Verified by swapping out stdin.
 func TestPromptYesNo(t *testing.T) {
 	cases := []struct {
 		input string
@@ -48,9 +48,9 @@ func TestPromptYesNo(t *testing.T) {
 		{"Y\n", true},
 		{"YES\n", true},
 		{"n\n", false},
-		{"\n", false},      // 既定 No
-		{"maybe\n", false}, // 不明な入力は No
-		{"", false},        // EOF（パイプ閉じ）も No
+		{"\n", false},      // default No
+		{"maybe\n", false}, // unknown input is No
+		{"", false},        // EOF (pipe closed) is also No
 	}
 	for _, c := range cases {
 		t.Run(strings.TrimSpace(c.input)+"->"+boolStr(c.want), func(t *testing.T) {
@@ -67,8 +67,8 @@ func TestPromptYesNo(t *testing.T) {
 	}
 }
 
-// isInteractive はパイプ / リダイレクト stdin では false を返す（非 TTY 経路・→ ADR-0025 §5）。
-// TTY=true 経路は実端末が要るため CI では検証できず、false 経路のみ検証する。
+// isInteractive returns false for pipe / redirect stdin (the non-TTY path; → ADR-0025 §5).
+// The TTY=true path needs a real terminal and cannot be verified in CI, so only the false path is verified.
 func TestIsInteractiveNonTTY(t *testing.T) {
 	restore := withStdin(t, "")
 	defer restore()
@@ -77,8 +77,8 @@ func TestIsInteractiveNonTTY(t *testing.T) {
 	}
 }
 
-// reset の出力ストリーム規律（#13 AC-9）: dryrun plan は stdout 専有、
-// 削除予定 / 結果レポートは stderr。
+// reset's output stream discipline (#13 AC-9): the dryrun plan owns stdout,
+// while the planned removals / result report go to stderr.
 func TestResetOutputStreams(t *testing.T) {
 	res := &engine.ResetResult{
 		Root:            "/root",
@@ -127,7 +127,7 @@ func boolStr(b bool) string {
 	return "false"
 }
 
-// withStdin は os.Stdin を input を返すパイプに差し替え、復元する関数を返す。
+// withStdin replaces os.Stdin with a pipe that returns input, and returns a function that restores it.
 func withStdin(t *testing.T, input string) func() {
 	t.Helper()
 	old := os.Stdin
@@ -143,7 +143,7 @@ func withStdin(t *testing.T, input string) func() {
 	return func() { os.Stdin = old; _ = r.Close() }
 }
 
-// captureOutErr は f 実行中の stdout / stderr を捕捉して返す（ストリーム規律の検証用）。
+// captureOutErr captures and returns stdout / stderr produced while f runs (for verifying stream discipline).
 func captureOutErr(t *testing.T, f func()) (stdout, stderr string) {
 	t.Helper()
 	oldOut, oldErr := os.Stdout, os.Stderr

--- a/cmd/nput/rollback.go
+++ b/cmd/nput/rollback.go
@@ -24,7 +24,7 @@ func newRollbackCmd() *cobra.Command {
 	}
 }
 
-// runRollback は eval 先取りで rootKind を確認（home mode 限定）し、engine.Rollback を駆動する。
+// runRollback confirms rootKind via eval pre-resolution (home mode only) and drives engine.Rollback.
 func runRollback(name string) error {
 	ep, err := discoverEntrypoint(flagFile)
 	if err != nil {
@@ -59,7 +59,7 @@ func runRollback(name string) error {
 	return nil
 }
 
-// reportRollback は世代遷移と配置差分を stderr に出す（stdout は機械可読出力に専有・→ ADR-0023）。
+// reportRollback prints the generation transition and placement diff to stderr (stdout is reserved for machine-readable output; → ADR-0023).
 func reportRollback(res *engine.RollbackResult, name string) {
 	fmt.Fprintf(os.Stderr, "nput: rollback %s done (generation %d → %d, root=%s)\n", name, res.From, res.To, res.Root)
 	for _, t := range res.Placed {

--- a/internal/engine/commit.go
+++ b/internal/engine/commit.go
@@ -6,9 +6,10 @@ import (
 	"os/exec"
 )
 
-// nixEnvCommit は既定のコミット点。`nix-env --profile <profileLink> --set <linkFarm>`
-// で 1 世代 = 1 link-farm の atomic 置換を行う（→ ADR-0002, ADR-0006, ADR-0015）。
-// stdout は機械可読出力を専有するため nix の出力は stderr に流す（→ docs/spec.md ストリーム規律）。
+// nixEnvCommit is the default commit point. It performs an atomic swap of one
+// generation = one link-farm via `nix-env --profile <profileLink> --set <linkFarm>`
+// (→ ADR-0002, ADR-0006, ADR-0015). stdout is reserved for machine-readable output,
+// so nix output is routed to stderr (→ docs/spec.md stream discipline).
 func nixEnvCommit(profileLink, linkFarm string) error {
 	if _, err := exec.LookPath("nix-env"); err != nil {
 		return fmt.Errorf("nix-env が PATH にありません: %w", err)

--- a/internal/engine/copy.go
+++ b/internal/engine/copy.go
@@ -11,9 +11,10 @@ import (
 	"github.com/yasunori0418/nput/internal/planner"
 )
 
-// materializeCopies は copy entry を実 FS に反映する分岐点。--recopy のときは全 copy target を
-// 無条件上書き（recopyAll）、通常は planner の place-once 分類（target 不在のみ新規コピー）に従う
-// （→ ADR-0020）。通常 apply と世代スキップ時のドリフト修復が共有する。
+// materializeCopies is the branch point that reflects copy entries onto the real FS.
+// On --recopy it overwrites all copy targets unconditionally (recopyAll); normally it
+// follows the planner's place-once classification (new copy only when the target is
+// absent) (→ ADR-0020). Shared by normal apply and generation-skip drift repair.
 func (a *applier) materializeCopies(plan planner.Plan, recopy bool) error {
 	if recopy {
 		return a.recopyAll()
@@ -21,9 +22,10 @@ func (a *applier) materializeCopies(plan planner.Plan, recopy bool) error {
 	return a.placeCopies(plan.Copies)
 }
 
-// placeCopies materializes the planner's place-once CopyActions（target 不在の copy のみ・
-// → ADR-0002, ADR-0016）。既存 target（記録あり / foreign）は planner が CopyAction を
-// 生まないため、ここは「新規コピー」だけを実 FS に反映する薄い executor に徹する。
+// placeCopies materializes the planner's place-once CopyActions (only copies whose
+// target is absent · → ADR-0002, ADR-0016). The planner emits no CopyAction for an
+// existing target (recorded / foreign), so this stays a thin executor that reflects
+// only "new copies" onto the real FS.
 func (a *applier) placeCopies(actions []planner.CopyAction) error {
 	for _, act := range actions {
 		if err := os.MkdirAll(filepath.Dir(act.TargetAbs), 0o755); err != nil {
@@ -37,10 +39,11 @@ func (a *applier) placeCopies(actions []planner.CopyAction) error {
 	return nil
 }
 
-// recopyAll は apply --recopy の copy 上書き経路（→ ADR-0020, docs/spec.md「recopy」）。
-// config 内の全 copy entry について、target が在れば削除してから無条件に再コピーする
-// （差分判定なし・ローカル編集は破棄）。place-once 分類（planner.Copies）は使わず manifest を
-// 直接走査するが、祖先 symlink / 構造不一致は planner の conflict ゲートで apply 前に弾かれている。
+// recopyAll is the copy overwrite path of apply --recopy (→ ADR-0020, docs/spec.md "recopy").
+// For every copy entry in the config, if the target exists it is removed and then
+// re-copied unconditionally (no diff check · local edits are discarded). It does not use
+// the place-once classification (planner.Copies) but scans the manifest directly; ancestor
+// symlinks / structural mismatches are already rejected by the planner's conflict gate before apply.
 func (a *applier) recopyAll() error {
 	for _, e := range a.manifest.Entries {
 		if e.Method != manifest.MethodCopy {
@@ -72,11 +75,12 @@ func (a *applier) recopyAll() error {
 	return nil
 }
 
-// copyTree は src（ファイル / ディレクトリ / symlink）を dst へネイティブにコピーする
-// （→ ADR-0016, docs/spec.md「copy モード」）。
-//   - mode は保存しつつ owner-write（0o200）を付与する（store の read-only 0444/0555 →
-//     編集可能な 0644/0755）。
-//   - src ツリー内の symlink は deref せず symlink のまま複製する（循環 / サイズ膨張回避）。
+// copyTree natively copies src (file / directory / symlink) to dst
+// (→ ADR-0016, docs/spec.md "copy mode").
+//   - Preserves mode while adding owner-write (0o200) (store's read-only 0444/0555 →
+//     editable 0644/0755).
+//   - Symlinks inside the src tree are duplicated as symlinks without deref (avoids
+//     cycles / size blow-up).
 func copyTree(src, dst string) error {
 	info, err := os.Lstat(src)
 	if err != nil {
@@ -109,7 +113,7 @@ func copyTree(src, dst string) error {
 			if err := os.MkdirAll(dstPath, 0o755); err != nil {
 				return err
 			}
-			// umask に依らず最終 mode を確定する（owner-write 付与）。
+			// Fix the final mode regardless of umask (add owner-write).
 			return os.Chmod(dstPath, fi.Mode().Perm()|0o200)
 		default:
 			return copyFile(path, dstPath, fi.Mode())
@@ -117,7 +121,7 @@ func copyTree(src, dst string) error {
 	})
 }
 
-// copyFile は単一ファイルを内容コピーし、mode 保存 + owner-write を付与する。
+// copyFile copies a single file's contents, preserving mode and adding owner-write.
 func copyFile(src, dst string, mode os.FileMode) error {
 	in, err := os.Open(src)
 	if err != nil {
@@ -137,17 +141,17 @@ func copyFile(src, dst string, mode os.FileMode) error {
 	if err := out.Close(); err != nil {
 		return err
 	}
-	// OpenFile の mode は umask でマスクされるため、最終 perm を明示確定する。
+	// OpenFile's mode is masked by umask, so set the final perm explicitly.
 	return os.Chmod(dst, perm)
 }
 
-// copySymlink は symlink を deref せず、同じリンク先で複製する（→ ADR-0016）。
+// copySymlink duplicates a symlink without deref, pointing at the same link target (→ ADR-0016).
 func copySymlink(src, dst string) error {
 	target, err := os.Readlink(src)
 	if err != nil {
 		return err
 	}
-	// 再コピー時の残骸対策（recopy は親を RemoveAll 済みだが防御的に消す）。
+	// Guard against leftovers on re-copy (recopy has already RemoveAll'd the parent, but remove defensively).
 	_ = os.Remove(dst)
 	return os.Symlink(target, dst)
 }

--- a/internal/engine/drift.go
+++ b/internal/engine/drift.go
@@ -6,18 +6,20 @@ import (
 	"github.com/yasunori0418/nput/internal/planner"
 )
 
-// 世代スキップ + lstat ドリフト修復（project mode 限定・→ ADR-0005, ADR-0017,
-// docs/spec.md「project mode の世代」）。
+// Generation skip + lstat drift repair (project mode only · → ADR-0005, ADR-0017,
+// docs/spec.md "project mode generations").
 //
-// devShell / direnv の shellHook はシェル再入のたびに走るため、新 link-farm
-// derivation が前世代と同一なら新世代は積まない（--set を省く・世代無限増殖の回避）。
-// ただし「derivation 同一 ⇒ FS 同一」は foreign tool の書き換えで崩れるため、完全
-// no-op にはせず各 entry の target を lstat 検査し、ドリフトした entry だけ再張りする。
+// The devShell / direnv shellHook runs on every shell re-entry, so if the new
+// link-farm derivation is identical to the previous generation, no new generation
+// is committed (--set is omitted · avoiding unbounded generation growth). However,
+// "same derivation ⇒ same FS" breaks under foreign tool rewrites, so instead of a
+// full no-op each entry's target is lstat-checked and only drifted entries are re-linked.
 
-// generationUnchanged は新 link-farm が前世代（profile リンクが指す世代）と同一の store
-// derivation かを返す。profile リンク → 世代リンク → link-farm store パスの連鎖を解決して
-// 新 link-farm の store パスと突き合わせる。どちらかが解決できなければ error を返し、呼び出し側は
-// 安全側（通常 apply = 新世代コミット）に倒す。
+// generationUnchanged reports whether the new link-farm is the same store derivation
+// as the previous generation (the one the profile link points at). It resolves the
+// chain profile link → generation link → link-farm store path and compares it with the
+// new link-farm's store path. If either cannot be resolved it returns an error and the
+// caller falls back to the safe side (normal apply = new generation commit).
 func generationUnchanged(profileLink, newLinkFarm string) (bool, error) {
 	prev, err := filepath.EvalSymlinks(profileLink)
 	if err != nil {
@@ -30,21 +32,24 @@ func generationUnchanged(profileLink, newLinkFarm string) (bool, error) {
 	return prev == next, nil
 }
 
-// repairDrift は世代スキップ時の lstat ドリフト修復を行う。planner が現 FS 状態から算出した
-// プランのうち、ドリフトした entry **だけ** を再収束させ、stale 除去も世代コミットもしない。
+// repairDrift performs the lstat drift repair during a generation skip. Of the plan the
+// planner computed from the current FS state, it re-converges **only** the drifted entries,
+// performing neither stale removal nor a generation commit.
 //
-//   - symlink: PlaceNew（target 消失）と PlaceForeign（foreign 書き換え）だけ再張りする。
-//     PlaceReplace は「記録通りの先を指す symlink」= ドリフトなしのため触らない（→ ADR-0017）。
-//     foreign 書き換えの warning は呼び出し側が emitWarnings(plan.Warnings) で既に出している。
-//   - copy: planner.Copies は target 不在の place-once アクションのみを含むため、それを反映すると
-//     「copy は target 不在時のみ place-once 復帰」になる。内容差（ユーザー編集）は CopyAction が
-//     生まれず触らない（→ docs/spec.md「project mode の世代」・ADR-0022）。--recopy のときは
-//     recopyAll で無条件上書きする（recopy は世代外の opt-in）。
+//   - symlink: re-links only PlaceNew (target gone) and PlaceForeign (foreign rewrite).
+//     PlaceReplace is "a symlink pointing at the recorded dest" = no drift, so it is left
+//     untouched (→ ADR-0017). The foreign-rewrite warning has already been emitted by the
+//     caller via emitWarnings(plan.Warnings).
+//   - copy: planner.Copies contains only place-once actions for absent targets, so reflecting
+//     it gives "copy reverts place-once only when the target is absent". Content diffs (user
+//     edits) produce no CopyAction and are left untouched (→ docs/spec.md "project mode
+//     generations" · ADR-0022). On --recopy, recopyAll overwrites unconditionally (recopy is
+//     an opt-in outside generations).
 func (a *applier) repairDrift(plan planner.Plan, recopy bool) error {
 	drifted := make([]planner.PlaceAction, 0, len(plan.Place))
 	for _, act := range plan.Place {
 		if act.Kind == planner.PlaceReplace {
-			continue // 記録通りの先を指す symlink = in-sync。ドリフトなしで再張り不要。
+			continue // symlink pointing at the recorded dest = in-sync. No drift, no re-link needed.
 		}
 		drifted = append(drifted, act)
 	}

--- a/internal/engine/drift_test.go
+++ b/internal/engine/drift_test.go
@@ -9,11 +9,12 @@ import (
 	"github.com/yasunori0418/nput/internal/manifest"
 )
 
-// 世代スキップ + lstat ドリフト修復の tmpdir 統合テスト（実 FS・nix 不使用・fakeCommit 経路）。
-// fakeCommit は profile リンクを link-farm へ直接張るため、同一 link-farm を 2 度 apply すると
-// generationUnchanged が成立し（project mode 限定）、新世代を積まず（--set 省略）lstat 修復だけ走る。
+// tmpdir integration tests for generation skip + lstat drift repair (real FS · no nix · fakeCommit path).
+// fakeCommit links the profile link directly to the link-farm, so applying the same link-farm twice
+// makes generationUnchanged hold (project mode only), committing no new generation (--set omitted) and
+// running only the lstat repair.
 
-// applyOnce は project mode（roothash キー）の 1 回分 apply を回す共通ヘルパ。
+// applyOnce is a shared helper that runs a single apply in project mode (roothash key).
 func applyOnce(t *testing.T, lf, name, root, state string, commits *[][2]string, warns *[]string) *Result {
 	t.Helper()
 	opts := Options{
@@ -33,7 +34,7 @@ func TestApplyGenerationSkipNoDrift(t *testing.T) {
 	root := realTempDir(t)
 	state := realTempDir(t)
 	src := makeSrc(t, "x")
-	// 同一 link-farm を 2 度使う（derivation 同一 = 世代スキップ対象）。
+	// Use the same link-farm twice (same derivation = generation-skip candidate).
 	lf := writeLinkFarm(t, projectManifest(storeEntry(src, ".", ".config/foo")))
 
 	var commits [][2]string
@@ -42,7 +43,7 @@ func TestApplyGenerationSkipNoDrift(t *testing.T) {
 		t.Fatalf("first apply commit calls = %d, want 1", len(commits))
 	}
 
-	// 2 回目: link-farm 同一・FS もドリフトなし → 世代スキップ・完全 no-op（commit 増えない）。
+	// Second apply: same link-farm, no FS drift → generation skip, full no-op (commit count unchanged).
 	res := applyOnce(t, lf, "c", root, state, &commits, nil)
 	if !res.GenerationSkipped {
 		t.Errorf("GenerationSkipped = false, want true (same derivation)")
@@ -53,7 +54,7 @@ func TestApplyGenerationSkipNoDrift(t *testing.T) {
 	if len(res.Placed)+len(res.Replaced)+len(res.Removed) != 0 {
 		t.Errorf("no-drift skip should touch nothing: Placed=%v Replaced=%v Removed=%v", res.Placed, res.Replaced, res.Removed)
 	}
-	// symlink は記録通りのまま。
+	// symlink stays as recorded.
 	if dest, _ := os.Readlink(filepath.Join(root, ".config", "foo")); dest != src {
 		t.Errorf("symlink dest = %q, want %q (untouched)", dest, src)
 	}
@@ -68,13 +69,13 @@ func TestApplyGenerationSkipRepairsDeletedSymlink(t *testing.T) {
 	var commits [][2]string
 	applyOnce(t, lf, "c", root, state, &commits, nil)
 
-	// foreign tool が target を消す。
+	// foreign tool removes the target.
 	tgt := filepath.Join(root, ".config", "foo")
 	if err := os.Remove(tgt); err != nil {
 		t.Fatal(err)
 	}
 
-	// 2 回目: 世代スキップだが、消えた entry を再張りする（完全 no-op にしない）。
+	// Second apply: generation skip, but re-link the deleted entry (not a full no-op).
 	res := applyOnce(t, lf, "c", root, state, &commits, nil)
 	if !res.GenerationSkipped {
 		t.Errorf("GenerationSkipped = false, want true")
@@ -99,7 +100,7 @@ func TestApplyGenerationSkipRepairsForeignSymlinkWithWarn(t *testing.T) {
 	var commits [][2]string
 	applyOnce(t, lf, "c", root, state, &commits, nil)
 
-	// foreign tool が target を別の先へ書き換える。
+	// foreign tool rewrites the target to point elsewhere.
 	tgt := filepath.Join(root, ".config", "foo")
 	foreign := realTempDir(t)
 	if err := os.Remove(tgt); err != nil {
@@ -109,7 +110,7 @@ func TestApplyGenerationSkipRepairsForeignSymlinkWithWarn(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// 2 回目: 世代スキップだが foreign 書き換えを warning 付きで再張り（後勝ち）。
+	// Second apply: generation skip, but re-link the foreign rewrite with a warning (last-wins).
 	var warns []string
 	res := applyOnce(t, lf, "c", root, state, &commits, &warns)
 	if !res.GenerationSkipped {
@@ -148,7 +149,7 @@ func TestApplyGenerationSkipRepairsDeletedCopy(t *testing.T) {
 		t.Fatalf("copy target should exist after first apply: %v", err)
 	}
 
-	// foreign tool が copy target を消す → place-once 復帰の対象。
+	// foreign tool removes the copy target → subject to place-once revert.
 	if err := os.Remove(tgt); err != nil {
 		t.Fatal(err)
 	}
@@ -177,7 +178,7 @@ func TestApplyGenerationSkipKeepsEditedCopy(t *testing.T) {
 	var commits [][2]string
 	applyOnce(t, lf, "c", root, state, &commits, nil)
 
-	// ユーザーが copy を編集する（内容差）→ 世代スキップの修復では触らない（src 追従は --recopy 限定）。
+	// User edits the copy (content diff) → generation-skip repair leaves it untouched (src follow is --recopy only).
 	tgt := filepath.Join(root, ".config", "foo")
 	if err := os.WriteFile(tgt, []byte("user-edit"), 0o644); err != nil {
 		t.Fatal(err)
@@ -196,12 +197,12 @@ func TestApplyGenerationSkipKeepsEditedCopy(t *testing.T) {
 }
 
 func TestApplyGenerationSkipOnlyProjectMode(t *testing.T) {
-	// home mode は世代スキップしない（毎回新世代）。home mode は同一 link-farm でも commit が増える。
+	// home mode does not skip generations (a new generation every time). In home mode the commit count grows even with the same link-farm.
 	root := realTempDir(t)
 	state := realTempDir(t)
 	src := makeSrc(t, "x")
 
-	// home mode manifest（RootKindHome）。RootOverride で root を tmpdir に逃がす（→ ADR-0017 --root 全モード上書き）。
+	// home mode manifest (RootKindHome). RootOverride redirects root to a tmpdir (→ ADR-0017 --root overrides all modes).
 	hm := manifest.Manifest{
 		SchemaVersion: 1,
 		Root:          manifest.Root{RootKind: manifest.RootKindHome},
@@ -231,7 +232,7 @@ func TestApplyGenerationSkipOnlyProjectMode(t *testing.T) {
 }
 
 func TestApplyGenerationSkipRecopyOverwrites(t *testing.T) {
-	// --recopy は世代スキップ時も copy を無条件上書きする（recopy は世代外の opt-in）。
+	// --recopy overwrites copies unconditionally even during a generation skip (recopy is an opt-in outside generations).
 	root := realTempDir(t)
 	state := realTempDir(t)
 	src := makeROSrc(t, "file.txt", "store-content")
@@ -244,7 +245,7 @@ func TestApplyGenerationSkipRecopyOverwrites(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// 2 回目: derivation 同一で世代スキップだが --recopy で copy を上書き。世代は積まない。
+	// Second apply: same derivation so generation skip, but --recopy overwrites the copy. No new generation.
 	res, err := Apply(Options{
 		LinkFarm: lf, Name: "c", RootOverride: root, StateDir: state, Recopy: true, Commit: fakeCommit(&commits),
 	})
@@ -266,7 +267,7 @@ func TestApplyGenerationSkipRecopyOverwrites(t *testing.T) {
 }
 
 func TestApplyNewDerivationCommitsNewGeneration(t *testing.T) {
-	// link-farm derivation が変われば（別 src）世代スキップせず新世代を積む。
+	// If the link-farm derivation changes (different src), no generation skip and a new generation is committed.
 	root := realTempDir(t)
 	state := realTempDir(t)
 
@@ -275,7 +276,7 @@ func TestApplyNewDerivationCommitsNewGeneration(t *testing.T) {
 	var commits [][2]string
 	applyOnce(t, lf1, "c", root, state, &commits, nil)
 
-	// 別 link-farm（別 src = 別 derivation）→ 世代スキップしない。
+	// Different link-farm (different src = different derivation) → no generation skip.
 	src2 := makeSrc(t, "x")
 	lf2 := writeLinkFarm(t, projectManifest(storeEntry(src2, ".", ".config/foo")))
 	res := applyOnce(t, lf2, "c", root, state, &commits, nil)

--- a/internal/engine/dryrun_test.go
+++ b/internal/engine/dryrun_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/yasunori0418/nput/internal/manifest"
 )
 
-// TestApplyDryRunNoSideEffects は apply --dryrun が plan を返すだけで FS / profileDir を一切
-// 変えないことを検証する（→ ADR-0006, ADR-0023）。
+// TestApplyDryRunNoSideEffects verifies that apply --dryrun only returns a plan and
+// changes neither the FS nor the profileDir (→ ADR-0006, ADR-0023).
 func TestApplyDryRunNoSideEffects(t *testing.T) {
 	root := realTempDir(t)
 	state := realTempDir(t)
@@ -34,25 +34,26 @@ func TestApplyDryRunNoSideEffects(t *testing.T) {
 	if got := res.Placed; len(got) != 1 || got[0] != ".link" {
 		t.Errorf("Placed = %v, want [.link]", got)
 	}
-	// symlink は張られない。
+	// symlink is not created.
 	if _, err := os.Lstat(filepath.Join(root, ".link")); !os.IsNotExist(err) {
 		t.Errorf(".link should not be created in dryrun, lstat err = %v", err)
 	}
-	// profileDir も作られない（mkdir / flock を取らない）。
+	// profileDir is not created either (no mkdir / flock taken).
 	if _, err := os.Stat(res.ProfileDir); !os.IsNotExist(err) {
 		t.Errorf("profileDir should not be created in dryrun, stat err = %v", err)
 	}
 }
 
-// TestApplyDryRunConflict は target が通常ファイルで占有されているとき conflict を plan に載せ、
-// FS を変えないことを検証する（CLI が exit 2 を判定する・→ docs/spec.md 終了コード表）。
+// TestApplyDryRunConflict verifies that when the target is occupied by a regular file a
+// conflict is recorded in the plan and the FS is left unchanged (the CLI decides exit 2 ·
+// → docs/spec.md exit code table).
 func TestApplyDryRunConflict(t *testing.T) {
 	root := realTempDir(t)
 	state := realTempDir(t)
 	src := makeSrc(t, "sub/file")
 	lf := writeLinkFarm(t, homeManifest(storeEntry(src, "sub", ".link")))
 
-	// target を通常ファイルで占有する（symlink 上書き不可 → conflict）。
+	// Occupy the target with a regular file (cannot overwrite as symlink → conflict).
 	if err := os.WriteFile(filepath.Join(root, ".link"), []byte("x"), 0o644); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -3,9 +3,10 @@
 // links conservatively, and commits a generation with `nix-env --set`
 // (→ ADR-0002, ADR-0005, ADR-0006, ADR-0011, ADR-0013, ADR-0015, ADR-0025).
 //
-// 本スライス（#6）の最小核は project mode の store-symlink 配置に絞る。配置〜
-// stale 除去（ネイティブ FS）は nix 不使用でユニット/統合テスト可能にし、commit
-// （nix-env --set）は注入可能にして tmpdir テストでは nix を呼ばない（→ ADR-0006）。
+// The minimal core of this slice (#6) is limited to store-symlink placement in
+// project mode. Placement through stale removal (native FS) is made unit/integration
+// testable without nix, and commit (nix-env --set) is injectable so tmpdir tests do
+// not call nix (→ ADR-0006).
 package engine
 
 import (
@@ -20,85 +21,89 @@ import (
 	"github.com/yasunori0418/nput/internal/planner"
 )
 
-// CommitFunc は配置成功後に世代を積むコミット点（→ ADR-0006, docs/spec.md 実行フロー f）。
-// 既定は nix-env --profile <profileLink> --set <linkFarm>。tmpdir テストはこれを
-// 差し替えて nix を呼ばずに検証する。
+// CommitFunc is the commit point that records a generation after a successful placement
+// (→ ADR-0006, docs/spec.md execution flow f). The default is
+// nix-env --profile <profileLink> --set <linkFarm>. tmpdir tests substitute this to
+// verify without calling nix.
 type CommitFunc func(profileLink, linkFarm string) error
 
-// BuildFunc は flock 取得後・ロック内で link-farm を build するコールバック（→ docs/spec.md 実行フロー 2b・ADR-0011, ADR-0023）。
-// 引数 pending は out-link を張る先（<profileDir>/.pending）。返り値は build された link-farm の
-// store パス（os.Readlink の解決後）。CLI が `nix build <ep>#nput.<system>.<name> --out-link <pending>`
-// を差し込む。nil のときは opts.LinkFarm を既ビルド済みとして使う（tmpdir テスト経路）。
+// BuildFunc is the callback that builds the link-farm in-lock after the flock is taken
+// (→ docs/spec.md execution flow 2b · ADR-0011, ADR-0023). The pending argument is the
+// out-link destination (<profileDir>/.pending). The return value is the built link-farm's
+// store path (after os.Readlink resolution). The CLI injects
+// `nix build <ep>#nput.<system>.<name> --out-link <pending>`. When nil, opts.LinkFarm is
+// used as pre-built (tmpdir test path).
 type BuildFunc func(pending string) (linkFarm string, err error)
 
-// GitFunc は project mode の git toplevel 解決（→ ADR-0005）。既定は gitutil.Toplevel。
+// GitFunc resolves the git toplevel in project mode (→ ADR-0005). The default is gitutil.Toplevel.
 type GitFunc func(dir string) (string, error)
 
-// Options は Apply の入力。
+// Options is the input to Apply.
 type Options struct {
-	// LinkFarm は manifest.json と GC アンカー symlink farm を含む link-farm ディレクトリ。
-	// Build を渡さない経路（tmpdir テスト）でのみ使う既ビルド済み link-farm（→ ADR-0011）。
+	// LinkFarm is the link-farm directory containing manifest.json and the GC anchor symlink farm.
+	// Pre-built link-farm used only on the path that does not pass Build (tmpdir tests) (→ ADR-0011).
 	LinkFarm string
-	// Name は config 名（profile を一意特定する。entrypoint の nput.<name> 由来）。
+	// Name is the config name (uniquely identifies a profile; derived from the entrypoint's nput.<name>).
 	Name string
-	// RootKind は eval 先取りで得た root kind（→ docs/spec.md 実行フロー 1・ADR-0023）。
-	// Build 経路では manifest 未ビルドのため必須。空のときは LinkFarm の manifest から得る。
+	// RootKind is the root kind obtained via eval pre-resolution (→ docs/spec.md execution flow 1 · ADR-0023).
+	// Required on the Build path since the manifest is not yet built. When empty, obtained from LinkFarm's manifest.
 	RootKind string
-	// FixedRoot は rootKind=fixed のときの絶対パス（eval 先取りの passthru.root 由来）。
-	// 空かつ Build=nil のときは LinkFarm の manifest.Root.Root を使う。
+	// FixedRoot is the absolute path when rootKind=fixed (from eval pre-resolution's passthru.root).
+	// When empty and Build=nil, LinkFarm's manifest.Root.Root is used.
 	FixedRoot string
-	// RootOverride は --root 上書き（空 = なし）。明示時は全モードで roothash キー（→ ADR-0023）。
+	// RootOverride is the --root override (empty = none). When set, uses the roothash key in all modes (→ ADR-0023).
 	RootOverride string
-	// WorkDir は project mode の git toplevel 解決の起点（空 = os.Getwd）。
+	// WorkDir is the starting point for project-mode git toplevel resolution (empty = os.Getwd).
 	WorkDir string
-	// StateDir は profile 基底 <state> の上書き（空 = paths.StateDir で解決・主にテスト用）。
+	// StateDir overrides the profile base <state> (empty = resolved via paths.StateDir · mainly for tests).
 	StateDir string
-	// NoWait は flock を try-lock にする（shellHook 経路・保持中なら ErrSkipped・→ ADR-0013）。
+	// NoWait makes the flock a try-lock (shellHook path · ErrSkipped if held · → ADR-0013).
 	NoWait bool
-	// Recopy は apply --recopy 修飾（config 内の全 copy target を src から無条件上書き再コピー・→ ADR-0020）。
-	// place-once を破る opt-in 経路。symlink 部の通常 apply（stale 除去 + 世代コミット）は不変。
+	// Recopy is the apply --recopy modifier (unconditionally overwrite/re-copy all copy targets in the config from src · → ADR-0020).
+	// An opt-in path that breaks place-once. The normal apply of the symlink part (stale removal + generation commit) is unchanged.
 	Recopy bool
-	// DryRun は副作用ゼロの読み取り専用プレビュー（apply --dryrun・→ ADR-0006, ADR-0023）。
-	// true のとき planner を読み取り専用で回して plan を Result に詰めて return し、
-	// FS 書込・--set・flock・pending gcroot いずれも取らない。build（src 解決）はするが配置しない。
+	// DryRun is a side-effect-free read-only preview (apply --dryrun · → ADR-0006, ADR-0023).
+	// When true it runs the planner read-only, packs the plan into Result and returns,
+	// taking none of FS writes / --set / flock / pending gcroot. It builds (src resolution) but does not place.
 	DryRun bool
 
-	// Build はロック内 build の差し替え（nil = opts.LinkFarm を既ビルド済みとして使う）。
+	// Build substitutes the in-lock build (nil = use opts.LinkFarm as pre-built).
 	Build BuildFunc
-	// Git は git toplevel 解決の差し替え（nil = gitutil.Toplevel）。
+	// Git substitutes git toplevel resolution (nil = gitutil.Toplevel).
 	Git GitFunc
-	// Commit は世代コミットの差し替え（nil = nix-env --set）。
+	// Commit substitutes the generation commit (nil = nix-env --set).
 	Commit CommitFunc
-	// Warnf は warning の出力先（nil = stderr）。foreign symlink 等の可視化に使う（→ ADR-0015）。
+	// Warnf is the warning output sink (nil = stderr). Used to surface foreign symlinks etc. (→ ADR-0015).
 	Warnf func(format string, args ...any)
 }
 
-// Result は Apply の結果レポート（dryrun / レポート表示・テスト検証用）。
+// Result is the result report of Apply (for dryrun / report display · test verification).
 type Result struct {
-	Root       string   // 解決後の絶対 root パス
-	ProfileDir string   // 確定した profileDir
-	Placed     []string // 新規配置した symlink target
-	Replaced   []string // 既存 symlink を張り替えた target
-	Copied     []string // place-once で新規コピーした copy target
-	Recopied   []string // --recopy で上書き再コピーした既存 copy target（→ ADR-0020）
-	Removed    []string // stale 除去した target
-	Skipped    bool     // try-lock 競合で skip した（NoWait 経路）
-	DryRun     bool     // 読み取り専用プレビュー（Placed 等は「これから配置する」予定・→ ADR-0023）
-	Conflicts  []string // dryrun で検出した conflict（"target: reason"・CLI が exit 2 判定に使う・→ ADR-0006）
-	// GenerationSkipped は project mode の世代スキップで新世代を積まなかった（--set を省いた）
-	// ことを表す。新 link-farm が前世代と同一のため commit せず、ドリフトした entry だけ
-	// lstat 修復した経路（→ ADR-0005, ADR-0017, docs/spec.md 世代スキップ）。
+	Root       string   // resolved absolute root path
+	ProfileDir string   // the fixed profileDir
+	Placed     []string // newly placed symlink targets
+	Replaced   []string // targets whose existing symlink was re-linked
+	Copied     []string // copy targets newly copied via place-once
+	Recopied   []string // existing copy targets overwritten/re-copied by --recopy (→ ADR-0020)
+	Removed    []string // stale-removed targets
+	Skipped    bool     // skipped on try-lock contention (NoWait path)
+	DryRun     bool     // read-only preview (Placed etc. are "to be placed" plans · → ADR-0023)
+	Conflicts  []string // conflicts detected in dryrun ("target: reason" · used by the CLI to decide exit 2 · → ADR-0006)
+	// GenerationSkipped indicates that the project-mode generation skip committed no new
+	// generation (omitted --set). The path where the new link-farm equals the previous
+	// generation so no commit happens and only drifted entries are lstat-repaired
+	// (→ ADR-0005, ADR-0017, docs/spec.md generation skip).
 	GenerationSkipped bool
 }
 
-// ErrSkipped は NoWait 経路で他の apply が進行中のため skip したことを表す。
+// ErrSkipped indicates a skip on the NoWait path because another apply is in progress.
 var ErrSkipped = lock.ErrLocked
 
-// Apply は project mode の store-symlink 配置を行い、成功後に世代をコミットする。
-// docs/spec.md「実行フロー」の engine 駆動部（2. engine を駆動）に対応し、
-// 「flock → ロック内 build → 配置 → --set → .pending 削除」の順を engine が所有する。
-// build は opts.Build（CLI が nix build を差し込む）にロック内で委譲し、未指定なら
-// opts.LinkFarm を既ビルド済みとして使う（tmpdir テスト経路）。
+// Apply places store-symlinks in project mode and commits a generation on success.
+// It corresponds to the engine-driven part of docs/spec.md "execution flow" (2. drive the
+// engine), and the engine owns the order "flock → in-lock build → placement → --set →
+// .pending removal". The build is delegated in-lock to opts.Build (the CLI injects nix
+// build); when unspecified, opts.LinkFarm is used as pre-built (tmpdir test path).
 func Apply(opts Options) (*Result, error) {
 	a := &applier{opts: opts, result: &Result{}}
 	if a.opts.Warnf == nil {
@@ -107,8 +112,8 @@ func Apply(opts Options) (*Result, error) {
 		}
 	}
 
-	// root kind: Build 経路では manifest 未ビルドのため eval 先取りの opts.RootKind を使う。
-	// 既ビルド済み LinkFarm 経路（テスト）では先に manifest を読んで rootKind を得る。
+	// root kind: on the Build path the manifest is not yet built, so use eval-pre-resolved opts.RootKind.
+	// On the pre-built LinkFarm path (tests), read the manifest first to obtain rootKind.
 	rootKind := opts.RootKind
 	fixedRoot := opts.FixedRoot
 	if opts.Build == nil {
@@ -125,7 +130,7 @@ func Apply(opts Options) (*Result, error) {
 		}
 	}
 
-	// 1. root 解決 → profileDir 確定（→ docs/spec.md「root の解決」）。
+	// 1. resolve root → fix profileDir (→ docs/spec.md "root resolution").
 	root, err := a.resolveRoot(rootKind, fixedRoot)
 	if err != nil {
 		return nil, err
@@ -143,19 +148,19 @@ func Apply(opts Options) (*Result, error) {
 	a.profile = paths.Resolve(stateDir, opts.Name, rootKind, root, opts.RootOverride != "")
 	a.result.ProfileDir = a.profile.Dir
 
-	// 1.5 dryrun は副作用ゼロの読み取り専用短絡（→ ADR-0006, ADR-0023, docs/spec.md 実行フロー）。
-	//     profileDir 確定までは apply と共通だが、ここから先（mkdir / flock / 配置 / --set /
-	//     pending gcroot）は一切行わず、planner を read-only で回して plan を Result に詰めて返す。
+	// 1.5 dryrun is a side-effect-free read-only short-circuit (→ ADR-0006, ADR-0023, docs/spec.md execution flow).
+	//     Up to fixing profileDir it is common with apply, but from here on (mkdir / flock / placement / --set /
+	//     pending gcroot) nothing is done; the planner is run read-only and the plan is packed into Result and returned.
 	if opts.DryRun {
 		return a.dryRun()
 	}
 
-	// 2. profileDir / backref を用意（flock は profileDir を開くため先に作る）。
+	// 2. prepare profileDir / backref (the flock opens profileDir, so create it first).
 	if err := a.ensureProfileDir(); err != nil {
 		return nil, err
 	}
 
-	// 3. 解決後 profileDir 単位で flock を取得し直列化する（→ ADR-0013）。
+	// 3. acquire a flock per resolved profileDir and serialize (→ ADR-0013).
 	l, err := lock.Acquire(a.profile.Dir, !opts.NoWait)
 	if err != nil {
 		if opts.NoWait && err == lock.ErrLocked {
@@ -166,8 +171,8 @@ func Apply(opts Options) (*Result, error) {
 	}
 	defer func() { _ = l.Release() }()
 
-	// 4. ロック内で link-farm を build する（→ docs/spec.md 実行フロー 2b・ADR-0023）。
-	//    build をロック内に閉じることで並行 apply の .pending 奪い合いが構造的に消える。
+	// 4. build the link-farm in-lock (→ docs/spec.md execution flow 2b · ADR-0023).
+	//    Closing the build inside the lock structurally removes .pending contention among concurrent applies.
 	if opts.Build != nil {
 		linkFarm, err := opts.Build(a.profile.Pending)
 		if err != nil {
@@ -181,10 +186,10 @@ func Apply(opts Options) (*Result, error) {
 		a.manifest = m
 	}
 
-	// 5. 前世代 manifest を読む（無ければ初回 = stale 除去ゼロ）。
+	// 5. read the previous generation's manifest (absent = first run = zero stale removals).
 	prev := a.loadPrevManifest()
 
-	// 6. planner で place/replace/remove プランを算出する（純ロジック・→ internal/planner）。
+	// 6. compute the place/replace/remove plan with the planner (pure logic · → internal/planner).
 	plan, err := planner.Compute(prev, a.manifest, a.root, planner.OSFS)
 	if err != nil {
 		return nil, err
@@ -195,20 +200,20 @@ func Apply(opts Options) (*Result, error) {
 	}
 	a.emitWarnings(plan.Warnings, opts.Recopy)
 
-	// 6.5 out-of-store のリンク先存在を配置直前に検査（dangling 禁止・→ ADR-0001, ADR-0013）。
-	//     FS 変更前に閉じるため、不在なら何も配置せずエラー停止する。
+	// 6.5 check out-of-store link target existence just before placement (no dangling · → ADR-0001, ADR-0013).
+	//     Closed before any FS change, so on absence it places nothing and stops with an error.
 	if err := a.checkOutOfStore(); err != nil {
 		return nil, err
 	}
 
-	// 7. project mode の世代スキップ判定（新 link-farm derivation が前世代と同一か）。
-	//    同一なら新世代を積まず（--set を省く）、ドリフトした entry だけ lstat 修復して返す
-	//    （完全 no-op にしない）。home / fixed / system は対象外で毎回新世代を積む
-	//    （世代スキップは project mode 限定・→ ADR-0005, ADR-0017, docs/spec.md 世代スキップ）。
+	// 7. project-mode generation-skip decision (is the new link-farm derivation the same as the previous generation?).
+	//    If the same, commit no new generation (omit --set) and return after lstat-repairing only drifted entries
+	//    (not a full no-op). home / fixed / system are excluded and commit a new generation every time
+	//    (generation skip is project mode only · → ADR-0005, ADR-0017, docs/spec.md generation skip).
 	if rootKind == manifest.RootKindProject && prev != nil {
 		same, err := generationUnchanged(a.profile.Profile, a.opts.LinkFarm)
 		if err != nil {
-			// 前世代 link-farm を解決できないときは安全側に倒して通常 apply（新世代を積む）。
+			// When the previous generation's link-farm cannot be resolved, fall back to the safe side: normal apply (commit a new generation).
 			a.opts.Warnf("nput: 前世代 link-farm を解決できませんでした。世代スキップせず再コミットします: %v", err)
 		} else if same {
 			if err := a.repairDrift(plan, opts.Recopy); err != nil {
@@ -220,9 +225,9 @@ func Apply(opts Options) (*Result, error) {
 		}
 	}
 
-	// 8. プランを実 FS に反映（新規 / 張替を先に、stale 除去を最後に・→ ADR-0006）。
-	//    symlink は plan 駆動。copy は --recopy のとき全 copy target を無条件上書き、
-	//    通常は place-once（target 不在のみ新規コピー）に分岐する（→ ADR-0020）。
+	// 8. reflect the plan onto the real FS (new / re-link first, stale removal last · → ADR-0006).
+	//    symlinks are plan-driven. copy branches: on --recopy overwrite all copy targets unconditionally,
+	//    normally place-once (new copy only when target is absent) (→ ADR-0020).
 	if err := a.place(plan.Place); err != nil {
 		return nil, err
 	}
@@ -233,7 +238,7 @@ func Apply(opts Options) (*Result, error) {
 		return nil, err
 	}
 
-	// 9. 世代コミット（→ docs/spec.md 実行フロー 2f）。
+	// 9. generation commit (→ docs/spec.md execution flow 2f).
 	commit := opts.Commit
 	if commit == nil {
 		commit = nixEnvCommit
@@ -242,14 +247,14 @@ func Apply(opts Options) (*Result, error) {
 		return nil, fmt.Errorf("nput: 世代コミット（nix-env --set）に失敗しました: %w", err)
 	}
 
-	// 10. --set 成功後に .pending を削除する（世代リンクが gcroot を引き継ぐ・→ ADR-0011, ADR-0025）。
+	// 10. remove .pending after --set succeeds (the generation link inherits the gcroot · → ADR-0011, ADR-0025).
 	a.cleanupPending()
 
 	return a.result, nil
 }
 
-// cleanupPending は --set 成功後（または世代スキップ後）に .pending out-link を削除する。
-// build 経路でのみ pending を張るため、その経路でのみ削除する（→ ADR-0011, ADR-0025）。
+// cleanupPending removes the .pending out-link after --set succeeds (or after a generation skip).
+// pending is only created on the build path, so it is removed only on that path (→ ADR-0011, ADR-0025).
 func (a *applier) cleanupPending() {
 	if a.opts.Build == nil {
 		return
@@ -267,14 +272,15 @@ type applier struct {
 	result   *Result
 }
 
-// dryRun は apply --dryrun の読み取り専用短絡（→ ADR-0006, ADR-0023）。manifest を build で
-// 解決（src 解決のため build はするが配置しない・pending gcroot は張らない）し、前世代 manifest
-// と planner.Compute で place/replace/remove/conflict を算出して Result に詰めて返す。flock /
-// FS 書込 / --set は一切行わない。conflict があっても error にせず Result.Conflicts に載せ、
-// CLI が exit 2 を判定する（→ docs/spec.md 終了コード表）。
+// dryRun is the read-only short-circuit of apply --dryrun (→ ADR-0006, ADR-0023). It resolves
+// the manifest via build (it builds for src resolution but does not place · does not create a
+// pending gcroot), computes place/replace/remove/conflict via planner.Compute against the
+// previous generation's manifest, and packs them into Result before returning. It performs none
+// of flock / FS writes / --set. Even on a conflict it does not error but records it in
+// Result.Conflicts, and the CLI decides exit 2 (→ docs/spec.md exit code table).
 func (a *applier) dryRun() (*Result, error) {
-	// build 経路（CLI）は manifest 未取得なので read-only build で src を解決する。
-	// CLI は dryrun では `nix build --no-link --print-out-paths`（gcroot なし）を差し込む。
+	// On the build path (CLI) the manifest is not yet obtained, so resolve src via a read-only build.
+	// In dryrun the CLI injects `nix build --no-link --print-out-paths` (no gcroot).
 	if a.opts.Build != nil {
 		linkFarm, err := a.opts.Build(a.profile.Pending)
 		if err != nil {
@@ -319,9 +325,9 @@ func (a *applier) resolveRoot(rootKind, fixedRoot string) (string, error) {
 	return resolveRoot(rootKind, fixedRoot, a.opts.RootOverride, a.opts.WorkDir, a.opts.Git)
 }
 
-// resolveRoot は rootKind（+ fixed root のときは絶対パス）から配置先の絶対 root を解決する
-// （→ docs/spec.md「root の解決」）。Apply / Rollback / ProfileFor が共有する純解決ロジックで、
-// `--root` 上書き時は kind に依らず上書きパスを使う。
+// resolveRoot resolves the absolute placement root from rootKind (+ the absolute path when
+// fixed root) (→ docs/spec.md "root resolution"). Pure resolution logic shared by Apply /
+// Rollback / ProfileFor; on `--root` override it uses the override path regardless of kind.
 func resolveRoot(rootKind, fixedRoot, rootOverride, workDir string, git GitFunc) (string, error) {
 	if rootOverride != "" {
 		return filepath.Abs(rootOverride)
@@ -364,7 +370,7 @@ func (a *applier) ensureProfileDir() error {
 	if err := os.MkdirAll(a.profile.Dir, 0o755); err != nil {
 		return fmt.Errorf("nput: profileDir を作成できません (%s): %w", a.profile.Dir, err)
 	}
-	// backref .root を <roothash> 階層に置く（孤児 profile の逆引き seam・→ ADR-0013）。
+	// Place backref .root at the <roothash> level (reverse-lookup seam for orphan profiles · → ADR-0013).
 	if a.profile.Backref != "" {
 		if err := os.MkdirAll(a.profile.BackrefDir, 0o755); err != nil {
 			return fmt.Errorf("nput: backref ディレクトリを作成できません (%s): %w", a.profile.BackrefDir, err)
@@ -376,25 +382,26 @@ func (a *applier) ensureProfileDir() error {
 	return nil
 }
 
-// loadPrevManifest は profileDir/profile（前世代 link-farm への symlink）が指す
-// manifest.json を読む。初回（profile 不在）は nil を返す（削除対象ゼロ・→ ADR-0006）。
+// loadPrevManifest reads the manifest.json pointed at by profileDir/profile (the symlink to
+// the previous generation's link-farm). On the first run (profile absent) it returns nil
+// (zero removal targets · → ADR-0006).
 func (a *applier) loadPrevManifest() *manifest.Manifest {
 	if _, err := os.Stat(a.profile.Profile); err != nil {
 		return nil
 	}
 	m, err := manifest.Load(a.profile.Profile)
 	if err != nil {
-		// 前世代が読めなくても新規配置は妨げない（stale 除去だけ諦める）。
+		// Even if the previous generation cannot be read, do not block new placement (just give up stale removal).
 		a.opts.Warnf("nput: 前世代 manifest を読めませんでした。stale 除去をスキップします: %v", err)
 		return nil
 	}
 	return m
 }
 
-// emitWarnings は planner が算出した非致命 warning を stderr（opts.Warnf）へ出す。
-// warning は --quiet でも消えない（→ docs/spec.md ストリーム規律・ADR-0015, ADR-0024）。
-// recopy=true のときは copy foreign skip 警告を抑制する（recopy は foreign も上書きするため
-// 「skip した」は誤報になる・→ ADR-0020）。
+// emitWarnings emits the non-fatal warnings computed by the planner to stderr (opts.Warnf).
+// Warnings are not silenced even by --quiet (→ docs/spec.md stream discipline · ADR-0015, ADR-0024).
+// When recopy=true it suppresses the copy foreign skip warning (recopy overwrites foreign too, so
+// "skipped" would be a false report · → ADR-0020).
 func (a *applier) emitWarnings(ws []planner.Warning, recopy bool) {
 	for _, w := range ws {
 		switch w.Kind {

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/yasunori0418/nput/internal/paths"
 )
 
-// profileDirFor は --root 上書き（roothash キー）時の profileDir を返す。
+// profileDirFor returns the profileDir for the --root override (roothash key) case.
 func profileDirFor(t *testing.T, state, root, name string) string {
 	t.Helper()
 	return paths.Resolve(state, name, manifest.RootKindProject, root, true).Dir
@@ -21,7 +21,7 @@ func profileDirFor(t *testing.T, state, root, name string) string {
 
 // --- test helpers ----------------------------------------------------------
 
-// realTempDir は EvalSymlinks 済みの tmpdir を返す（macOS の /var → /private/var 対策）。
+// realTempDir returns an EvalSymlinks'd tmpdir (works around macOS /var → /private/var).
 func realTempDir(t *testing.T) string {
 	t.Helper()
 	d, err := filepath.EvalSymlinks(t.TempDir())
@@ -31,7 +31,7 @@ func realTempDir(t *testing.T) string {
 	return d
 }
 
-// writeLinkFarm は手書き manifest.json を持つ link-farm ディレクトリを作って返す。
+// writeLinkFarm creates and returns a link-farm directory with a hand-written manifest.json.
 func writeLinkFarm(t *testing.T, m manifest.Manifest) string {
 	t.Helper()
 	dir := realTempDir(t)
@@ -45,7 +45,7 @@ func writeLinkFarm(t *testing.T, m manifest.Manifest) string {
 	return dir
 }
 
-// makeSrc は store src 相当の tmpdir に <subpath> のファイルを作って src dir を返す。
+// makeSrc creates a file at <subpath> in a store-src-equivalent tmpdir and returns the src dir.
 func makeSrc(t *testing.T, subpath string) string {
 	t.Helper()
 	src := realTempDir(t)
@@ -59,8 +59,8 @@ func makeSrc(t *testing.T, subpath string) string {
 	return src
 }
 
-// fakeCommit は nix-env --set を模し、profile リンクを link-farm へ張る
-// （前世代 manifest の読み取りを後続 apply で成立させる）。
+// fakeCommit mimics nix-env --set and links the profile link to the link-farm
+// (so that reading the previous generation's manifest works on a subsequent apply).
 func fakeCommit(captured *[][2]string) CommitFunc {
 	return func(profileLink, linkFarm string) error {
 		if captured != nil {
@@ -95,7 +95,7 @@ func storeEntry(src, subpath, target string) manifest.Entry {
 	}
 }
 
-// outOfStoreEntry は marker のローカル絶対パス（store 外）を指す out-of-store symlink entry。
+// outOfStoreEntry is an out-of-store symlink entry pointing at the marker's local absolute path (outside the store).
 func outOfStoreEntry(src, subpath, target string) manifest.Entry {
 	return manifest.Entry{
 		SrcKind: manifest.SrcKindOutOfStore,
@@ -112,8 +112,8 @@ func copyEntry(src, subpath, target string) manifest.Entry {
 	return e
 }
 
-// makeROSrc は store 相当の read-only ファイル（0o444）を <subpath> に作って src dir を返す。
-// copy の mode 保存 + owner-write 付与（0444 → 0644）を検証するための src。
+// makeROSrc creates a store-equivalent read-only file (0o444) at <subpath> and returns the src dir.
+// A src for verifying copy's mode preservation + owner-write addition (0444 → 0644).
 func makeROSrc(t *testing.T, subpath, content string) string {
 	t.Helper()
 	src := realTempDir(t)
@@ -153,7 +153,7 @@ func TestApplyFirstPlacementProjectMode(t *testing.T) {
 		t.Fatalf("Apply: %v", err)
 	}
 
-	// symlink が <root>/<target> -> <src>/<subpath> で張られる。
+	// symlink is created as <root>/<target> -> <src>/<subpath>.
 	target := filepath.Join(root, ".claude", "skills", "nix")
 	dest, err := os.Readlink(target)
 	if err != nil {
@@ -163,7 +163,7 @@ func TestApplyFirstPlacementProjectMode(t *testing.T) {
 		t.Errorf("symlink dest = %q, want %q", dest, want)
 	}
 
-	// profileDir レイアウトが <state>/nix/profiles/nput/<roothash>/<name> に作られる。
+	// The profileDir layout is created at <state>/nix/profiles/nput/<roothash>/<name>.
 	if !strings.HasPrefix(res.ProfileDir, filepath.Join(state, "nix", "profiles", "nput")) {
 		t.Errorf("ProfileDir = %q, not under state base", res.ProfileDir)
 	}
@@ -171,7 +171,7 @@ func TestApplyFirstPlacementProjectMode(t *testing.T) {
 		t.Errorf("profileDir not created: %v", err)
 	}
 
-	// backref .root が <roothash> 階層に root の絶対パスを記録する。
+	// backref .root records root's absolute path at the <roothash> level.
 	backref := filepath.Join(filepath.Dir(res.ProfileDir), ".root")
 	data, err := os.ReadFile(backref)
 	if err != nil {
@@ -181,7 +181,7 @@ func TestApplyFirstPlacementProjectMode(t *testing.T) {
 		t.Errorf("backref = %q, want %q", strings.TrimSpace(string(data)), root)
 	}
 
-	// commit が profileDir/profile と link-farm で 1 回呼ばれる。
+	// commit is called once with profileDir/profile and the link-farm.
 	if len(commits) != 1 {
 		t.Fatalf("commit calls = %d, want 1", len(commits))
 	}
@@ -209,7 +209,7 @@ func TestApplySubpathDot(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if dest != src { // subpath="." → src そのもの
+	if dest != src { // subpath="." → src itself
 		t.Errorf("dest = %q, want %q", dest, src)
 	}
 }
@@ -219,7 +219,7 @@ func TestApplyAncestorSymlinkError(t *testing.T) {
 	src := makeSrc(t, "x")
 	state := realTempDir(t)
 
-	// <root>/.claude を symlink 配置済みにする → 配下に nix をネストできない。
+	// Make <root>/.claude an already-placed symlink → cannot nest nix beneath it.
 	if err := os.Symlink(realTempDir(t), filepath.Join(root, ".claude")); err != nil {
 		t.Fatal(err)
 	}
@@ -259,7 +259,7 @@ func TestApplyForeignSymlinkWarns(t *testing.T) {
 	src := makeSrc(t, "x")
 	state := realTempDir(t)
 
-	// 記録の無い foreign symlink を target に置く。
+	// Place an unrecorded foreign symlink at the target.
 	foreign := realTempDir(t)
 	if err := os.MkdirAll(filepath.Join(root, ".config"), 0o755); err != nil {
 		t.Fatal(err)
@@ -302,7 +302,7 @@ func TestApplyRecordedSymlinkReplacedSilently(t *testing.T) {
 		t.Fatalf("first Apply: %v", err)
 	}
 
-	// 2 回目: 同 target・別 src。前世代記録と一致するので foreign 警告を出さず張替。
+	// Second apply: same target, different src. Matches the previous generation's record, so re-link without a foreign warning.
 	src2 := makeSrc(t, "x")
 	lf2 := writeLinkFarm(t, projectManifest(storeEntry(src2, ".", ".config/foo")))
 	var warns []string
@@ -332,7 +332,7 @@ func TestApplyStaleRemoval(t *testing.T) {
 	state := realTempDir(t)
 	src := makeSrc(t, "x")
 
-	// 1 回目: 2 entry。
+	// First apply: 2 entries.
 	lf1 := writeLinkFarm(t, projectManifest(
 		storeEntry(src, ".", ".config/keep"),
 		storeEntry(src, ".", ".config/drop"),
@@ -347,7 +347,7 @@ func TestApplyStaleRemoval(t *testing.T) {
 		t.Fatalf("drop should exist after first apply: %v", err)
 	}
 
-	// 2 回目: drop を外す → stale 除去される。keep は残る。
+	// Second apply: drop drop → stale-removed. keep remains.
 	lf2 := writeLinkFarm(t, projectManifest(storeEntry(src, ".", ".config/keep")))
 	res, err := Apply(Options{
 		LinkFarm: lf2, Name: "c", RootOverride: root, StateDir: state, Commit: fakeCommit(&commits),
@@ -379,14 +379,14 @@ func TestApplyStaleRemovalKeepsForeign(t *testing.T) {
 		t.Fatalf("first Apply: %v", err)
 	}
 
-	// ユーザーが target を別の先へ差し替える（記録と不一致）→ stale 除去しない。
+	// User swaps the target to point elsewhere (mismatch with the record) → no stale removal.
 	tgt := filepath.Join(root, ".config", "drop")
 	_ = os.Remove(tgt)
 	if err := os.Symlink(realTempDir(t), tgt); err != nil {
 		t.Fatal(err)
 	}
 
-	lf2 := writeLinkFarm(t, projectManifest()) // 空 manifest = 全クリア。
+	lf2 := writeLinkFarm(t, projectManifest()) // empty manifest = clear everything.
 	var warns []string
 	res, err := Apply(Options{
 		LinkFarm: lf2, Name: "c", RootOverride: root, StateDir: state,
@@ -431,7 +431,7 @@ func TestApplyNoWaitSkipsWhenLocked(t *testing.T) {
 	src := makeSrc(t, "x")
 	lf := writeLinkFarm(t, projectManifest(storeEntry(src, ".", ".config/foo")))
 
-	// profileDir を先に作って flock を握っておく。
+	// Create profileDir first and hold the flock.
 	prof := profileDirFor(t, state, root, "c")
 	if err := os.MkdirAll(prof, 0o755); err != nil {
 		t.Fatal(err)
@@ -451,7 +451,7 @@ func TestApplyNoWaitSkipsWhenLocked(t *testing.T) {
 	if res == nil || !res.Skipped {
 		t.Errorf("expected res.Skipped = true, got %+v", res)
 	}
-	// skip したので配置はされない。
+	// Skipped, so nothing is placed.
 	if _, err := os.Lstat(filepath.Join(root, ".config", "foo")); !os.IsNotExist(err) {
 		t.Errorf("skip should not place: lstat err = %v", err)
 	}
@@ -460,7 +460,7 @@ func TestApplyNoWaitSkipsWhenLocked(t *testing.T) {
 func TestApplyOutOfStorePlacesLiveSymlink(t *testing.T) {
 	root := realTempDir(t)
 	state := realTempDir(t)
-	// store 外のローカル実体を out-of-store のリンク先に使う。
+	// Use a local entity outside the store as the out-of-store link target.
 	src := makeSrc(t, "lua/init.lua")
 	lf := writeLinkFarm(t, projectManifest(outOfStoreEntry(src, "lua", ".config/nvim")))
 
@@ -476,11 +476,11 @@ func TestApplyOutOfStorePlacesLiveSymlink(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Readlink target: %v", err)
 	}
-	// live symlink は marker の絶対パス（<src>/<subpath>）を直接指す。
+	// The live symlink points directly at the marker's absolute path (<src>/<subpath>).
 	if want := filepath.Join(src, "lua"); dest != want {
 		t.Errorf("symlink dest = %q, want %q (local abs path)", dest, want)
 	}
-	// dangling でなく実体に解決できる。
+	// Resolves to a live entity, not dangling.
 	if _, err := os.Stat(target); err != nil {
 		t.Errorf("symlink should resolve to a live path: %v", err)
 	}
@@ -494,7 +494,7 @@ func TestApplyOutOfStoreStaleRemoval(t *testing.T) {
 	state := realTempDir(t)
 	src := makeSrc(t, "x")
 
-	// 1 回目: out-of-store entry を配置（manifest に marker の絶対パスが記録される）。
+	// First apply: place the out-of-store entry (the marker's absolute path is recorded in the manifest).
 	lf1 := writeLinkFarm(t, projectManifest(outOfStoreEntry(src, ".", ".config/nvim")))
 	var commits [][2]string
 	if _, err := Apply(Options{
@@ -507,7 +507,7 @@ func TestApplyOutOfStoreStaleRemoval(t *testing.T) {
 		t.Fatalf("first apply dest = %q, want %q", dest, src)
 	}
 
-	// 2 回目: 空 manifest。記録された out-of-store パスを指す link なので保守的不変条件を満たし除去。
+	// Second apply: empty manifest. The link points at the recorded out-of-store path, so it satisfies the conservative invariant and is removed.
 	lf2 := writeLinkFarm(t, projectManifest())
 	res, err := Apply(Options{
 		LinkFarm: lf2, Name: "c", RootOverride: root, StateDir: state, Commit: fakeCommit(&commits),
@@ -536,7 +536,7 @@ func TestApplyOutOfStoreStaleKeepsMismatch(t *testing.T) {
 		t.Fatalf("first Apply: %v", err)
 	}
 
-	// ユーザーが target を別のローカル先へ差し替える（記録と不一致）→ stale 除去しない。
+	// User swaps the target to a different local destination (mismatch with the record) → no stale removal.
 	tgt := filepath.Join(root, ".config", "nvim")
 	_ = os.Remove(tgt)
 	if err := os.Symlink(realTempDir(t), tgt); err != nil {
@@ -566,7 +566,7 @@ func TestApplyOutOfStoreStaleKeepsMismatch(t *testing.T) {
 func TestApplyOutOfStoreMissingPathError(t *testing.T) {
 	root := realTempDir(t)
 	state := realTempDir(t)
-	// 存在しないローカルパスを out-of-store のリンク先にする。
+	// Use a non-existent local path as the out-of-store link target.
 	missing := filepath.Join(realTempDir(t), "does-not-exist")
 	lf := writeLinkFarm(t, projectManifest(outOfStoreEntry(missing, ".", ".config/nvim")))
 
@@ -579,7 +579,7 @@ func TestApplyOutOfStoreMissingPathError(t *testing.T) {
 	if !strings.Contains(err.Error(), "out-of-store") {
 		t.Errorf("error should mention out-of-store: %v", err)
 	}
-	// 不在検査は配置前に閉じるため target は作られない。
+	// The absence check is closed before placement, so the target is not created.
 	if _, err := os.Lstat(filepath.Join(root, ".config", "nvim")); !os.IsNotExist(err) {
 		t.Errorf("should not place on missing path: lstat err = %v", err)
 	}
@@ -599,7 +599,7 @@ func TestApplyCopyPlaceOnceFile(t *testing.T) {
 	}
 
 	target := filepath.Join(root, ".config", "foo")
-	// 内容がコピーされる（symlink ではなく実ファイル）。
+	// Content is copied (a regular file, not a symlink).
 	fi, err := os.Lstat(target)
 	if err != nil {
 		t.Fatalf("Lstat target: %v", err)
@@ -611,7 +611,7 @@ func TestApplyCopyPlaceOnceFile(t *testing.T) {
 	if err != nil || string(data) != "store-content" {
 		t.Errorf("content = %q (err %v), want store-content", data, err)
 	}
-	// mode は保存しつつ owner-write を付与（0444 → 0644）。
+	// Preserve mode while adding owner-write (0444 → 0644).
 	if fi.Mode().Perm() != 0o644 {
 		t.Errorf("mode = %o, want 0644 (mode-preserve + owner-write)", fi.Mode().Perm())
 	}
@@ -626,20 +626,20 @@ func TestApplyCopyPlaceOnceKeepsExisting(t *testing.T) {
 	src := makeROSrc(t, "file.txt", "store-content")
 	lf := writeLinkFarm(t, projectManifest(copyEntry(src, "file.txt", ".config/foo")))
 
-	// 1 回目: 新規コピー。
+	// First apply: new copy.
 	var commits [][2]string
 	if _, err := Apply(Options{
 		LinkFarm: lf, Name: "c", RootOverride: root, StateDir: state, Commit: fakeCommit(&commits),
 	}); err != nil {
 		t.Fatalf("first Apply: %v", err)
 	}
-	// ユーザーが編集する。
+	// User edits it.
 	target := filepath.Join(root, ".config", "foo")
 	if err := os.WriteFile(target, []byte("user-edit"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
-	// 2 回目: place-once により target は触られない（編集が残る）。
+	// Second apply: place-once leaves the target untouched (the edit remains).
 	res, err := Apply(Options{
 		LinkFarm: lf, Name: "c", RootOverride: root, StateDir: state, Commit: fakeCommit(&commits),
 	})
@@ -660,7 +660,7 @@ func TestApplyCopyForeignFileSkipsWithWarn(t *testing.T) {
 	state := realTempDir(t)
 	src := makeROSrc(t, "file.txt", "store-content")
 
-	// 記録の無い foreign 実ファイルを target に置く。
+	// Place an unrecorded foreign regular file at the target.
 	target := filepath.Join(root, ".config", "foo")
 	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
 		t.Fatal(err)
@@ -678,7 +678,7 @@ func TestApplyCopyForeignFileSkipsWithWarn(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Apply: %v", err)
 	}
-	// place-once skip: foreign ファイルは上書きしない。
+	// place-once skip: the foreign file is not overwritten.
 	if data, _ := os.ReadFile(target); string(data) != "foreign" {
 		t.Errorf("foreign file should be kept, content = %q", data)
 	}
@@ -694,7 +694,7 @@ func TestApplyCopyDirRecursivePreservesSymlinks(t *testing.T) {
 	root := realTempDir(t)
 	state := realTempDir(t)
 
-	// src ツリー: ディレクトリ + ファイル + 内部 symlink。
+	// src tree: directory + file + internal symlink.
 	src := realTempDir(t)
 	if err := os.MkdirAll(filepath.Join(src, "tree", "sub"), 0o755); err != nil {
 		t.Fatal(err)
@@ -717,7 +717,7 @@ func TestApplyCopyDirRecursivePreservesSymlinks(t *testing.T) {
 	if data, _ := os.ReadFile(filepath.Join(dst, "sub", "f.txt")); string(data) != "hi" {
 		t.Errorf("nested file content = %q, want hi", data)
 	}
-	// 内部 symlink は deref されず symlink のまま複製される。
+	// The internal symlink is duplicated as a symlink without deref.
 	li, err := os.Lstat(filepath.Join(dst, "link"))
 	if err != nil {
 		t.Fatalf("Lstat link: %v", err)
@@ -736,7 +736,7 @@ func TestApplyRecopyOverwrites(t *testing.T) {
 	src := makeROSrc(t, "file.txt", "store-content")
 	lf := writeLinkFarm(t, projectManifest(copyEntry(src, "file.txt", ".config/foo")))
 
-	// 1 回目: 新規コピー。
+	// First apply: new copy.
 	var commits [][2]string
 	if _, err := Apply(Options{
 		LinkFarm: lf, Name: "c", RootOverride: root, StateDir: state, Commit: fakeCommit(&commits),
@@ -748,7 +748,7 @@ func TestApplyRecopyOverwrites(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// 2 回目: --recopy で無条件上書き → src 内容に戻る。
+	// Second apply: --recopy overwrites unconditionally → reverts to src content.
 	res, err := Apply(Options{
 		LinkFarm: lf, Name: "c", RootOverride: root, StateDir: state,
 		Recopy: true, Commit: fakeCommit(&commits),
@@ -769,7 +769,7 @@ func TestApplyRecopyForeignFileOverwrites(t *testing.T) {
 	state := realTempDir(t)
 	src := makeROSrc(t, "file.txt", "store-content")
 
-	// 記録の無い foreign ファイル: 通常 apply なら skip だが --recopy は無条件上書き。
+	// Unrecorded foreign file: normal apply would skip, but --recopy overwrites unconditionally.
 	target := filepath.Join(root, ".config", "foo")
 	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
 		t.Fatal(err)
@@ -793,7 +793,7 @@ func TestApplyRecopyForeignFileOverwrites(t *testing.T) {
 	if len(res.Recopied) != 1 {
 		t.Errorf("Recopied = %v, want 1", res.Recopied)
 	}
-	// recopy 経路では foreign skip 警告を出さない（上書きするため誤報）。
+	// On the recopy path no foreign skip warning is emitted (it overwrites, so that would be a false report).
 	for _, w := range warns {
 		if strings.Contains(w, "スキップ") {
 			t.Errorf("unexpected copy foreign skip warning during recopy: %q", w)

--- a/internal/engine/generations.go
+++ b/internal/engine/generations.go
@@ -14,24 +14,25 @@ import (
 	"github.com/yasunori0418/nput/internal/planner"
 )
 
-// 世代操作は `nix-env --profile <profileDir>/profile` 系で統一する（→ docs/spec.md 世代管理仕様・
-// ADR-0015, ADR-0025）。コミット（--set）は commit.go、ここでは rollback（--switch-generation）・
-// 一覧（--list-generations）を扱う。--set と同じく注入可能にして tmpdir テストでは nix を呼ばない。
+// Generation operations are unified under the `nix-env --profile <profileDir>/profile`
+// family (→ docs/spec.md generation management spec · ADR-0015, ADR-0025). Commit (--set)
+// lives in commit.go; here we handle rollback (--switch-generation) and listing
+// (--list-generations). Like --set, these are injectable so tmpdir tests do not call nix.
 
-// Generation は profile の 1 世代（nix-env --list-generations の 1 行）。
+// Generation is one generation of a profile (one line of nix-env --list-generations).
 type Generation struct {
-	Number  int    // 世代番号
-	Date    string // 作成日時（nix-env の表示そのまま。解析せず原文を運ぶ）
-	Current bool   // 現世代（profile リンクが指す）か
+	Number  int    // generation number
+	Date    string // creation timestamp (nix-env's display verbatim; carried unparsed)
+	Current bool   // whether it is the current generation (the one the profile link points at)
 }
 
-// ListGenerationsFunc は世代一覧の取得点（既定は nix-env --list-generations）。tmpdir テストで差し替える。
+// ListGenerationsFunc is the generation-list retrieval point (default nix-env --list-generations). Substituted in tmpdir tests.
 type ListGenerationsFunc func(profileLink string) ([]Generation, error)
 
-// SwitchGenerationFunc は profile ポインタ移動点（既定は nix-env --switch-generation）。tmpdir テストで差し替える。
+// SwitchGenerationFunc is the profile pointer move point (default nix-env --switch-generation). Substituted in tmpdir tests.
 type SwitchGenerationFunc func(profileLink string, gen int) error
 
-// ProfileOptions は profileDir を確定するための入力（Rollback / list-generations が共有）。
+// ProfileOptions is the input for fixing the profileDir (shared by Rollback / list-generations).
 type ProfileOptions struct {
 	Name         string
 	RootKind     string
@@ -42,8 +43,8 @@ type ProfileOptions struct {
 	Git          GitFunc
 }
 
-// ProfileFor は root を解決し profileDir レイアウトを確定する（apply の前段と同型・→ ADR-0023, ADR-0024）。
-// build をしない rollback / list-generations が flock / 世代読みのために共通で使う。
+// ProfileFor resolves root and fixes the profileDir layout (same shape as apply's preamble · → ADR-0023, ADR-0024).
+// Used in common by non-building rollback / list-generations for flock / generation reads.
 func ProfileFor(opts ProfileOptions) (paths.Profile, string, error) {
 	root, err := resolveRoot(opts.RootKind, opts.FixedRoot, opts.RootOverride, opts.WorkDir, opts.Git)
 	if err != nil {
@@ -60,13 +61,13 @@ func ProfileFor(opts ProfileOptions) (paths.Profile, string, error) {
 	return prof, root, nil
 }
 
-// ListGenerations は profileLink の世代一覧を返す（既定の nix-env 実装）。CLI の list-generations が使う。
+// ListGenerations returns the generation list for profileLink (default nix-env implementation). Used by the CLI's list-generations.
 func ListGenerations(profileLink string) ([]Generation, error) {
 	return nixEnvListGenerations(profileLink)
 }
 
-// RollbackOptions は Rollback の入力。Rollback は home mode 限定だが、その判定は CLI が担い
-// engine は rootKind に依らず profileDir を解決して前世代へ収束させる。
+// RollbackOptions is the input to Rollback. Rollback is home mode only, but that decision is
+// the CLI's; the engine resolves the profileDir regardless of rootKind and converges to the previous generation.
 type RollbackOptions struct {
 	Name         string
 	RootKind     string
@@ -75,26 +76,28 @@ type RollbackOptions struct {
 	WorkDir      string
 	StateDir     string
 
-	// ListGenerations / SwitchGeneration は nix-env 呼び出しの差し替え（nil = 既定の nix-env 実装）。
+	// ListGenerations / SwitchGeneration substitute the nix-env calls (nil = default nix-env implementation).
 	ListGenerations  ListGenerationsFunc
 	SwitchGeneration SwitchGenerationFunc
-	// Git は git toplevel 解決の差し替え（nil = gitutil.Toplevel）。home mode では未使用。
+	// Git substitutes git toplevel resolution (nil = gitutil.Toplevel). Unused in home mode.
 	Git GitFunc
-	// Warnf は warning の出力先（nil = stderr）。
+	// Warnf is the warning output sink (nil = stderr).
 	Warnf func(format string, args ...any)
 }
 
-// RollbackResult は Rollback の結果レポート。Result（配置差分）に世代遷移 From→To を添える。
+// RollbackResult is the result report of Rollback. It augments Result (placement diff) with the generation transition From→To.
 type RollbackResult struct {
 	Result
-	From int // 戻る前の現世代 N
-	To   int // 戻った先の前世代 N-1
+	From int // current generation N before rolling back
+	To   int // previous generation N-1 rolled back to
 }
 
-// Rollback は home mode の profile を 1 世代前へ戻す。profile ポインタ移動だけでは任意 root の FS は
-// 変わらないため、現世代 N を baseline・前世代 N-1 を target として planner で diff し、N∖N-1 を保守的に
-// stale 除去・N-1 の entry を再配置してから **最後に** profile ポインタを移す（→ docs/spec.md ロールバック・ADR-0015）。
-// ポインタを先に動かすと baseline が N-2 へずれ stale 除去が誤るため、FS 収束を先・ポインタ移動を最後にする。
+// Rollback reverts a home-mode profile to one generation earlier. A profile pointer move alone
+// does not change the FS at an arbitrary root, so it diffs with the planner using current
+// generation N as baseline and previous generation N-1 as target, conservatively stale-removes
+// N∖N-1, re-places N-1's entries, and only **last** moves the profile pointer (→ docs/spec.md
+// rollback · ADR-0015). Moving the pointer first would shift the baseline to N-2 and corrupt
+// stale removal, so FS convergence comes first and the pointer move last.
 func Rollback(opts RollbackOptions) (*RollbackResult, error) {
 	warnf := opts.Warnf
 	if warnf == nil {
@@ -111,7 +114,7 @@ func Rollback(opts RollbackOptions) (*RollbackResult, error) {
 		switchFn = nixEnvSwitchGeneration
 	}
 
-	// 1. profileDir 確定（root 解決 → レイアウト・apply と共通の前段）。
+	// 1. fix profileDir (resolve root → layout · preamble shared with apply).
 	prof, root, err := ProfileFor(ProfileOptions{
 		Name: opts.Name, RootKind: opts.RootKind, FixedRoot: opts.FixedRoot,
 		RootOverride: opts.RootOverride, WorkDir: opts.WorkDir, StateDir: opts.StateDir, Git: opts.Git,
@@ -120,19 +123,19 @@ func Rollback(opts RollbackOptions) (*RollbackResult, error) {
 		return nil, err
 	}
 
-	// profileDir が無ければ一度も apply していない → 戻る世代が存在しない。
+	// If profileDir is absent, apply has never run → no generation to roll back to.
 	if _, err := os.Stat(prof.Dir); err != nil {
 		return nil, fmt.Errorf("nput: profile がありません（一度も apply していません）: %s", prof.Dir)
 	}
 
-	// 2. flock（blocking）で並行 apply / rollback と直列化する（→ ADR-0013）。
+	// 2. serialize with concurrent apply / rollback via a blocking flock (→ ADR-0013).
 	l, err := lock.Acquire(prof.Dir, true)
 	if err != nil {
 		return nil, fmt.Errorf("nput: flock の取得に失敗しました (%s): %w", prof.Dir, err)
 	}
 	defer func() { _ = l.Release() }()
 
-	// 3. 世代一覧から現世代 N と前世代 N-1 を特定する。
+	// 3. identify current generation N and previous generation N-1 from the generation list.
 	gens, err := listFn(prof.Profile)
 	if err != nil {
 		return nil, err
@@ -152,7 +155,7 @@ func Rollback(opts RollbackOptions) (*RollbackResult, error) {
 	cur := gens[curIdx]
 	prev := gens[curIdx-1]
 
-	// 4. baseline = 現世代 N の manifest（FS の現状）/ target = 前世代 N-1 の manifest。
+	// 4. baseline = current generation N's manifest (current FS state) / target = previous generation N-1's manifest.
 	baseline, err := manifest.Load(prof.Profile)
 	if err != nil {
 		return nil, fmt.Errorf("nput: 現世代 manifest を読めません: %w", err)
@@ -162,7 +165,7 @@ func Rollback(opts RollbackOptions) (*RollbackResult, error) {
 		return nil, fmt.Errorf("nput: 前世代 manifest を読めません (世代 %d): %w", prev.Number, err)
 	}
 
-	// 5. planner で N∖N-1 stale 除去・N-1 entry 再配置のプランを算出する（apply エンジンを (baseline, target) 差し替えで再利用）。
+	// 5. compute the plan for N∖N-1 stale removal · N-1 entry re-placement with the planner (reusing the apply engine with (baseline, target) substituted).
 	plan, err := planner.Compute(baseline, target, root, planner.OSFS)
 	if err != nil {
 		return nil, err
@@ -172,7 +175,7 @@ func Rollback(opts RollbackOptions) (*RollbackResult, error) {
 		return nil, fmt.Errorf("nput: %s (target: %s)", c.Reason, c.Entry.Target)
 	}
 
-	// 6. プランを実 FS に反映（新規/張替を先に、stale 除去を最後に・→ ADR-0006）。
+	// 6. reflect the plan onto the real FS (new/re-link first, stale removal last · → ADR-0006).
 	a := &applier{opts: Options{Warnf: warnf}, result: &Result{Root: root, ProfileDir: prof.Dir}}
 	a.profile = prof
 	a.root = root
@@ -184,7 +187,7 @@ func Rollback(opts RollbackOptions) (*RollbackResult, error) {
 		return nil, err
 	}
 
-	// 7. 最後に profile ポインタを N-1 へ移す（→ docs/spec.md ロールバック手順 3）。
+	// 7. finally move the profile pointer to N-1 (→ docs/spec.md rollback step 3).
 	if err := switchFn(prof.Profile, prev.Number); err != nil {
 		return nil, fmt.Errorf("nput: profile ポインタの移動に失敗しました（--switch-generation %d）: %w", prev.Number, err)
 	}
@@ -192,8 +195,8 @@ func Rollback(opts RollbackOptions) (*RollbackResult, error) {
 	return &RollbackResult{Result: *a.result, From: cur.Number, To: prev.Number}, nil
 }
 
-// nixEnvListGenerations は既定の世代一覧取得（nix-env --profile <p> --list-generations）。
-// stdout を捕捉して解析する（機械可読出力の取り込み）。
+// nixEnvListGenerations is the default generation-list retrieval (nix-env --profile <p> --list-generations).
+// It captures and parses stdout (ingesting machine-readable output).
 func nixEnvListGenerations(profileLink string) ([]Generation, error) {
 	if _, err := exec.LookPath("nix-env"); err != nil {
 		return nil, fmt.Errorf("nix-env が PATH にありません: %w", err)
@@ -212,8 +215,8 @@ func nixEnvListGenerations(profileLink string) ([]Generation, error) {
 	return parseGenerations(stdout.String())
 }
 
-// nixEnvSwitchGeneration は既定の profile ポインタ移動（nix-env --profile <p> --switch-generation <gen>）。
-// nix の出力は stderr に流す（stdout は機械可読出力に専有・→ docs/spec.md ストリーム規律）。
+// nixEnvSwitchGeneration is the default profile pointer move (nix-env --profile <p> --switch-generation <gen>).
+// nix output is routed to stderr (stdout is reserved for machine-readable output · → docs/spec.md stream discipline).
 func nixEnvSwitchGeneration(profileLink string, gen int) error {
 	if _, err := exec.LookPath("nix-env"); err != nil {
 		return fmt.Errorf("nix-env が PATH にありません: %w", err)
@@ -224,8 +227,8 @@ func nixEnvSwitchGeneration(profileLink string, gen int) error {
 	return cmd.Run()
 }
 
-// parseGenerations は `nix-env --list-generations` の出力を解析する。各行は
-// 「<番号>   <日時>   [(current)]」形式（先頭・区切りは空白可変）。
+// parseGenerations parses the output of `nix-env --list-generations`. Each line is of the
+// form "<number>   <timestamp>   [(current)]" (leading and separating whitespace is variable).
 func parseGenerations(out string) ([]Generation, error) {
 	var gens []Generation
 	for _, line := range strings.Split(out, "\n") {

--- a/internal/engine/generations_test.go
+++ b/internal/engine/generations_test.go
@@ -59,8 +59,8 @@ func TestParseGenerationsBadLine(t *testing.T) {
 	}
 }
 
-// TestRollbackReconverges は現世代 N → 前世代 N-1 への FS 再収束を検証する。
-// gen1 = {a, b}, gen2(現) = {a, c}。rollback で c を stale 除去・b を再配置し a は残す。
+// TestRollbackReconverges verifies FS re-convergence from current generation N → previous generation N-1.
+// gen1 = {a, b}, gen2(current) = {a, c}. Rollback stale-removes c, re-places b, and keeps a.
 func TestRollbackReconverges(t *testing.T) {
 	root := realTempDir(t)
 	state := realTempDir(t)
@@ -68,7 +68,7 @@ func TestRollbackReconverges(t *testing.T) {
 	srcB := makeSrc(t, "x")
 	srcC := makeSrc(t, "x")
 
-	// --root 上書きで home + roothash キーにし $HOME 非依存にする。
+	// Use the --root override for home + roothash key to be independent of $HOME.
 	prof := paths.Resolve(state, "vim", manifest.RootKindHome, root, true)
 	if err := os.MkdirAll(prof.Dir, 0o755); err != nil {
 		t.Fatal(err)
@@ -83,7 +83,7 @@ func TestRollbackReconverges(t *testing.T) {
 		storeEntry(srcC, ".", "c"),
 	))
 
-	// 世代リンク（profile-N-link）と現 profile（gen2）を用意する。
+	// Prepare the generation links (profile-N-link) and the current profile (gen2).
 	if err := os.Symlink(lf1, paths.GenerationLink(prof.Profile, 1)); err != nil {
 		t.Fatal(err)
 	}
@@ -94,7 +94,7 @@ func TestRollbackReconverges(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// 現状 FS = gen2: a→srcA, c→srcC を配置済みにする。
+	// Current FS = gen2: place a→srcA, c→srcC.
 	if err := os.Symlink(srcA, filepath.Join(root, "a")); err != nil {
 		t.Fatal(err)
 	}
@@ -124,7 +124,7 @@ func TestRollbackReconverges(t *testing.T) {
 		t.Errorf("switched generation = %d, want 1", switched)
 	}
 
-	// FS は gen1 と一致する: a 残存・b 新規・c 除去。
+	// FS matches gen1: a remains, b new, c removed.
 	if dest, err := os.Readlink(filepath.Join(root, "a")); err != nil || dest != srcA {
 		t.Errorf("a: dest=%q err=%v, want %q", dest, err, srcA)
 	}
@@ -139,7 +139,7 @@ func TestRollbackReconverges(t *testing.T) {
 	}
 }
 
-// TestRollbackNoPreviousErrors は現世代が最古（前世代なし）のとき rollback がエラー停止することを検証する。
+// TestRollbackNoPreviousErrors verifies that rollback stops with an error when the current generation is the oldest (no previous generation).
 func TestRollbackNoPreviousErrors(t *testing.T) {
 	root := realTempDir(t)
 	state := realTempDir(t)
@@ -162,7 +162,7 @@ func TestRollbackNoPreviousErrors(t *testing.T) {
 	}
 }
 
-// TestRollbackNoProfileErrors は profileDir が無い（未 apply）とき rollback がエラー停止することを検証する。
+// TestRollbackNoProfileErrors verifies that rollback stops with an error when profileDir is absent (never applied).
 func TestRollbackNoProfileErrors(t *testing.T) {
 	root := realTempDir(t)
 	state := realTempDir(t)
@@ -176,7 +176,7 @@ func TestRollbackNoProfileErrors(t *testing.T) {
 	}
 }
 
-// TestResolveRootHome は rootKind=home が $HOME を返すことを検証する（root resolver 単体）。
+// TestResolveRootHome verifies that rootKind=home returns $HOME (root resolver unit test).
 func TestResolveRootHome(t *testing.T) {
 	home := realTempDir(t)
 	t.Setenv("HOME", home)
@@ -189,7 +189,7 @@ func TestResolveRootHome(t *testing.T) {
 	}
 }
 
-// TestResolveRootOverrideWins は --root 上書きが rootKind に依らず優先されることを検証する。
+// TestResolveRootOverrideWins verifies that the --root override takes precedence regardless of rootKind.
 func TestResolveRootOverrideWins(t *testing.T) {
 	override := realTempDir(t)
 	got, err := resolveRoot(manifest.RootKindHome, "", override, "", nil)

--- a/internal/engine/place.go
+++ b/internal/engine/place.go
@@ -9,12 +9,13 @@ import (
 )
 
 // place materializes the planner's Place actions as native symlinks
-// （新規 / 張替を stale 除去より先に・→ ADR-0006）。プランは planner.Compute が
-// 現 FS 状態から算出済みで、ここは plan を実 FS に反映する薄い executor に徹する。
-// 本スライスは store / out-of-store の symlink 配置のみ（copy は将来スライス・→ Issue #6）。
+// (new / re-link before stale removal · → ADR-0006). The plan is already computed by
+// planner.Compute from the current FS state, so this stays a thin executor that reflects
+// the plan onto the real FS. This slice covers only store / out-of-store symlink placement
+// (copy is a future slice · → Issue #6).
 func (a *applier) place(actions []planner.PlaceAction) error {
 	for _, act := range actions {
-		// 親ディレクトリを作成（祖先 symlink は planner が conflict として弾き済み・→ ADR-0015）。
+		// Create the parent directory (ancestor symlinks are already rejected as conflicts by the planner · → ADR-0015).
 		if err := os.MkdirAll(filepath.Dir(act.TargetAbs), 0o755); err != nil {
 			return fmt.Errorf("nput: 親ディレクトリを作成できません (%s): %w", filepath.Dir(act.TargetAbs), err)
 		}
@@ -23,8 +24,8 @@ func (a *applier) place(actions []planner.PlaceAction) error {
 		case planner.PlaceNew:
 			a.result.Placed = append(a.result.Placed, act.Entry.Target)
 		case planner.PlaceReplace, planner.PlaceForeign:
-			// 張替は unlink + symlink（rename ベースの atomic swap は採らない・→ ADR-0017）。
-			// foreign 上書きの warning は planner.Warnings 経由で emitWarnings 済み（→ ADR-0015）。
+			// Re-link is unlink + symlink (no rename-based atomic swap · → ADR-0017).
+			// The foreign-overwrite warning is already emitted via planner.Warnings by emitWarnings (→ ADR-0015).
 			if err := os.Remove(act.TargetAbs); err != nil {
 				return fmt.Errorf("nput: 既存 symlink を除去できません (%s): %w", act.TargetAbs, err)
 			}

--- a/internal/engine/preflight.go
+++ b/internal/engine/preflight.go
@@ -8,14 +8,15 @@ import (
 	"github.com/yasunori0418/nput/internal/planner"
 )
 
-// checkOutOfStore は out-of-store symlink entry のリンク先（marker のローカル絶対パス +
-// subpath = planner.LinkDest）が実在することを配置直前に検査する。不在なら dangling symlink
-// を張ることになるため engine 実行時エラーで停止する（「リンク先不在は実行時エラー」・→ ADR-0001,
-// ADR-0013, docs/spec.md「out-of-store symlink」）。
+// checkOutOfStore checks, just before placement, that the link target of out-of-store symlink
+// entries (the marker's local absolute path + subpath = planner.LinkDest) actually exists. If
+// absent, placing it would create a dangling symlink, so it stops with an engine runtime error
+// ("an absent link target is a runtime error" · → ADR-0001, ADR-0013, docs/spec.md "out-of-store symlink").
 //
-// 検査は out-of-store のみに閉じる: store link は farm derivation のビルドで実在が保証され、
-// copy は別経路（place-once・本検査の対象外）。method=copy × out-of-store marker は
-// normalizeManifest が eval 時に弾くため、ここに copy の out-of-store entry は来ない（→ ADR-0013）。
+// The check is closed to out-of-store only: store links are guaranteed to exist by the farm
+// derivation build, and copy goes through a different path (place-once · outside this check).
+// method=copy × out-of-store marker is rejected by normalizeManifest at eval time, so no copy
+// out-of-store entry reaches here (→ ADR-0013).
 func (a *applier) checkOutOfStore() error {
 	for _, e := range a.manifest.Entries {
 		if e.SrcKind != manifest.SrcKindOutOfStore {

--- a/internal/engine/reset.go
+++ b/internal/engine/reset.go
@@ -10,21 +10,26 @@ import (
 	"github.com/yasunori0418/nput/internal/planner"
 )
 
-// reset は配置物を無い状態へ戻す FS-only teardown（→ ADR-0020, ADR-0021, ADR-0025,
-// docs/spec.md「recopy・reset」）。
+// reset is an FS-only teardown that reverts placed entities to a not-placed state (→ ADR-0020,
+// ADR-0021, ADR-0025, docs/spec.md "recopy · reset").
 //
-//   - symlink: stale 除去と同じ保守的不変条件（前世代 manifest が記録し、かつ現状もその記録通りの
-//     先を指す symlink のみ削除。foreign / 記録不一致は warning で残す）。planner.Compute（next=nil）+
-//     staleremove を再利用する（完成済みモジュール・→ planner, staleremove.go）。
-//   - copy target: 削除する（copy を消す唯一の明示手段・事前存在ファイルを消すリスクは CLI の確認で守る）。
-//   - profile / 世代は触らない。config が entry を残す限り次の apply で再配置される（transient）。
+//   - symlink: the same conservative invariant as stale removal (delete only symlinks that the
+//     previous generation's manifest recorded and that currently still point at the recorded dest.
+//     foreign / record mismatches are kept with a warning). Reuses planner.Compute (next=nil) +
+//     staleremove (finished modules · → planner, staleremove.go).
+//   - copy target: deleted (the only explicit means to remove a copy · the risk of deleting a
+//     pre-existing file is guarded by the CLI's confirmation).
+//   - profile / generations are untouched. As long as the config keeps the entry it is re-placed
+//     on the next apply (transient).
 //
-// 撤去対象 entry の源は **前世代 manifest（profileDir/profile が指す link-farm の manifest.json）**。
-// これが「nput が実際に配置した（記録した）真実」で、保守的不変条件の "recorded dest" と一致する
-// （config を build し直すと src ドリフト時に記録 dest とズレ誤判定するため、記録済み前世代を使う）。
-// rootKind 先取り eval（profileDir 確定）は CLI が担い、entries はこの前世代 manifest から読む。
+// The source of teardown-target entries is the **previous generation's manifest (the manifest.json
+// of the link-farm that profileDir/profile points at)**. This is "the truth of what nput actually
+// placed (recorded)" and matches the conservative invariant's "recorded dest" (rebuilding the
+// config would diverge from the recorded dest under src drift and misjudge, so the recorded
+// previous generation is used). The CLI handles the rootKind pre-resolution eval (fixing profileDir),
+// and entries are read from this previous generation's manifest.
 
-// ResetOptions は Reset の入力。Reset は build しない（前世代 manifest を読む）。
+// ResetOptions is the input to Reset. Reset does not build (it reads the previous generation's manifest).
 type ResetOptions struct {
 	Name         string
 	RootKind     string
@@ -34,32 +39,34 @@ type ResetOptions struct {
 	StateDir     string
 	Git          GitFunc
 
-	// Targets は撤去対象 target の絞り込み（root 相対・空 = 全 entry）。
-	// 前世代 manifest に存在しない target を指定するとエラーになる。
+	// Targets narrows the teardown-target targets (root-relative · empty = all entries).
+	// Specifying a target not present in the previous generation's manifest is an error.
 	Targets []string
-	// DryRun は副作用ゼロのプレビュー（削除対象を算出して返すだけ・flock / confirm / FS 削除なし・→ ADR-0021）。
+	// DryRun is a side-effect-free preview (just computes and returns the removal targets · no flock / confirm / FS deletion · → ADR-0021).
 	DryRun bool
-	// Confirm は削除実行前の確認コールバック（nil = 確認なしで実行・--yes 経路 / dryrun）。
-	// 算出済みプランを渡し、false を返すと中断する（Result.Aborted = true）。CLI が TTY プロンプトを担う。
+	// Confirm is the confirmation callback before performing deletion (nil = run without confirmation · --yes path / dryrun).
+	// It is passed the computed plan; returning false aborts (Result.Aborted = true). The CLI handles the TTY prompt.
 	Confirm func(*ResetResult) (bool, error)
-	// Warnf は warning の出力先（nil = stderr）。foreign symlink を残す等の可視化に使う。
+	// Warnf is the warning output sink (nil = stderr). Used to surface kept foreign symlinks etc.
 	Warnf func(format string, args ...any)
 }
 
-// ResetResult は Reset の結果（dryrun はプレビュー・実行時は実削除結果）。
+// ResetResult is the result of Reset (dryrun is a preview · at run time the actual deletion result).
 type ResetResult struct {
-	Root            string   // 解決後の絶対 root
-	ProfileDir      string   // 確定した profileDir
-	RemovedSymlinks []string // 削除した（dryrun は削除予定の）symlink target
-	RemovedCopies   []string // 削除した（dryrun は削除予定の）copy target
-	KeptForeign     []string // 保守的不変条件を満たさず残した symlink target（foreign / 記録不一致）
-	DryRun          bool     // 読み取り専用プレビューだった
-	Aborted         bool     // 確認プロンプトで中断した
+	Root            string   // resolved absolute root
+	ProfileDir      string   // the fixed profileDir
+	RemovedSymlinks []string // removed (in dryrun, to-be-removed) symlink targets
+	RemovedCopies   []string // removed (in dryrun, to-be-removed) copy targets
+	KeptForeign     []string // symlink targets kept for not satisfying the conservative invariant (foreign / record mismatch)
+	DryRun          bool     // was a read-only preview
+	Aborted         bool     // aborted at the confirmation prompt
 }
 
-// Reset は対象 entry の配置物を無い状態へ戻す。docs/spec.md「実行フロー」の非 build コマンド前段
-// （rootKind 先取り eval → root 解決 → profileDir 確定）を CLI と分担し、engine 側は profileDir 解決・
-// blocking flock・前世代 manifest 読み・保守的 symlink 除去 + copy 削除を所有する（→ ADR-0021, ADR-0024）。
+// Reset reverts the placed entities of the target entries to a not-placed state. It shares with the
+// CLI the non-build command preamble of docs/spec.md "execution flow" (rootKind pre-resolution eval →
+// root resolution → fixing profileDir), and the engine side owns profileDir resolution · blocking
+// flock · reading the previous generation's manifest · conservative symlink removal + copy deletion
+// (→ ADR-0021, ADR-0024).
 func Reset(opts ResetOptions) (*ResetResult, error) {
 	warnf := opts.Warnf
 	if warnf == nil {
@@ -68,7 +75,7 @@ func Reset(opts ResetOptions) (*ResetResult, error) {
 		}
 	}
 
-	// 1. profileDir 確定（root 解決 → レイアウト・apply / rollback と共通の前段・→ ADR-0024）。
+	// 1. fix profileDir (resolve root → layout · preamble shared with apply / rollback · → ADR-0024).
 	prof, root, err := ProfileFor(ProfileOptions{
 		Name: opts.Name, RootKind: opts.RootKind, FixedRoot: opts.FixedRoot,
 		RootOverride: opts.RootOverride, WorkDir: opts.WorkDir, StateDir: opts.StateDir, Git: opts.Git,
@@ -78,7 +85,7 @@ func Reset(opts ResetOptions) (*ResetResult, error) {
 	}
 	res := &ResetResult{Root: root, ProfileDir: prof.Dir, DryRun: opts.DryRun}
 
-	// profile（前世代リンク）が無ければ一度も apply していない = 撤去対象ゼロの no-op。
+	// If profile (the previous generation link) is absent, apply has never run = a no-op with zero teardown targets.
 	if _, err := os.Stat(prof.Profile); err != nil {
 		if os.IsNotExist(err) {
 			return res, nil
@@ -86,8 +93,8 @@ func Reset(opts ResetOptions) (*ResetResult, error) {
 		return nil, fmt.Errorf("nput: profile を確認できません (%s): %w", prof.Profile, err)
 	}
 
-	// 2. 実行時は blocking flock で並行 apply / reset と直列化する（→ ADR-0013, ADR-0021）。
-	//    dryrun は読み取り専用なので flock を取らない。
+	// 2. at run time, serialize with concurrent apply / reset via a blocking flock (→ ADR-0013, ADR-0021).
+	//    dryrun is read-only, so it does not take a flock.
 	if !opts.DryRun {
 		l, err := lock.Acquire(prof.Dir, true)
 		if err != nil {
@@ -96,7 +103,7 @@ func Reset(opts ResetOptions) (*ResetResult, error) {
 		defer func() { _ = l.Release() }()
 	}
 
-	// 3. 前世代 manifest（記録済みの真実）を読み、対象 entry を絞り込む。
+	// 3. read the previous generation's manifest (the recorded truth) and narrow the target entries.
 	prev, err := manifest.Load(prof.Profile)
 	if err != nil {
 		return nil, err
@@ -106,8 +113,8 @@ func Reset(opts ResetOptions) (*ResetResult, error) {
 		return nil, err
 	}
 
-	// 4. symlink は保守的不変条件で除去するプランを planner で算出（next=nil で全対象が remove 候補）。
-	//    copy は planner が決して消さない領域なので分離して扱う。
+	// 4. for symlinks, compute a conservative-invariant removal plan with the planner (next=nil makes all targets remove candidates).
+	//    copy is a region the planner never removes, so handle it separately.
 	var symEntries, copyEntries []manifest.Entry
 	for _, e := range entries {
 		if e.Method == manifest.MethodCopy {
@@ -122,7 +129,7 @@ func Reset(opts ResetOptions) (*ResetResult, error) {
 		return nil, err
 	}
 
-	// 5. copy target のうち実在するものを削除候補にする（不在は no-op・→ docs/spec.md エラー仕様）。
+	// 5. make the existing copy targets removal candidates (absent ones are a no-op · → docs/spec.md error spec).
 	copyTargets := make([]string, 0, len(copyEntries))
 	for _, e := range copyEntries {
 		targetAbs := filepath.Join(root, filepath.Clean(e.Target))
@@ -134,7 +141,7 @@ func Reset(opts ResetOptions) (*ResetResult, error) {
 		}
 	}
 
-	// プレビュー（dryrun / confirm 表示）用に symlink 削除予定・残す foreign を詰める。
+	// For the preview (dryrun / confirm display), pack the to-be-removed symlinks and the kept foreign.
 	for _, a := range plan.Remove {
 		res.RemovedSymlinks = append(res.RemovedSymlinks, a.Entry.Target)
 	}
@@ -144,12 +151,12 @@ func Reset(opts ResetOptions) (*ResetResult, error) {
 		}
 	}
 
-	// 6. dryrun は算出済みプランを返して終了（FS 削除・confirm なし・→ ADR-0021）。
+	// 6. dryrun returns the computed plan and finishes (no FS deletion · no confirm · → ADR-0021).
 	if opts.DryRun {
 		return res, nil
 	}
 
-	// 7. 確認（データ損失リスク・→ ADR-0020, ADR-0025）。CLI が TTY プロンプト / --yes を担う。
+	// 7. confirmation (data-loss risk · → ADR-0020, ADR-0025). The CLI handles the TTY prompt / --yes.
 	if opts.Confirm != nil {
 		proceed, err := opts.Confirm(res)
 		if err != nil {
@@ -161,8 +168,8 @@ func Reset(opts ResetOptions) (*ResetResult, error) {
 		}
 	}
 
-	// 8. 実 FS に反映する。symlink は staleremove（plan 後ドリフト再検証つき）を再利用し、
-	//    copy target は削除する。残す foreign の warning を出す。
+	// 8. reflect onto the real FS. For symlinks reuse staleremove (with post-plan drift re-verification),
+	//    and delete copy targets. Emit warnings for the kept foreign.
 	a := &applier{opts: Options{Warnf: warnf}, result: &Result{Root: root, ProfileDir: prof.Dir}}
 	a.profile = prof
 	a.root = root
@@ -170,7 +177,7 @@ func Reset(opts ResetOptions) (*ResetResult, error) {
 	if err := a.removeStale(plan.Remove); err != nil {
 		return nil, err
 	}
-	res.RemovedSymlinks = a.result.Removed // 実削除分（ドリフトで残ったものは除外）
+	res.RemovedSymlinks = a.result.Removed // actually removed (excludes those kept due to drift)
 
 	removedCopies := make([]string, 0, len(copyTargets))
 	for i, targetAbs := range copyTargets {
@@ -184,8 +191,8 @@ func Reset(opts ResetOptions) (*ResetResult, error) {
 	return res, nil
 }
 
-// selectResetEntries は前世代 manifest の entry を Targets で絞り込む（空 = 全 entry）。
-// 指定 target が前世代に存在しなければエラー（nput が配置していない target は撤去対象にならない）。
+// selectResetEntries narrows the previous generation's manifest entries by Targets (empty = all entries).
+// If a specified target does not exist in the previous generation, it is an error (a target nput did not place is not a teardown target).
 func selectResetEntries(entries []manifest.Entry, targets []string) ([]manifest.Entry, error) {
 	if len(targets) == 0 {
 		return entries, nil

--- a/internal/engine/reset_test.go
+++ b/internal/engine/reset_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/yasunori0418/nput/internal/manifest"
 )
 
-// applyForReset は reset テストの前提として 1 世代を積む（prof.Profile が link-farm を指す）。
-// --root 上書き（RootOverride=root）で git に依存せず root を固定する。
+// applyForReset commits one generation as a precondition for reset tests (prof.Profile points at the link-farm).
+// The --root override (RootOverride=root) fixes root without depending on git.
 func applyForReset(t *testing.T, root, state string, m manifest.Manifest) {
 	t.Helper()
 	lf := writeLinkFarm(t, m)
@@ -83,7 +83,7 @@ func TestResetKeepsForeignSymlink(t *testing.T) {
 
 	applyForReset(t, root, state, homeManifest(storeEntry(symSrc, "sub", ".link")))
 
-	// 配置済み symlink を別の先へ差し替える（foreign / 記録不一致をシミュレート）。
+	// Swap the placed symlink to point elsewhere (simulate foreign / record mismatch).
 	linkAbs := filepath.Join(root, ".link")
 	if err := os.Remove(linkAbs); err != nil {
 		t.Fatal(err)
@@ -97,7 +97,7 @@ func TestResetKeepsForeignSymlink(t *testing.T) {
 		t.Fatalf("Reset: %v", err)
 	}
 
-	// 保守的不変条件を満たさないため残る。
+	// Kept because it does not satisfy the conservative invariant.
 	if _, err := os.Lstat(linkAbs); err != nil {
 		t.Errorf("foreign symlink should be kept, lstat err = %v", err)
 	}
@@ -128,14 +128,14 @@ func TestResetDryRunNoSideEffects(t *testing.T) {
 		t.Error("Result.DryRun = false, want true")
 	}
 
-	// FS は不変（プレビューのみ）。
+	// FS unchanged (preview only).
 	if _, err := os.Lstat(filepath.Join(root, ".link")); err != nil {
 		t.Errorf(".link should still exist after dryrun: %v", err)
 	}
 	if _, err := os.Stat(filepath.Join(root, ".copied")); err != nil {
 		t.Errorf(".copied should still exist after dryrun: %v", err)
 	}
-	// プランは削除予定を列挙する。
+	// The plan enumerates the to-be-removed entries.
 	if len(res.RemovedSymlinks) != 1 || len(res.RemovedCopies) != 1 {
 		t.Errorf("dryrun plan = sym%v copy%v, want one each", res.RemovedSymlinks, res.RemovedCopies)
 	}
@@ -179,7 +179,7 @@ func TestResetNoProfileIsNoop(t *testing.T) {
 	root := realTempDir(t)
 	state := realTempDir(t)
 
-	// 一度も apply していない（profile 不在）→ no-op・エラーなし。
+	// Never applied (profile absent) → no-op, no error.
 	res, err := Reset(resetOpts(root, state, nil, false, nil))
 	if err != nil {
 		t.Fatalf("Reset no-profile: %v", err)
@@ -195,7 +195,7 @@ func TestResetConfirmAbort(t *testing.T) {
 	src := makeSrc(t, "sub/file")
 	applyForReset(t, root, state, homeManifest(storeEntry(src, "sub", ".a")))
 
-	// confirm が false を返したら中断し FS は不変。
+	// If confirm returns false, abort and leave the FS unchanged.
 	res, err := Reset(resetOpts(root, state, nil, false, func(*ResetResult) (bool, error) {
 		return false, nil
 	}))

--- a/internal/engine/staleremove.go
+++ b/internal/engine/staleremove.go
@@ -9,11 +9,11 @@ import (
 
 // removeStale applies the planner's Remove actions, re-verifying the conservative
 // invariant against the real FS immediately before each unlink. The plan already
-// restricts removals to「前世代記録あり かつ 現状も記録通りの先を指す symlink」,
-// but placement (and any concurrent change) runs between planning and removal, so
-// the stale-remover re-checks lstat/readlink and unlinks only when the invariant
-// still holds; drifted targets are kept with a warning (→ ADR-0002, ADR-0006,
-// docs/spec.md「stale 除去の対象と安全不変条件」).
+// restricts removals to "symlinks recorded in the previous generation that still
+// point at the recorded dest", but placement (and any concurrent change) runs
+// between planning and removal, so the stale-remover re-checks lstat/readlink and
+// unlinks only when the invariant still holds; drifted targets are kept with a
+// warning (→ ADR-0002, ADR-0006, docs/spec.md "stale removal targets and safety invariant").
 func (a *applier) removeStale(actions []planner.RemoveAction) error {
 	for _, act := range actions {
 		if !reverifyStale(act) {

--- a/internal/gitutil/gitutil.go
+++ b/internal/gitutil/gitutil.go
@@ -1,5 +1,5 @@
 // Package gitutil resolves the git toplevel for project mode root resolution
-// (→ ADR-0005, docs/spec.md「root の解決」).
+// (→ ADR-0005, docs/spec.md "root resolution").
 package gitutil
 
 import (
@@ -10,15 +10,16 @@ import (
 	"strings"
 )
 
-// ErrNotInRepo は dir が git リポジトリ外で toplevel を解決できないときに返る。
+// ErrNotInRepo is returned when dir is outside a git repository and the toplevel cannot be resolved.
 var ErrNotInRepo = errors.New("nput: git リポジトリ外です（--root で root を明示してください）")
 
-// ErrGitNotFound は git が PATH に無いときに返る。
+// ErrGitNotFound is returned when git is not on PATH.
 var ErrGitNotFound = errors.New("nput: git が PATH にありません")
 
-// Toplevel は dir を起点に `git rev-parse --show-toplevel` を実行し、
-// 解決後の絶対 root パスを返す（→ ADR-0005）。どのサブディレクトリから叩いても
-// 同じ root に解決される。git が無い／リポジトリ外なら明確なエラーで停止する。
+// Toplevel runs `git rev-parse --show-toplevel` rooted at dir and returns the
+// resolved absolute root path (→ ADR-0005). It resolves to the same root no matter
+// which subdirectory it is invoked from. It stops with a clear error if git is
+// missing or dir is outside a repository.
 func Toplevel(dir string) (string, error) {
 	if _, err := exec.LookPath("git"); err != nil {
 		return "", ErrGitNotFound
@@ -31,7 +32,7 @@ func Toplevel(dir string) (string, error) {
 	if err := cmd.Run(); err != nil {
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) {
-			// git 自体は起動できたが非ゼロ終了 = リポジトリ外が代表ケース。
+			// git started but exited non-zero; the representative case is being outside a repository.
 			return "", fmt.Errorf("%w: %s", ErrNotInRepo, strings.TrimSpace(stderr.String()))
 		}
 		return "", fmt.Errorf("nput: git rev-parse の実行に失敗しました: %w", err)

--- a/internal/gitutil/gitutil_test.go
+++ b/internal/gitutil/gitutil_test.go
@@ -13,7 +13,7 @@ func initRepo(t *testing.T) string {
 		t.Skip("git not available")
 	}
 	dir := t.TempDir()
-	// macOS の /tmp は /private/tmp への symlink なので解決後パスで比較する。
+	// On macOS /tmp is a symlink to /private/tmp, so compare against the resolved path.
 	dir, err := filepath.EvalSymlinks(dir)
 	if err != nil {
 		t.Fatal(err)
@@ -46,7 +46,7 @@ func TestToplevelOutsideRepo(t *testing.T) {
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git not available")
 	}
-	// $HOME 等の祖先が git repo だと誤検知するため、隔離した tmpdir を使う。
+	// Use an isolated tmpdir, since an ancestor like $HOME being a git repo would cause false positives.
 	dir := t.TempDir()
 	t.Setenv("HOME", dir)
 	t.Setenv("GIT_CEILING_DIRECTORIES", filepath.Dir(dir))

--- a/internal/lock/lock.go
+++ b/internal/lock/lock.go
@@ -1,8 +1,9 @@
 // Package lock serializes concurrent apply / reset / rollback on a profileDir
 // via an advisory flock (→ ADR-0011, ADR-0013).
 //
-// syscall.Flock の advisory ロックはプロセス終了時に OS が自動解放するため、
-// クラッシュしても stale lock が残らない。linux / darwin 両対応（→ ADR-0011）。
+// The advisory lock from syscall.Flock is released automatically by the OS on
+// process exit, so no stale lock remains even after a crash. Supports both
+// linux and darwin (→ ADR-0011).
 package lock
 
 import (
@@ -11,19 +12,19 @@ import (
 	"syscall"
 )
 
-// ErrLocked は非ブロッキング取得（try-lock）で他者が保持中のときに返る。
-// shellHook 経路（--no-wait）の skip 判定に使う（→ ADR-0013）。
+// ErrLocked is returned by a non-blocking acquisition (try-lock) when another holder is active.
+// Used for the skip decision on the shellHook path (--no-wait) (→ ADR-0013).
 var ErrLocked = errors.New("nput: profileDir is locked by another process")
 
-// Lock は profileDir 上に取得した排他 flock。
+// Lock is an exclusive flock acquired on a profileDir.
 type Lock struct {
 	f *os.File
 }
 
-// Acquire は dir（profileDir）に対し排他 flock を取得する。
-// blocking=true は明示 apply 用の LOCK_EX（取得まで待つ）、
-// blocking=false は shellHook 用の LOCK_NB（保持中なら ErrLocked・→ ADR-0013）。
-// dir は事前に存在している必要がある。
+// Acquire takes an exclusive flock on dir (the profileDir).
+// blocking=true uses LOCK_EX for explicit apply (waits until acquired);
+// blocking=false uses LOCK_NB for shellHook (returns ErrLocked if held; → ADR-0013).
+// dir must already exist.
 func Acquire(dir string, blocking bool) (*Lock, error) {
 	f, err := os.Open(dir)
 	if err != nil {
@@ -44,7 +45,7 @@ func Acquire(dir string, blocking bool) (*Lock, error) {
 	return &Lock{f: f}, nil
 }
 
-// Release は flock を解放しファイルを閉じる。
+// Release releases the flock and closes the file.
 func (l *Lock) Release() error {
 	if l == nil || l.f == nil {
 		return nil

--- a/internal/lock/lock_test.go
+++ b/internal/lock/lock_test.go
@@ -14,7 +14,7 @@ func TestTryLockConflict(t *testing.T) {
 	}
 	defer func() { _ = l1.Release() }()
 
-	// 保持中の try-lock は ErrLocked。
+	// A try-lock while held returns ErrLocked.
 	if _, err := Acquire(dir, false); err != ErrLocked {
 		t.Fatalf("try-lock while held: got %v, want ErrLocked", err)
 	}
@@ -48,7 +48,7 @@ func TestBlockingWaitsForRelease(t *testing.T) {
 
 	acquired := make(chan struct{})
 	go func() {
-		l2, err := Acquire(dir, true) // blocking: 取得まで待つ。
+		l2, err := Acquire(dir, true) // blocking: wait until acquired.
 		if err != nil {
 			t.Errorf("blocking Acquire: %v", err)
 			close(acquired)
@@ -62,7 +62,7 @@ func TestBlockingWaitsForRelease(t *testing.T) {
 	case <-acquired:
 		t.Fatal("blocking Acquire returned before lock was released")
 	case <-time.After(100 * time.Millisecond):
-		// まだ取得できていない = blocking が効いている。
+		// Still not acquired = blocking is in effect.
 	}
 
 	if err := l1.Release(); err != nil {
@@ -70,7 +70,7 @@ func TestBlockingWaitsForRelease(t *testing.T) {
 	}
 	select {
 	case <-acquired:
-		// 解放後に取得できた。
+		// Acquired after release.
 	case <-time.After(2 * time.Second):
 		t.Fatal("blocking Acquire did not proceed after release")
 	}

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -1,8 +1,9 @@
 // Package manifest reads and validates the manifest.json contract that
 // lib.mkManifest emits and the engine consumes (→ ADR-0006, ADR-0010, ADR-0013).
 //
-// manifest.json は Nix↔Go の唯一の安定契約。engine は自身の対応版より新しい
-// schemaVersion を拒否する（→ ADR-0006, docs/spec.md「manifest.json スキーマ（v1）」）。
+// manifest.json is the sole stable contract between Nix and Go. The engine rejects
+// any schemaVersion newer than the version it supports
+// (→ ADR-0006, docs/spec.md "manifest.json schema (v1)").
 package manifest
 
 import (
@@ -14,18 +15,18 @@ import (
 	"path/filepath"
 )
 
-// ErrSchemaVersionUnsupported は engine の対応版（SchemaVersion）より新しい manifest を読んだことを表す。
-// CLI/flake pin 間の schemaVersion skew を上位（CLI）で errors.Is 判定し案内を補うための sentinel（→ ADR-0006）。
+// ErrSchemaVersionUnsupported indicates that a manifest newer than the engine's supported version (SchemaVersion) was read.
+// A sentinel so the caller (CLI) can detect schemaVersion skew between CLI/flake pin via errors.Is and add guidance (→ ADR-0006).
 var ErrSchemaVersionUnsupported = errors.New("nput: schemaVersion が engine の対応版より新しい")
 
-// SchemaVersion は engine が解釈できる manifest.json の最新版（→ ADR-0013）。
-// MVP は v1 のみを受理し、これより新しい版は拒否する（→ ADR-0006, ADR-0015）。
+// SchemaVersion is the latest manifest.json version the engine can interpret (→ ADR-0013).
+// The MVP accepts only v1 and rejects any newer version (→ ADR-0006, ADR-0015).
 const SchemaVersion = 1
 
-// FileName は link-farm derivation 内に埋め込まれる manifest の固定名。
+// FileName is the fixed manifest name embedded in the link-farm derivation.
 const FileName = "manifest.json"
 
-// 配置元・配置方法の clean enum（_nputMarker は manifest に漏れない・→ ADR-0010）。
+// Clean enums for src kind and placement method (_nputMarker does not leak into the manifest; → ADR-0010).
 const (
 	SrcKindStore      = "store"
 	SrcKindOutOfStore = "outOfStore"
@@ -39,14 +40,15 @@ const (
 	RootKindFixed   = "fixed"
 )
 
-// Root は配置先基準の kind。project / home / system は実行時解決のためパスを持たず、
-// fixed のみ評価時確定の絶対パスを Root に持つ（→ docs/spec.md）。
+// Root is the kind of the placement target base. project / home / system are
+// resolved at runtime and carry no path; only fixed holds an absolute path in
+// Root determined at evaluation time (→ docs/spec.md).
 type Root struct {
 	RootKind string `json:"rootKind"`
 	Root     string `json:"root,omitempty"`
 }
 
-// Entry は 1 配置定義。identity は Target（属性キー由来・stale 除去の diff キー・→ ADR-0014）。
+// Entry is a single placement definition. Its identity is Target (derived from the attribute key; the diff key for stale removal; → ADR-0014).
 type Entry struct {
 	SrcKind string `json:"srcKind"`
 	Src     string `json:"src"`
@@ -55,19 +57,19 @@ type Entry struct {
 	Method  string `json:"method"`
 }
 
-// Manifest は manifest.json トップレベル。
+// Manifest is the top level of manifest.json.
 type Manifest struct {
 	SchemaVersion int     `json:"schemaVersion"`
 	Root          Root    `json:"root"`
 	Entries       []Entry `json:"entries"`
 }
 
-// Load は link-farm ディレクトリ内の manifest.json を読み、schemaVersion を検証する。
+// Load reads manifest.json inside the link-farm directory and validates schemaVersion.
 func Load(linkFarm string) (*Manifest, error) {
 	return LoadFile(filepath.Join(linkFarm, FileName))
 }
 
-// LoadFile は manifest.json ファイルを直接読み、schemaVersion を検証する。
+// LoadFile reads a manifest.json file directly and validates schemaVersion.
 func LoadFile(path string) (*Manifest, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -88,7 +90,7 @@ func LoadFile(path string) (*Manifest, error) {
 }
 
 func (m *Manifest) validate() error {
-	// engine は自身の対応版より新しい schemaVersion を拒否する（→ ADR-0006）。
+	// The engine rejects any schemaVersion newer than the version it supports (→ ADR-0006).
 	if m.SchemaVersion > SchemaVersion {
 		return fmt.Errorf("schemaVersion %d は未対応です（この engine は v%d まで対応）: %w", m.SchemaVersion, SchemaVersion, ErrSchemaVersionUnsupported)
 	}

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -51,7 +51,7 @@ func TestLoadRejectsNewerSchema(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for schemaVersion 2, got nil")
 	}
-	// CLI が skew 案内を補えるよう sentinel を errors.Is で判定できること（→ docs/spec.md）。
+	// The sentinel must be detectable via errors.Is so the CLI can add skew guidance (→ docs/spec.md).
 	if !errors.Is(err, ErrSchemaVersionUnsupported) {
 		t.Errorf("error should wrap ErrSchemaVersionUnsupported, got %v", err)
 	}

--- a/internal/paths/paths.go
+++ b/internal/paths/paths.go
@@ -1,9 +1,10 @@
 // Package paths computes the on-disk profile layout the engine operates on
 // (→ ADR-0005, ADR-0013, ADR-0022, ADR-0024, ADR-0025).
 //
-// profileDir は各 config 専用ディレクトリ（= flock キー）。profile リンクはその中の
-// profile、世代は profile-N-link、build out-link は .pending、backref .root は
-// <roothash> 階層に置く（→ docs/spec.md「profile のオンディスクレイアウト」）。
+// profileDir is the per-config dedicated directory (= flock key). The profile
+// link sits inside it as profile, generations as profile-N-link, the build
+// out-link as .pending, and the backref .root at the <roothash> level
+// (→ docs/spec.md "on-disk layout of the profile").
 package paths
 
 import (
@@ -16,12 +17,13 @@ import (
 	"github.com/yasunori0418/nput/internal/manifest"
 )
 
-// rootHashLen は roothash の hex 文字数（128bit・固定長・FS 安全・→ ADR-0013）。
-// lib.mkManifest の anchorName（sha256 の先頭 32 hex）と桁を揃える。
+// rootHashLen is the hex character count of the roothash (128 bit; fixed length;
+// FS-safe; → ADR-0013). It matches the digit count of lib.mkManifest's anchorName
+// (the first 32 hex of sha256).
 const rootHashLen = 32
 
-// StateDir は profile 群の基底 <state> を返す。$XDG_STATE_HOME があればそれ、
-// 無ければ $HOME/.local/state（nix 本体の profile 既定と整合・→ ADR-0022）。
+// StateDir returns the base <state> for the profiles. $XDG_STATE_HOME if set,
+// otherwise $HOME/.local/state (consistent with nix's own profile default; → ADR-0022).
 func StateDir() (string, error) {
 	if s := os.Getenv("XDG_STATE_HOME"); s != "" {
 		return s, nil
@@ -33,48 +35,51 @@ func StateDir() (string, error) {
 	return filepath.Join(home, ".local", "state"), nil
 }
 
-// RootHash は解決後の絶対 root パスの sha256 を短縮した hex を返す（→ ADR-0013）。
+// RootHash returns the truncated hex of the sha256 of the resolved absolute root path (→ ADR-0013).
 func RootHash(absRoot string) string {
 	sum := sha256.Sum256([]byte(absRoot))
 	return hex.EncodeToString(sum[:])[:rootHashLen]
 }
 
-// Base は profile 群の基底 <state>/nix/profiles/nput を返す。home（--root なし）の
-// profileDir はこの直下の <name>、roothash 系列は <roothash>/<name>（→ ADR-0024）。
+// Base returns the base <state>/nix/profiles/nput for the profiles. The home
+// (no --root) profileDir is <name> directly under it; the roothash series is
+// <roothash>/<name> (→ ADR-0024).
 func Base(stateDir string) string {
 	return filepath.Join(stateDir, "nix", "profiles", "nput")
 }
 
-// GenerationLink は profile リンクの兄弟として nix-env が作る世代リンク
-// <profileDir>/profile-<gen>-link のパスを返す（→ docs/spec.md オンディスクレイアウト・ADR-0025）。
+// GenerationLink returns the path of the generation link
+// <profileDir>/profile-<gen>-link that nix-env creates as a sibling of the
+// profile link (→ docs/spec.md on-disk layout; ADR-0025).
 func GenerationLink(profileLink string, gen int) string {
 	return fmt.Sprintf("%s-%d-link", profileLink, gen)
 }
 
-// Profile は 1 config 分の profile レイアウトのパス一式。
+// Profile is the full set of profile-layout paths for one config.
 type Profile struct {
-	// Dir は profileDir（config 専用ディレクトリ・flock キー）。
+	// Dir is the profileDir (per-config directory; flock key).
 	Dir string
-	// Profile は profile リンク（nix-env --profile の対象）。
+	// Profile is the profile link (the target of nix-env --profile).
 	Profile string
-	// Pending は nix build --out-link の出力先（profile を貫通しない兄弟）。
+	// Pending is the output of nix build --out-link (a sibling that does not pass through the profile).
 	Pending string
-	// BackrefDir は backref .root を置く階層。home（--root なし）では空。
+	// BackrefDir is the level where the backref .root is placed. Empty for home (no --root).
 	BackrefDir string
-	// Backref は元 root の絶対パスを記録する backref ファイル。home では空。
+	// Backref is the backref file recording the original root's absolute path. Empty for home.
 	Backref string
 }
 
-// Resolve は state 基底・config 名・rootKind・解決後絶対 root・--root 上書き有無から
-// profile レイアウトを確定する（→ docs/spec.md「root の解決」表・ADR-0024, ADR-0025）。
+// Resolve determines the profile layout from the state base, config name,
+// rootKind, resolved absolute root, and whether --root was overridden
+// (→ docs/spec.md "root resolution" table; ADR-0024, ADR-0025).
 //
-//   - home（--root なし）              : <state>/nix/profiles/nput/<name>（backref なし）
-//   - project / fixed / --root 上書き : <state>/nix/profiles/nput/<roothash>/<name>
-//     （backref .root は <roothash> 階層）
+//   - home (no --root)               : <state>/nix/profiles/nput/<name> (no backref)
+//   - project / fixed / --root override : <state>/nix/profiles/nput/<roothash>/<name>
+//     (backref .root at the <roothash> level)
 func Resolve(stateDir, name, rootKind, absRoot string, rootOverride bool) Profile {
 	base := Base(stateDir)
 
-	// home（--root なし）のみ <name> 直キー。それ以外は root ごとに独立系列へ分離する。
+	// Only home (no --root) keys directly on <name>. Otherwise separate into an independent series per root.
 	if rootKind == manifest.RootKindHome && !rootOverride {
 		dir := filepath.Join(base, name)
 		return Profile{

--- a/internal/paths/paths_test.go
+++ b/internal/paths/paths_test.go
@@ -19,7 +19,7 @@ func TestRootHashDeterministicAndFixedLen(t *testing.T) {
 	if c := RootHash("/home/me/other"); c == a {
 		t.Errorf("distinct roots collided: %q", c)
 	}
-	// FS 安全（hex のみ）。
+	// FS-safe (hex only).
 	for _, r := range a {
 		if (r < '0' || r > '9') && (r < 'a' || r > 'f') {
 			t.Errorf("RootHash has non-hex char %q in %q", r, a)
@@ -61,7 +61,7 @@ func TestResolveHomeUsesNameKey(t *testing.T) {
 }
 
 func TestResolveHomeWithOverrideUsesRootHash(t *testing.T) {
-	// --root 明示時は home でも roothash キー（→ ADR-0023）。
+	// With --root explicit, even home uses the roothash key (→ ADR-0023).
 	state := "/state"
 	root := "/tmp/sandbox"
 	p := Resolve(state, "vim", manifest.RootKindHome, root, true)
@@ -75,7 +75,7 @@ func TestResolveHomeWithOverrideUsesRootHash(t *testing.T) {
 }
 
 func TestResolveFixedUsesRootHash(t *testing.T) {
-	// fixed root（--root なし）も roothash キー（→ ADR-0024）。
+	// A fixed root (no --root) also uses the roothash key (→ ADR-0024).
 	state := "/state"
 	root := "/opt/x"
 	p := Resolve(state, "c", manifest.RootKindFixed, root, false)

--- a/internal/planner/planner.go
+++ b/internal/planner/planner.go
@@ -6,7 +6,7 @@
 // link still points to the recorded destination. Regular files, foreign links,
 // and record/reality mismatches are never removed; copy entries are never
 // removed (orphan warning only); the first apply (no previous manifest) removes
-// nothing (→ ADR-0002, ADR-0006, ADR-0015, docs/spec.md「stale 除去の対象と安全不変条件」).
+// nothing (→ ADR-0002, ADR-0006, ADR-0015, docs/spec.md "targets and safety invariant of stale removal").
 //
 // The plan is computed without mutating the filesystem. The engine consumes the
 // plan: it materializes Place actions and hands Remove actions to the
@@ -26,7 +26,7 @@ import (
 // FS abstracts the lstat/readlink probes the planner needs, so diff
 // classification is a pure function over (manifests, FS state) and can be
 // table-tested with a fake FS without touching the real filesystem
-// (→ ADR-0006, docs/spec.md「stale 除去の対象と安全不変条件」).
+// (→ ADR-0006, docs/spec.md "targets and safety invariant of stale removal").
 type FS interface {
 	Lstat(path string) (os.FileInfo, error)
 	Readlink(path string) (string, error)
@@ -45,11 +45,11 @@ var OSFS FS = osFS{}
 type PlaceKind int
 
 const (
-	// PlaceNew は target が不在で新規 symlink を作る。
+	// PlaceNew creates a new symlink when target is absent.
 	PlaceNew PlaceKind = iota
-	// PlaceReplace は自身の前世代 manifest が記録した symlink を silent に張り替える。
+	// PlaceReplace silently re-links a symlink recorded by this profile's own previous-generation manifest.
 	PlaceReplace
-	// PlaceForeign は記録の無い symlink（foreign）を warning 付きで後勝ち置換する（→ ADR-0015）。
+	// PlaceForeign last-wins replaces an unrecorded symlink (foreign) with a warning (→ ADR-0015).
 	PlaceForeign
 )
 
@@ -62,12 +62,12 @@ type PlaceAction struct {
 }
 
 // CopyAction is a place-once copy to materialize: copy Src (= <src>/<subpath>)
-// into TargetAbs（target 不在のときのみ・place-once・→ ADR-0002, ADR-0016）。
-// 既存 target（記録あり / foreign）は触らないため CopyAction を生まない。
+// into TargetAbs (only when target is absent; place-once; → ADR-0002, ADR-0016).
+// An existing target (recorded / foreign) is left untouched, so no CopyAction is emitted for it.
 type CopyAction struct {
 	Entry     manifest.Entry
 	TargetAbs string
-	Src       string // LinkDest(Entry): <src>/<subpath>（コピー元）
+	Src       string // LinkDest(Entry): <src>/<subpath> (copy source)
 }
 
 // RemoveAction is a stale symlink that satisfies the conservative invariant at
@@ -90,16 +90,16 @@ type Conflict struct {
 type WarnKind int
 
 const (
-	// WarnForeignReplace は記録の無い symlink を上書きする（place・後勝ち・→ ADR-0015）。
+	// WarnForeignReplace overwrites an unrecorded symlink (place; last-wins; → ADR-0015).
 	WarnForeignReplace WarnKind = iota
-	// WarnStaleMismatch は stale target が記録と不一致な symlink のため残す（→ ADR-0002）。
+	// WarnStaleMismatch keeps a stale target because its symlink mismatches the record (→ ADR-0002).
 	WarnStaleMismatch
-	// WarnStaleNonSymlink は stale target が symlink でない（通常ファイル等）ため残す。
+	// WarnStaleNonSymlink keeps a stale target because it is not a symlink (regular file, etc.).
 	WarnStaleNonSymlink
-	// WarnCopyOrphan は消えた copy entry の orphan（削除はしない・reset で撤去・→ ADR-0020）。
+	// WarnCopyOrphan is the orphan of a vanished copy entry (not removed; cleared by reset; → ADR-0020).
 	WarnCopyOrphan
-	// WarnCopyForeign は copy target に記録の無い実ファイルがあり place-once で skip する
-	// （上書きしない・masking 防止に可視化・symlink の foreign 警告と対称・→ ADR-0022）。
+	// WarnCopyForeign skips a copy target under place-once because an unrecorded real file exists there
+	// (no overwrite; surfaced to prevent masking; symmetric with the symlink foreign warning; → ADR-0022).
 	WarnCopyForeign
 )
 
@@ -110,8 +110,8 @@ type Warning struct {
 }
 
 // Plan is the computed place/replace/remove plan plus non-fatal warnings and
-// fatal conflicts. The engine executes Place / Copies then Remove (「新規/張替を先に、
-// stale 除去を最後に」・→ ADR-0006); a non-empty Conflicts means apply must stop.
+// fatal conflicts. The engine executes Place / Copies then Remove ("new/re-link
+// first, stale removal last"; → ADR-0006); a non-empty Conflicts means apply must stop.
 type Plan struct {
 	Place     []PlaceAction
 	Copies    []CopyAction
@@ -120,7 +120,7 @@ type Plan struct {
 	Warnings  []Warning
 }
 
-// LinkDest は entry の symlink が指すべき先（<src>/<subpath>）を返す。
+// LinkDest returns the destination the entry's symlink should point to (<src>/<subpath>).
 func LinkDest(e manifest.Entry) string {
 	if e.Subpath == "" || e.Subpath == "." {
 		return e.Src
@@ -128,18 +128,19 @@ func LinkDest(e manifest.Entry) string {
 	return filepath.Join(e.Src, e.Subpath)
 }
 
-// Compute は前世代 manifest（prev・nil なら初回）と新 manifest（next）を root と FS
-// 状態に照らして diff し、place/replace/remove プランを算出する純ロジック。
-// 副作用は持たず、FS への反映は engine（place + stale-remover）が行う。
+// Compute diffs the previous-generation manifest (prev; nil means first apply)
+// against the new manifest (next), relative to root and FS state, and computes
+// the place/replace/remove plan as pure logic. It has no side effects; the FS
+// changes are applied by the engine (place + stale-remover).
 func Compute(prev, next *manifest.Manifest, root string, fs FS) (Plan, error) {
 	var plan Plan
 
-	// --- place / replace 側: 新世代の各 entry を現 FS に照らして分類する ---
+	// --- place / replace side: classify each new-generation entry against the current FS ---
 	prevByTarget := byTarget(prev)
 	for _, e := range entriesOf(next) {
 		targetAbs := filepath.Join(root, filepath.Clean(e.Target))
 
-		// 祖先 component が symlink ならネスト不可で conflict（全 method 共通・→ ADR-0015）。
+		// If an ancestor component is a symlink, nesting is forbidden: conflict (common to all methods; → ADR-0015).
 		offender, err := ancestorSymlink(root, e.Target, fs)
 		if err != nil {
 			return Plan{}, err
@@ -153,7 +154,7 @@ func Compute(prev, next *manifest.Manifest, root string, fs FS) (Plan, error) {
 			continue
 		}
 
-		// method ごとに place-once / 張替の分類を分岐する。
+		// Branch the place-once / re-link classification per method.
 		if e.Method == manifest.MethodCopy {
 			if err := classifyCopy(&plan, e, targetAbs, prevByTarget, fs); err != nil {
 				return Plan{}, err
@@ -175,7 +176,7 @@ func Compute(prev, next *manifest.Manifest, root string, fs FS) (Plan, error) {
 			}
 			plan.Place = append(plan.Place, PlaceAction{Entry: e, TargetAbs: targetAbs, Dest: LinkDest(e), Kind: kind})
 		case err == nil:
-			// 通常ファイル / ディレクトリは上書きしない（→ docs/spec.md エラー仕様）。
+			// A regular file / directory is not overwritten (→ docs/spec.md error spec).
 			plan.Conflicts = append(plan.Conflicts, Conflict{
 				Entry:     e,
 				TargetAbs: targetAbs,
@@ -188,8 +189,8 @@ func Compute(prev, next *manifest.Manifest, root string, fs FS) (Plan, error) {
 		}
 	}
 
-	// --- remove 側: stale entry（prev ∖ next）を保守的不変条件下で算出する ---
-	// 初回（prev == nil）は何も消さない（→ ADR-0006）。
+	// --- remove side: compute stale entries (prev ∖ next) under the conservative invariant ---
+	// On first apply (prev == nil) nothing is removed (→ ADR-0006).
 	if prev != nil {
 		nextByTarget := byTarget(next)
 		for _, pe := range prev.Entries {
@@ -197,7 +198,7 @@ func Compute(prev, next *manifest.Manifest, root string, fs FS) (Plan, error) {
 				continue
 			}
 			if pe.Method == manifest.MethodCopy {
-				// copy はユーザー所有データ。削除せず orphan を警告（→ ADR-0002, ADR-0020）。
+				// copy is user-owned data: not removed, warn as orphan (→ ADR-0002, ADR-0020).
 				plan.Warnings = append(plan.Warnings, Warning{Kind: WarnCopyOrphan, Target: pe.Target})
 				continue
 			}
@@ -206,18 +207,18 @@ func Compute(prev, next *manifest.Manifest, root string, fs FS) (Plan, error) {
 			info, err := fs.Lstat(targetAbs)
 			switch {
 			case err != nil && os.IsNotExist(err):
-				continue // 既に無い = no-op（警告なし）。
+				continue // already gone = no-op (no warning).
 			case err != nil:
 				return Plan{}, fmt.Errorf("nput: stale target を lstat できません (%s): %w", targetAbs, err)
 			case info.Mode()&os.ModeSymlink == 0:
-				// 通常ファイル / ディレクトリには触れない（→ docs/spec.md 安全不変条件）。
+				// A regular file / directory is left untouched (→ docs/spec.md safety invariant).
 				plan.Warnings = append(plan.Warnings, Warning{Kind: WarnStaleNonSymlink, Target: pe.Target})
 				continue
 			}
 
 			onDisk, err := fs.Readlink(targetAbs)
 			if err != nil || onDisk != LinkDest(pe) {
-				// 記録と実体が不一致（foreign / ユーザー差し替え）→ 削除せず警告（→ ADR-0002）。
+				// Record and reality mismatch (foreign / user-replaced) → not removed, warn (→ ADR-0002).
 				plan.Warnings = append(plan.Warnings, Warning{Kind: WarnStaleMismatch, Target: pe.Target})
 				continue
 			}
@@ -246,9 +247,10 @@ func byTarget(m *manifest.Manifest) map[string]manifest.Entry {
 	return out
 }
 
-// recordedLink は target が「自身の前世代 manifest が記録した symlink」かを判定する。
-// 前世代に同 target の entry があり、かつ実体の symlink が記録通りの先を指すときのみ true
-// （保守的不変条件・→ ADR-0002, ADR-0015）。
+// recordedLink reports whether target is "a symlink recorded by this profile's
+// own previous-generation manifest". True only when the previous generation has
+// an entry for the same target AND the on-disk symlink points to the recorded
+// destination (conservative invariant; → ADR-0002, ADR-0015).
 func recordedLink(target, targetAbs string, prevByTarget map[string]manifest.Entry, fs FS) bool {
 	pe, ok := prevByTarget[target]
 	if !ok {
@@ -261,21 +263,22 @@ func recordedLink(target, targetAbs string, prevByTarget map[string]manifest.Ent
 	return onDisk == LinkDest(pe)
 }
 
-// classifyCopy は copy entry を place-once 意味論で分類する（→ ADR-0002, ADR-0016, ADR-0022,
-// docs/spec.md「copy モード」）。
+// classifyCopy classifies a copy entry under place-once semantics (→ ADR-0002,
+// ADR-0016, ADR-0022, docs/spec.md "copy mode").
 //
-//	target 不在            → CopyAction（新規 place-once コピー）
-//	target 既存・構造不一致 → conflict（subpath dir × target file / subpath file × target dir）
-//	target 既存・記録あり   → no-op（nput が前世代で配置済み・place-once で触らない）
-//	target 既存・foreign    → skip + WarnCopyForeign（記録の無い実ファイル・masking 防止）
+//	target absent              → CopyAction (new place-once copy)
+//	target exists, structure mismatch → conflict (subpath dir × target file / subpath file × target dir)
+//	target exists, recorded    → no-op (placed by nput in a previous generation; place-once leaves it untouched)
+//	target exists, foreign     → skip + WarnCopyForeign (unrecorded real file; masking prevention)
 //
-// recopy（apply --recopy）は place-once を破る別経路で、engine 側が manifest の copy entry を
-// 直接上書きする。planner は通常の place-once 分類のみを行う（→ ADR-0020）。
+// recopy (apply --recopy) is a separate path that breaks place-once: the engine
+// overwrites the manifest's copy entry directly. The planner only does the
+// normal place-once classification (→ ADR-0020).
 func classifyCopy(plan *Plan, e manifest.Entry, targetAbs string, prevByTarget map[string]manifest.Entry, fs FS) error {
 	info, err := fs.Lstat(targetAbs)
 	switch {
 	case err == nil:
-		// target 既存: まず src 構造と種別が一致するか検査する。
+		// target exists: first check whether the src structure and kind match.
 		mismatch, err := copyStructureMismatch(e, info, fs)
 		if err != nil {
 			return err
@@ -288,7 +291,7 @@ func classifyCopy(plan *Plan, e manifest.Entry, targetAbs string, prevByTarget m
 			})
 			return nil
 		}
-		// place-once: 前世代が記録した copy なら触らない。記録の無い実ファイルは foreign 警告。
+		// place-once: leave a copy recorded by the previous generation untouched. An unrecorded real file gets a foreign warning.
 		if pe, ok := prevByTarget[e.Target]; ok && pe.Method == manifest.MethodCopy {
 			return nil
 		}
@@ -302,9 +305,10 @@ func classifyCopy(plan *Plan, e manifest.Entry, targetAbs string, prevByTarget m
 	}
 }
 
-// copyStructureMismatch は src（<src>/<subpath>）の dir/file 種別と既存 target の種別が
-// 食い違うか判定する（subpath dir × target file / subpath file × target dir・→ docs/spec.md）。
-// symlink target は IsDir()=false で「file 側」として扱う。
+// copyStructureMismatch reports whether the dir/file kind of src (<src>/<subpath>)
+// disagrees with the kind of the existing target (subpath dir × target file /
+// subpath file × target dir; → docs/spec.md). A symlink target has IsDir()=false
+// and is treated as the "file side".
 func copyStructureMismatch(e manifest.Entry, targetInfo os.FileInfo, fs FS) (bool, error) {
 	srcInfo, err := fs.Lstat(LinkDest(e))
 	if err != nil {
@@ -314,8 +318,8 @@ func copyStructureMismatch(e manifest.Entry, targetInfo os.FileInfo, fs FS) (boo
 }
 
 // ancestorSymlink walks the target's ancestor components under root and returns
-// the first existing ancestor that is a symlink (全体 symlink 配置の配下にネスト不可・
-// → ADR-0015). A non-existent ancestor stops the walk (its descendants don't exist
+// the first existing ancestor that is a symlink (cannot nest under a whole-tree
+// symlink placement; → ADR-0015). A non-existent ancestor stops the walk (its descendants don't exist
 // either), returning "" with no error.
 func ancestorSymlink(root, target string, fs FS) (string, error) {
 	clean := filepath.Clean(target)

--- a/internal/planner/planner_test.go
+++ b/internal/planner/planner_test.go
@@ -10,11 +10,11 @@ import (
 	"github.com/yasunori0418/nput/internal/manifest"
 )
 
-// --- fake FS（純関数 planner を実 FS なしで table-test するための偽 lstat/readlink）---
+// --- fake FS (fake lstat/readlink to table-test the pure planner without a real FS) ---
 
 type fakeEntry struct {
-	mode os.FileMode // ModeSymlink / ModeDir / 0(regular) を立てる
-	dest string      // symlink のとき readlink が返す先
+	mode os.FileMode // set ModeSymlink / ModeDir / 0 (regular)
+	dest string      // destination readlink returns when a symlink
 }
 
 func sym(dest string) fakeEntry { return fakeEntry{mode: os.ModeSymlink, dest: dest} }
@@ -26,7 +26,7 @@ type fakeFS map[string]fakeEntry
 func (f fakeFS) Lstat(path string) (os.FileInfo, error) {
 	e, ok := f[path]
 	if !ok {
-		return nil, os.ErrNotExist // os.IsNotExist が true になる
+		return nil, os.ErrNotExist // makes os.IsNotExist true
 	}
 	return fakeInfo{name: filepath.Base(path), mode: e.mode}, nil
 }
@@ -171,7 +171,7 @@ func TestComputeTableDriven(t *testing.T) {
 		want want
 	}{
 		{
-			// 初回（前世代マニフェストなし）: 何も削除しない・新規配置のみ。
+			// First apply (no previous-generation manifest): remove nothing, place only.
 			name: "first apply: prev nil, remove zero",
 			prev: nil,
 			next: mani(sl(srcA, ".config/foo")),
@@ -179,7 +179,7 @@ func TestComputeTableDriven(t *testing.T) {
 			want: want{placeNew: []string{".config/foo"}},
 		},
 		{
-			// 記録あり×記録通り: 自身の前世代 symlink を silent 張替（foreign 警告なし）。
+			// Recorded × matches record: silently re-link this profile's own previous-generation symlink (no foreign warning).
 			name: "recorded link → silent replace",
 			prev: mani(sl(srcA, ".config/foo")),
 			next: mani(sl(srcB, ".config/foo")),
@@ -187,7 +187,7 @@ func TestComputeTableDriven(t *testing.T) {
 			want: want{placeReplace: []string{".config/foo"}},
 		},
 		{
-			// foreign symlink（記録なし）: warning を出して後勝ち置換。
+			// foreign symlink (unrecorded): emit a warning and last-wins replace.
 			name: "foreign symlink → warn + replace",
 			prev: nil,
 			next: mani(sl(srcB, ".config/foo")),
@@ -195,7 +195,7 @@ func TestComputeTableDriven(t *testing.T) {
 			want: want{placeForeign: []string{".config/foo"}, warns: []WarnKind{WarnForeignReplace}},
 		},
 		{
-			// 通常ファイルが target に既存: 上書きしない conflict。
+			// A regular file already at target: no-overwrite conflict.
 			name: "regular file at place target → conflict",
 			prev: nil,
 			next: mani(sl(srcB, ".config/foo")),
@@ -203,7 +203,7 @@ func TestComputeTableDriven(t *testing.T) {
 			want: want{conflicts: 1},
 		},
 		{
-			// 祖先 component が symlink: 配下にネストできない conflict（→ ADR-0015）。
+			// An ancestor component is a symlink: cannot nest under it, conflict (→ ADR-0015).
 			name: "ancestor symlink → conflict",
 			prev: nil,
 			next: mani(sl(srcB, ".claude/skills/nix")),
@@ -211,7 +211,7 @@ func TestComputeTableDriven(t *testing.T) {
 			want: want{conflicts: 1},
 		},
 		{
-			// stale 記録通り: 保守的不変条件を満たすので remove。
+			// stale matches record: satisfies the conservative invariant, so remove.
 			name: "stale recorded link → remove",
 			prev: mani(sl(srcA, ".config/keep"), sl(srcA, ".config/drop")),
 			next: mani(sl(srcA, ".config/keep")),
@@ -225,7 +225,7 @@ func TestComputeTableDriven(t *testing.T) {
 			},
 		},
 		{
-			// entries = {}（空 manifest）: 前世代の全 nput symlink を保守的に除去（警告なし）。
+			// entries = {} (empty manifest): conservatively remove all previous-generation nput symlinks (no warning).
 			name: "empty manifest → remove all recorded (no warning)",
 			prev: mani(sl(srcA, "a"), sl(srcA, "b")),
 			next: mani(),
@@ -236,7 +236,7 @@ func TestComputeTableDriven(t *testing.T) {
 			want: want{remove: []string{"a", "b"}},
 		},
 		{
-			// stale 記録あり but 実体が別先を指す（不一致）: 削除せず warning。
+			// stale recorded but reality points elsewhere (mismatch): not removed, warning.
 			name: "stale mismatch (recorded but points elsewhere) → keep + warn",
 			prev: mani(sl(srcA, ".config/foo")),
 			next: mani(),
@@ -244,7 +244,7 @@ func TestComputeTableDriven(t *testing.T) {
 			want: want{warns: []WarnKind{WarnStaleMismatch}},
 		},
 		{
-			// stale target が通常ファイル: nput 非管理として残し warning。
+			// stale target is a regular file: kept as non-nput-managed, warning.
 			name: "stale non-symlink (regular file) → keep + warn",
 			prev: mani(sl(srcA, ".config/foo")),
 			next: mani(),
@@ -252,7 +252,7 @@ func TestComputeTableDriven(t *testing.T) {
 			want: want{warns: []WarnKind{WarnStaleNonSymlink}},
 		},
 		{
-			// stale target が既に無い: no-op（警告なし）。
+			// stale target already gone: no-op (no warning).
 			name: "stale already gone → no-op",
 			prev: mani(sl(srcA, ".config/foo")),
 			next: mani(),
@@ -260,7 +260,7 @@ func TestComputeTableDriven(t *testing.T) {
 			want: want{},
 		},
 		{
-			// copy entry が消えた: 削除せず orphan を警告（FS 状態に依らない）。
+			// copy entry vanished: not removed, warn as orphan (independent of FS state).
 			name: "copy orphan → keep + warn",
 			prev: mani(cp(srcA, ".config/foo")),
 			next: mani(),
@@ -268,7 +268,7 @@ func TestComputeTableDriven(t *testing.T) {
 			want: want{warns: []WarnKind{WarnCopyOrphan}},
 		},
 		{
-			// copy target 不在: place-once で新規コピー。
+			// copy target absent: new copy under place-once.
 			name: "copy target absent → place-once copy",
 			prev: nil,
 			next: mani(cp(srcA, ".config/foo")),
@@ -276,7 +276,7 @@ func TestComputeTableDriven(t *testing.T) {
 			want: want{copies: []string{".config/foo"}},
 		},
 		{
-			// copy 既存・記録あり（前世代も copy）: place-once で no-op。
+			// copy exists, recorded (previous generation was also copy): no-op under place-once.
 			name: "copy recorded → no-op",
 			prev: mani(cp(srcA, ".config/foo")),
 			next: mani(cp(srcA, ".config/foo")),
@@ -284,7 +284,7 @@ func TestComputeTableDriven(t *testing.T) {
 			want: want{},
 		},
 		{
-			// copy 既存・記録なし（foreign 実ファイル）: skip + warning。
+			// copy exists, unrecorded (foreign real file): skip + warning.
 			name: "copy foreign file → skip + warn",
 			prev: nil,
 			next: mani(cp(srcA, ".config/foo")),
@@ -292,7 +292,7 @@ func TestComputeTableDriven(t *testing.T) {
 			want: want{warns: []WarnKind{WarnCopyForeign}},
 		},
 		{
-			// 構造不一致（src dir × target file）: conflict。
+			// structure mismatch (src dir × target file): conflict.
 			name: "copy structure mismatch (src dir, target file) → conflict",
 			prev: nil,
 			next: mani(cp(srcA, ".config/foo")),
@@ -300,7 +300,7 @@ func TestComputeTableDriven(t *testing.T) {
 			want: want{conflicts: 1},
 		},
 		{
-			// 構造不一致（src file × target dir）: conflict。
+			// structure mismatch (src file × target dir): conflict.
 			name: "copy structure mismatch (src file, target dir) → conflict",
 			prev: nil,
 			next: mani(cp(srcA, ".config/foo")),
@@ -308,7 +308,7 @@ func TestComputeTableDriven(t *testing.T) {
 			want: want{conflicts: 1},
 		},
 		{
-			// copy 既存・記録あり・dir/dir 一致: no-op。
+			// copy exists, recorded, dir/dir match: no-op.
 			name: "copy recorded dir → no-op",
 			prev: mani(cp(srcA, ".config/foo")),
 			next: mani(cp(srcA, ".config/foo")),
@@ -316,16 +316,16 @@ func TestComputeTableDriven(t *testing.T) {
 			want: want{},
 		},
 		{
-			// 複合: 新規 + silent 張替 + foreign 警告 + stale 除去 + mismatch 残し。
+			// mixed: new + silent re-link + foreign warning + stale removal + mismatch kept.
 			name: "mixed plan",
 			prev: mani(sl(srcA, "keep"), sl(srcA, "drop"), sl(srcA, "mism")),
 			next: mani(sl(srcB, "keep"), sl(srcB, "fresh"), sl(srcB, "foreign")),
 			fs: fakeFS{
-				abs("keep"):    sym(srcA),          // 記録通り → silent replace
-				abs("drop"):    sym(srcA),          // stale 記録通り → remove
-				abs("mism"):    sym("/elsewhere"),  // stale 不一致 → keep + warn
-				abs("foreign"): sym("/foreign/ln"), // 記録なし symlink → foreign warn + replace
-				// fresh は不在 → PlaceNew
+				abs("keep"):    sym(srcA),          // matches record → silent replace
+				abs("drop"):    sym(srcA),          // stale matches record → remove
+				abs("mism"):    sym("/elsewhere"),  // stale mismatch → keep + warn
+				abs("foreign"): sym("/foreign/ln"), // unrecorded symlink → foreign warn + replace
+				// fresh is absent → PlaceNew
 			},
 			want: want{
 				placeNew:     []string{"fresh"},
@@ -356,7 +356,7 @@ func TestComputeTableDriven(t *testing.T) {
 	}
 }
 
-// TestComputeUnknownMethodErrors は未知 method を弾くことを検証する。
+// TestComputeUnknownMethodErrors verifies that an unknown method is rejected.
 func TestComputeUnknownMethodErrors(t *testing.T) {
 	e := sl("/nix/store/x", ".config/foo")
 	e.Method = "bogus"
@@ -366,7 +366,7 @@ func TestComputeUnknownMethodErrors(t *testing.T) {
 	}
 }
 
-// TestComputeAncestorDirNotSymlink は祖先が通常ディレクトリなら conflict にならないことを確認する。
+// TestComputeAncestorDirNotSymlink confirms that no conflict arises when the ancestor is a regular directory.
 func TestComputeAncestorDirNotSymlink(t *testing.T) {
 	plan, err := Compute(nil, mani(sl("/nix/store/x", ".config/foo")), root,
 		fakeFS{abs(".config"): dir()})

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -1,22 +1,23 @@
-# nput lib 公開 API のまとめ（→ docs/design.md「flake.nix outputs 設計」）。
+# Summary of the nput lib public API (→ docs/design.md "flake.nix outputs design").
 #
-# nixpkgs.lib のみ依存（home-manager / NixOS / nix-darwin は引かない・→ ADR-0006）。
-# マーカー群は純 attrset 構築子で依存なし。mkManifest は引数 attrset の `pkgs` から
-# linkFarm 相当（runCommandLocal）と `pkgs.lib` を得て derivation を組む。
+# Depends on nixpkgs.lib only (no dependency on home-manager / NixOS / nix-darwin・→ ADR-0006).
+# The markers are pure attrset constructors with no dependencies. mkManifest takes `pkgs`
+# from its argument attrset to obtain the linkFarm equivalent (runCommandLocal) and `pkgs.lib`
+# to build the derivation.
 let
   markers = import ./out-of-store.nix;
   manifest = import ./manifest.nix;
 in
 {
-  # lib.mkManifest { pkgs, root, entries } -> derivation（manifest.json + symlink farm・→ ADR-0006, ADR-0023）
+  # lib.mkManifest { pkgs, root, entries } -> derivation (manifest.json + symlink farm・→ ADR-0006, ADR-0023)
   inherit (manifest) mkManifest;
 
-  # 検査・正規化の純データ関数。nix-unit / namaka の単体対象 + 将来 modules から再利用（→ ADR-0010）。
+  # Pure data functions for validation/normalization. Unit-test target for nix-unit / namaka, plus future reuse from modules (→ ADR-0010).
   # normalizeManifest { lib, root, entries } -> attrset
   inherit (manifest) normalizeManifest;
 
-  # lib.mkOutOfStoreSymlink "/abs/path" -> marker（src に渡す・→ ADR-0001）
-  # lib.projectRoot / homeRoot / systemRoot -> marker（root に渡す・→ ADR-0004, ADR-0005, ADR-0007）
+  # lib.mkOutOfStoreSymlink "/abs/path" -> marker (passed to src・→ ADR-0001)
+  # lib.projectRoot / homeRoot / systemRoot -> marker (passed to root・→ ADR-0004, ADR-0005, ADR-0007)
   inherit (markers)
     mkOutOfStoreSymlink
     projectRoot

--- a/lib/manifest.nix
+++ b/lib/manifest.nix
@@ -1,23 +1,23 @@
-# normalizeManifest（純データ・検査ゲート）+ mkManifest（derivation 生成）（→ ADR-0006, ADR-0010, ADR-0016, ADR-0019, ADR-0023）。
+# normalizeManifest (pure data, validation gate) + mkManifest (derivation generation) (→ ADR-0006, ADR-0010, ADR-0016, ADR-0019, ADR-0023).
 #
-# 2 段に分ける（→ ADR-0010）:
+# Split into two stages (→ ADR-0010):
 #   - normalizeManifest { lib, root, entries } -> attrset
-#       evalModules 検査・デフォルト適用・パス安全性 / クロスフィールド throwIf・marker タグ → clean enum 変換。
-#       derivation の外に出すことで nix-unit / namaka の単体対象にする。
+#       evalModules validation, default application, path safety / cross-field throwIf, marker tag → clean enum conversion.
+#       Kept outside the derivation so it becomes a unit-test target for nix-unit / namaka.
 #   - mkManifest { pkgs, root, entries } -> derivation
-#       normalizeManifest の出力を manifest.json に書き、store src への symlink farm を組む。
+#       Writes normalizeManifest's output to manifest.json and builds a symlink farm to the store src.
 #
-# 本スライスの最小スコープ: root = projectRoot のみ / src = path・set の store-backed symlink entry のみ
-# （→ Issue #5）。型・throwIf は将来スライス（home / copy / out-of-store）も見据えて完全形で定義する。
+# Minimal scope of this slice: root = projectRoot only / src = store-backed symlink entries of path/set only
+# (→ Issue #5). Types and throwIf are defined in full form, anticipating future slices (home / copy / out-of-store).
 let
-  # ---- パス安全性（→ ADR-0019）----------------------------------------------
-  # target は root 相対・subpath は src 内相対。絶対パス（`/` 始まり）と
-  # `..` で外へ出るパスを eval 時に拒否する。root の実体値（実行時解決）に依らず静的に判定可能。
+  # ---- Path safety (→ ADR-0019)----------------------------------------------
+  # target is root-relative, subpath is relative within src. Absolute paths (leading `/`) and
+  # paths that escape outward via `..` are rejected at eval time. Decidable statically, independent of root's concrete value (runtime resolution).
   pathChecks =
     lib:
     let
       isAbsolute = lib.hasPrefix "/";
-      # `..` を辿って深さが負になる（base の外へ出る）かを判定する。
+      # Determine whether following `..` makes the depth go negative (escapes outside base).
       escapesBase =
         p:
         let
@@ -56,7 +56,7 @@ let
       t = import ./types.nix lib;
       checks = pathChecks lib;
 
-      # 両経路（CLI 直呼び / モジュール）で検査を効かせるため mkManifest 自身が evalModules を回す（→ ADR-0010）。
+      # mkManifest itself runs evalModules so validation applies on both paths (direct CLI call / module) (→ ADR-0010).
       evaluated = lib.evalModules {
         modules = [
           {
@@ -73,7 +73,7 @@ let
       };
       cfg = evaluated.config;
 
-      # root の marker タグ → clean enum（→ ADR-0010）。
+      # root marker tag → clean enum (→ ADR-0010).
       rootInfo =
         if t.isRootMarker cfg.root then
           { rootKind = cfg.root.kind; }
@@ -83,8 +83,8 @@ let
             root = cfg.root;
           };
 
-      # entry の marker タグ → clean enum + 解決済み src 文字列（→ ADR-0010）。
-      # 属性キー = target なので attrNames の辞書順で決定的に配列化する（Go は配列を読む・→ ADR-0014）。
+      # entry marker tag → clean enum + resolved src string (→ ADR-0010).
+      # Since the attribute key = target, serialize to an array deterministically in attrNames lexical order (Go reads the array・→ ADR-0014).
       resolveEntry =
         e:
         let
@@ -109,21 +109,21 @@ let
 
       targets = map (e: e.target) normEntries;
 
-      # ---- クロスフィールド / パス検査（→ ADR-0013, ADR-0019, ADR-0024）-------
+      # ---- Cross-field / path validation (→ ADR-0013, ADR-0019, ADR-0024)-------
       assertions = lib.concatLists [
-        # systemRoot は未実装（→ ADR-0013）。
+        # systemRoot is not implemented (→ ADR-0013).
         (lib.optional (
           rootInfo.rootKind == "system"
         ) "nput: root = systemRoot (system mode) は未実装です（→ ADR-0013）")
-        # method = "copy" かつ out-of-store marker は意図矛盾（→ ADR-0013）。
+        # method = "copy" combined with an out-of-store marker is a contradiction of intent (→ ADR-0013).
         (map (
           e: "nput: method = \"copy\" と out-of-store marker は同時指定できません（target: ${e.target}・→ ADR-0013）"
         ) (lib.filter (e: e.method == "copy" && e.srcKind == "outOfStore") normEntries))
-        # 別キーで target を同値に明示上書きした衝突（→ ADR-0024）。
+        # Collision from explicitly overriding target to the same value under a different key (→ ADR-0024).
         (lib.optional (
           lib.length targets != lib.length (lib.unique targets)
         ) "nput: 複数 entry が同一 target に解決されました（→ ADR-0024）")
-        # target / subpath の絶対パス・`..` エスケープ拒否（→ ADR-0019）。
+        # Reject absolute paths / `..` escapes in target / subpath (→ ADR-0019).
         (map (e: "nput: target が不正です（絶対パスまたは `..` で root の外）: ${e.target}（→ ADR-0019）") (
           lib.filter (e: checks.isUnsafe e.target) normEntries
         ))
@@ -138,10 +138,10 @@ let
         entries = normEntries;
       };
     in
-    # 全 assertion を throwIf で評価ゲートに通す。
+    # Run every assertion through the evaluation gate with throwIf.
     lib.foldl' (acc: msg: lib.throwIf true msg acc) result assertions;
 
-  # symlink farm の GC アンカー名 = target の sha256 短縮 hex（固定長・FS 安全・衝突不可能・→ ADR-0016）。
+  # GC anchor name for the symlink farm = sha256 short hex of target (fixed length, FS-safe, collision-free・→ ADR-0016).
   anchorName = lib: target: lib.substring 0 32 (builtins.hashString "sha256" target);
 
   mkManifest =
@@ -156,18 +156,18 @@ let
 
       manifestJson = pkgs.writeText "manifest.json" (builtins.toJSON norm);
 
-      # farm アンカーは「store-backed かつ method = symlink」の entry 限定（→ ADR-0016, ADR-0019）。
-      # out-of-store / copy は farm アンカーを持たない（copy は世代外・place-once で store から独立）。
+      # Farm anchors are limited to entries that are "store-backed and method = symlink" (→ ADR-0016, ADR-0019).
+      # out-of-store / copy have no farm anchor (copy is out-of-generation, place-once, and independent of the store).
       farmEntries = lib.filter (e: e.srcKind == "store" && e.method == "symlink") norm.entries;
 
       anchorLines = lib.concatMapStringsSep "\n" (
         e: "ln -s ${lib.escapeShellArg e.src} \"$out/${anchorName lib e.target}\""
       ) farmEntries;
     in
-    # derivation は manifest.json（engine の入力契約）+ store src への symlink farm（GC アンカー）を含む（→ ADR-0006）。
+    # The derivation contains manifest.json (the engine's input contract) + a symlink farm to the store src (GC anchors) (→ ADR-0006).
     pkgs.runCommandLocal "nput-manifest"
       {
-        # CLI が build 前に `nix eval … .rootKind` で読む（→ ADR-0023）。
+        # The CLI reads this via `nix eval … .rootKind` before build (→ ADR-0023).
         passthru = {
           inherit (norm.root) rootKind;
         }

--- a/lib/out-of-store.nix
+++ b/lib/out-of-store.nix
@@ -1,20 +1,20 @@
-# マーカー構築子（→ ADR-0001, ADR-0004, ADR-0005, ADR-0007, ADR-0010）。
+# Marker constructors (→ ADR-0001, ADR-0004, ADR-0005, ADR-0007, ADR-0010).
 #
-# マーカーは「実行時解決の種別を運ぶ入れ物」であり、パス文字列を返す糖衣ではない。
-# `src`（derivation）も marker もどちらも attrset で構造判別できないため、marker には
-# `_nputMarker` 判別タグを持たせ、`lib/types.nix` の custom optionType の `check` が判別する。
-# `_nputMarker` は Nix 評価内で完結させ `manifest.json` には漏らさない（Go 契約は clean enum・→ ADR-0010）。
+# A marker is a "container that carries the kind for runtime resolution", not syntactic sugar that returns a path string.
+# Since both `src` (a derivation) and a marker are attrsets and cannot be distinguished structurally, a marker
+# carries a `_nputMarker` discriminator tag, and the `check` of the custom optionType in `lib/types.nix` distinguishes them.
+# `_nputMarker` stays within Nix evaluation and is never leaked into `manifest.json` (the Go contract is a clean enum・→ ADR-0010).
 #
-# 依存なし（nixpkgs.lib すら要らない純 attrset 構築子）。
+# No dependencies (pure attrset constructors that do not even require nixpkgs.lib).
 {
-  # ローカルパスへの out-of-store symlink を表すマーカー（→ ADR-0001）。
-  # 引数は Nix 評価時に確定する絶対パスの文字列。実際の link 生成は engine の実行時責務。
+  # Marker representing an out-of-store symlink to a local path (→ ADR-0001).
+  # The argument is an absolute path string fixed at Nix eval time. Actual link creation is the engine's runtime responsibility.
   mkOutOfStoreSymlink = path: {
     _nputMarker = "outOfStore";
     inherit path;
   };
 
-  # root マーカー（→ ADR-0004 改訂, ADR-0005, ADR-0007）。kind を運ぶだけで、実体パス解決は engine の実行時責務。
+  # root markers (→ ADR-0004 revised, ADR-0005, ADR-0007). They merely carry kind; concrete path resolution is the engine's runtime responsibility.
   projectRoot = {
     _nputMarker = "root";
     kind = "project";

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -1,27 +1,27 @@
-# entry submodule + srcType / rootType / marker custom type（→ ADR-0010, ADR-0014）。
+# entry submodule + srcType / rootType / marker custom type (→ ADR-0010, ADR-0014).
 #
-# `mkManifest` の `evalModules` と `modules/common.nix` の `attrsOf (submodule …)` で
-# 共有できるよう、nixpkgs.lib を受け取り型定義一式を返す純関数として書く。
-# `lib.types` / `mkOption` / `evalModules` は nixpkgs.lib のコアなので
-# 「lib は nixpkgs.lib のみ依存」を満たす（home-manager / NixOS / nix-darwin は引かない）。
+# Written as a pure function that takes nixpkgs.lib and returns the full set of type definitions,
+# so it can be shared by `mkManifest`'s `evalModules` and `modules/common.nix`'s `attrsOf (submodule …)`.
+# `lib.types` / `mkOption` / `evalModules` are core to nixpkgs.lib, so this satisfies
+# "lib depends on nixpkgs.lib only" (no dependency on home-manager / NixOS / nix-darwin).
 lib:
 let
   inherit (lib) types mkOption mkDefault;
   inherit (lib.options) mergeEqualOption;
   inherit (builtins) isAttrs isString;
 
-  # marker 判別（`out-of-store.nix` が付ける `_nputMarker` タグで見分ける）。
+  # Marker discrimination (distinguished by the `_nputMarker` tag attached by `out-of-store.nix`).
   isOutOfStoreMarker = x: isAttrs x && (x._nputMarker or null) == "outOfStore";
   isRootMarker = x: isAttrs x && (x._nputMarker or null) == "root";
 
-  # store-backed src: path / derivation / flake input（`{ outPath = …; }`）を 1 ブランチに集約。
-  # 素の文字列は拒否し out-of-store の暗黙分岐を型で禁ずる（→ ADR-0001）。
-  # path と set は挙動が同一（ともに store link）なので型レベルで分けない（→ ADR-0010）。
+  # store-backed src: collapse path / derivation / flake input (`{ outPath = …; }`) into a single branch.
+  # Reject bare strings and forbid the implicit out-of-store branch at the type level (→ ADR-0001).
+  # path and set behave identically (both are store links), so they are not split at the type level (→ ADR-0010).
   isStoreBacked =
     x:
     lib.isPath x || lib.isDerivation x || (isAttrs x && x ? outPath && (x._nputMarker or null) == null);
 
-  # srcType = either storeBacked outOfStoreMarker（→ ADR-0010）。
+  # srcType = either storeBacked outOfStoreMarker (→ ADR-0010).
   srcType = types.mkOptionType {
     name = "nputSrc";
     description = "store-backed source (path / derivation / flake input) or out-of-store marker";
@@ -29,8 +29,8 @@ let
     merge = mergeEqualOption;
   };
 
-  # rootType = either str rootMarker（→ ADR-0010）。`mkManifest` 専用で modules は共有しない
-  # （modules は root を pin する・→ ADR-0003）。
+  # rootType = either str rootMarker (→ ADR-0010). Used only by `mkManifest`, not shared with modules
+  # (modules pin root・→ ADR-0003).
   rootType = types.mkOptionType {
     name = "nputRoot";
     description = "absolute path string or root marker (projectRoot / homeRoot / systemRoot)";
@@ -38,7 +38,7 @@ let
     merge = mergeEqualOption;
   };
 
-  # entry submodule（→ ADR-0014）。属性キー = target が識別子。strict（未知キー拒否）。
+  # entry submodule (→ ADR-0014). The attribute key = target is the identifier. strict (unknown keys rejected).
   entryModule =
     { name, ... }:
     {
@@ -54,7 +54,7 @@ let
         };
         target = mkOption {
           type = types.str;
-          # 既定 = 属性キー（→ ADR-0014）。
+          # Default = attribute key (→ ADR-0014).
           default = name;
           defaultText = "属性キー";
           description = "root 相対の配置先。省略時は属性キー。";

--- a/modules/common.nix
+++ b/modules/common.nix
@@ -1,16 +1,16 @@
-# 全モジュール共通の nput オプション定義（→ ADR-0003, ADR-0007, ADR-0010, ADR-0014）。
+# nput option definitions common to all modules (→ ADR-0003, ADR-0007, ADR-0010, ADR-0014).
 #
-# HM / NixOS / nix-darwin が import する共通の options。配置ロジックは持たず、
-# 「何を・どこへ・どう置くか」のデータ（entries）だけを宣言させる。各モジュールは
-# 自分の性質で root を pin する（HM → homeRoot）ため、利用者は root を再指定しない。
+# The common options imported by HM / NixOS / nix-darwin. They hold no placement logic and
+# only let the user declare the data (entries) of "what, where, and how to place". Each module
+# pins root according to its own nature (HM → homeRoot), so the user does not re-specify root.
 #
-# entry submodule の型は lib/types.nix と共有する（mkManifest の evalModules と同一の
-# entriesType）。これにより未知キー（タイポ・旧名）は strict submodule で eval エラーに
-# なり、検査の二重定義を避ける（→ ADR-0010, docs/spec.md「モジュールオプション仕様」）。
+# The entry submodule type is shared with lib/types.nix (the same entriesType as mkManifest's
+# evalModules). This way, unknown keys (typos, old names) become eval errors via the strict submodule,
+# avoiding a duplicate definition of validation (→ ADR-0010, docs/spec.md "module option spec").
 #
-# > HM モジュール経由は MVP で単一 nput.entries = 1 profile（固定名 default）に限り、
-# > role 分離（複数 profile）はできない。役割分離が要るユーザーは standalone CLI 経路
-# > （entrypoint の nput.<name>）を使う。複数 profile 化は将来 seam（→ ADR-0024, ADR-0025）。
+# > Via the HM module, the MVP is limited to a single nput.entries = 1 profile (fixed name default),
+# > and role separation (multiple profiles) is not possible. Users who need role separation use the
+# > standalone CLI path (entrypoint's nput.<name>). Multiple profiles are a future seam (→ ADR-0024, ADR-0025).
 { lib, ... }:
 let
   nputTypes = import ../lib/types.nix lib;

--- a/modules/flake-parts.nix
+++ b/modules/flake-parts.nix
@@ -1,14 +1,14 @@
-# flake-parts module: perSystem.nput.<name> を flake.nput.<system>.<name> へ転置する（→ ADR-0029）。
-# flake-parts 公式の mkTransposedPerSystemModule（packages / legacyPackages と同じ転置機構）を流用し、
-# 自前の mkPerSystemOption + transposition は手書きしない（ADR-0029 残作業1）。
+# flake-parts module: transpose perSystem.nput.<name> to flake.nput.<system>.<name> (→ ADR-0029).
+# Reuse flake-parts' official mkTransposedPerSystemModule (the same transposition mechanism as packages / legacyPackages),
+# rather than hand-writing our own mkPerSystemOption + transposition (ADR-0029 remaining task 1).
 #
-# option は lazyAttrsOf package。consumer は perSystem で
+# The option is lazyAttrsOf package. The consumer writes, in perSystem,
 #   nput.<name> = inputs.nput.lib.mkManifest { inherit pkgs; root = ...; entries = { ... }; };
-# と書く。転置先 flake.nput.<system>.<name> は CLI が `nix build .#nput.<system>.<name>` で叩く
-# build 可能な derivation でなければならない（mkManifest の結果＝derivation を格納する・ADR 決定2）。
+# The transposition target flake.nput.<system>.<name> must be a buildable derivation that the CLI invokes
+# via `nix build .#nput.<system>.<name>` (it stores the result of mkManifest = a derivation・ADR decision 2).
 #
-# module は純粋な transposition のみ。mkManifest やマーカー群を perSystem 引数に注入しない
-# （ADR 決定5）。consumer は同じ input の nput.lib を直接参照する。
+# The module does pure transposition only. It does not inject mkManifest or the markers into perSystem arguments
+# (ADR decision 5). The consumer references nput.lib of the same input directly.
 { lib, flake-parts-lib, ... }:
 let
   inherit (lib)

--- a/modules/home-manager.nix
+++ b/modules/home-manager.nix
@@ -1,22 +1,21 @@
-# home-manager モジュール: home.activation から nput エンジンを起動する薄い配線
-# （→ ADR-0002, ADR-0003, ADR-0007, docs/spec.md「モジュール別動作仕様」）。
+# home-manager module: thin wiring that kicks the nput engine from home.activation
+# (→ ADR-0002, ADR-0003, ADR-0007, docs/spec.md "per-module behavior spec").
 #
-# 配置ロジックは持たず、home.file / systemd.tmpfiles へは翻訳しない。配置・stale 除去は
-# 全層共通の nput エンジンが所有する（→ ADR-0003）。本モジュールは
-#   1. root = homeRoot を pin（利用者は root を再指定しない・→ ADR-0007）、
-#   2. nput.entries から link-farm（manifest.json + GC アンカー）を mkManifest でビルド、
-#   3. home.activation でその link-farm を `nput apply --manifest` に渡してエンジンを起動
-# するだけに徹する。
+# It holds no placement logic and does not translate to home.file / systemd.tmpfiles. Placement and stale
+# removal are owned by the nput engine common to all layers (→ ADR-0003). This module confines itself to
+#   1. pinning root = homeRoot (the user does not re-specify root・→ ADR-0007),
+#   2. building a link-farm (manifest.json + GC anchors) from nput.entries via mkManifest,
+#   3. passing that link-farm to `nput apply --manifest` from home.activation to kick the engine.
 #
-# 世代は nput 自前 profile（内部機構・前世代マニフェスト + stale 追跡）に乗る。MVP は固定名
-# `default` の単一 profile（<state>/nix/profiles/nput/default）で role 分離は不可。ユーザー
-# 向け rollback は host（home-manager --rollback）に一本化し、`nput rollback` は公開しない
-# （host rollback は旧 config を再 activate して nput を再 kick することで FS を自動収束させる）
-# （→ ADR-0002, ADR-0024, ADR-0025）。
+# Generations ride on nput's own profile (an internal mechanism, previous-generation manifest + stale tracking). The MVP is a
+# single profile with the fixed name `default` (<state>/nix/profiles/nput/default), and role separation is not possible.
+# User-facing rollback is unified to the host (home-manager --rollback), and `nput rollback` is not exposed
+# (host rollback re-activates the old config and re-kicks nput, automatically converging the FS)
+# (→ ADR-0002, ADR-0024, ADR-0025).
 #
-# nputPackage（pin 版 nput CLI）は flake.nix の homeManagerModules.default 配線が
-# _module.args として注入する（→ flake.nix）。nputLib は lib/ を直接 import する
-# （nixpkgs.lib のみ依存・home-manager に依存しない・→ ADR-0006）。
+# nputPackage (the pinned nput CLI) is injected as _module.args by flake.nix's homeManagerModules.default wiring
+# (→ flake.nix). nputLib imports lib/ directly
+# (depends on nixpkgs.lib only, no dependency on home-manager・→ ADR-0006).
 {
   config,
   lib,
@@ -28,8 +27,8 @@ let
   cfg = config.nput;
   nputLib = import ../lib;
 
-  # nput.entries から link-farm derivation（manifest.json + symlink farm）を生成する。
-  # root は homeRoot を pin（実体 $HOME の解決は engine 実行時・marker は eval 時に展開しない）。
+  # Generate a link-farm derivation (manifest.json + symlink farm) from nput.entries.
+  # root pins homeRoot (the concrete $HOME is resolved at engine runtime; the marker is not expanded at eval time).
   manifest = nputLib.mkManifest {
     inherit pkgs;
     root = nputLib.homeRoot;
@@ -40,10 +39,10 @@ in
   imports = [ ./common.nix ];
 
   config = lib.mkIf cfg.enable {
-    # home.activation から engine を起動する。ビルド済み link-farm を --manifest で渡すため
-    # activation 内で nix eval/build は行わない（entrypoint 経路ではない）。writeBoundary 後に
-    # 走らせ、home.file の symlink 配置と順序衝突しないようにする。`run` は home-manager の
-    # activation ヘルパで --dry-run（DRY_RUN_CMD）を尊重する。
+    # Kick the engine from home.activation. Since the pre-built link-farm is passed via --manifest,
+    # no nix eval/build is done inside activation (this is not the entrypoint path). Run it after
+    # writeBoundary so it does not collide in ordering with home.file's symlink placement. `run` is home-manager's
+    # activation helper and honors --dry-run (DRY_RUN_CMD).
     home.activation.nput = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
       run ${lib.getExe nputPackage} apply --manifest ${manifest}
     '';

--- a/templates/project/flake.nix
+++ b/templates/project/flake.nix
@@ -4,15 +4,15 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
 
-    # nput ライブラリ・CLI。nixpkgs を follows させて mkManifest の pkgs と
-    # devShell に載せる nput CLI のビルド入力を揃える（schemaVersion 整合）。
+    # The nput library / CLI. Make nixpkgs follow so that mkManifest's pkgs and
+    # the build inputs of the nput CLI placed on the devShell are aligned (schemaVersion consistency).
     nput = {
       url = "github:yasunori0418/nput";
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
-    # 実用では「配置したい git リポジトリ」を flake = false の input として宣言し、
-    # 下の entries の src をこの input へ差し替える（add me）:
+    # In practice, declare the "git repository you want to place" as a flake = false input,
+    # and swap the src of the entries below to this input (add me):
     #   my-repo = {
     #     url = "github:you/your-repo";
     #     flake = false;
@@ -27,7 +27,7 @@
       ...
     }:
     let
-      # 4 system に同じ config を展開するヘルパ（flake-parts は starter には過剰なので不使用）。
+      # Helper to expand the same config over 4 systems (flake-parts is overkill for a starter, so unused).
       forAllSystems = nixpkgs.lib.genAttrs [
         "x86_64-linux"
         "aarch64-linux"
@@ -36,27 +36,27 @@
       ];
     in
     {
-      # nput.<system>.<name> namespace。`nput apply <name>` がこの config をビルドして配置する。
-      # 標準 flake output ではないため `nix flake check` で
-      # `warning: unknown flake output 'nput'`（exit 0・無害）が出る。
+      # nput.<system>.<name> namespace. `nput apply <name>` builds and places this config.
+      # Since it is not a standard flake output, `nix flake check` emits
+      # `warning: unknown flake output 'nput'` (exit 0, harmless).
       nput = forAllSystems (
         system:
         let
           pkgs = nixpkgs.legacyPackages.${system};
         in
         {
-          # config 名 example は "rename me" の合図。`nput apply example` で配置する。
+          # The config name example signals "rename me". Place it with `nput apply example`.
           example = nput.lib.mkManifest {
             inherit pkgs;
 
-            # repo（git toplevel）配下を root に取る（target は repo ルート相対）。
+            # Take the repo (git toplevel) tree as root (target is relative to the repo root).
             root = nput.lib.projectRoot;
 
-            # 属性キー = 配置先（root 相対 target）。ここでは nput 自身の docs/ を例示する。
-            # 実用では src を上の my-repo input へ、subpath を配置したいサブディレクトリへ差し替える。
+            # Attribute key = placement target (root-relative target). Here, nput's own docs/ is shown as an example.
+            # In practice, swap src to the my-repo input above and subpath to the subdirectory you want to place.
             #
-            # 配置物は ephemeral（git 管理せず再生成する前提）。下の .gitignore に無視パターンを
-            # 追記済み。target を変えたら `nput gitignore example` の出力で更新する。
+            # The placed artifacts are ephemeral (assumed regenerated, not git-managed). An ignore pattern is already
+            # added to the .gitignore below. If you change target, update it with the output of `nput gitignore example`.
             entries.".nput/docs" = {
               src = nput;
               subpath = "docs";
@@ -65,9 +65,9 @@
         }
       );
 
-      # devShell。`nix develop` / direnv 入室時に pin 済み nput CLI を PATH に載せ、
-      # shellHook で config を自動配置する。.envrc は同梱しない（direnv 導入は利用者判断・ADR-0018）。
-      # direnv を使うなら repo に `echo 'use flake' > .envrc && direnv allow` を実行する。
+      # devShell. On `nix develop` / direnv entry, put the pinned nput CLI on PATH
+      # and auto-place the config in shellHook. No .envrc is bundled (adopting direnv is the user's call・ADR-0018).
+      # If you use direnv, run `echo 'use flake' > .envrc && direnv allow` in the repo.
       devShells = forAllSystems (
         system:
         let
@@ -77,8 +77,8 @@
           default = pkgs.mkShell {
             packages = [ nput.packages.${system}.nput ];
 
-            # 入室時に example を配置する。--no-wait で flock 競合時は待たず skip（多重入室で固まらない）。
-            # 複数 config を一括配置するなら:
+            # Place example on entry. With --no-wait, on flock contention skip without waiting (concurrent entries do not hang).
+            # To place multiple configs at once:
             #   nput apply --all --project-root --no-wait
             shellHook = ''
               nput apply example --no-wait

--- a/templates/standalone/flake.nix
+++ b/templates/standalone/flake.nix
@@ -4,14 +4,14 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
 
-    # nput ライブラリ・CLI。nixpkgs を follows させて mkManifest が使う pkgs を揃える。
+    # The nput library / CLI. Make nixpkgs follow to align the pkgs that mkManifest uses.
     nput = {
       url = "github:yasunori0418/nput";
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
-    # 実用では「配置したい git リポジトリ」を flake = false の input として宣言し、
-    # 下の entries の src をこの input へ差し替える（add me）:
+    # In practice, declare the "git repository you want to place" as a flake = false input,
+    # and swap the src of the entries below to this input (add me):
     #   my-repo = {
     #     url = "github:you/your-repo";
     #     flake = false;
@@ -26,7 +26,7 @@
       ...
     }:
     let
-      # 4 system に同じ config を展開するヘルパ（flake-parts は starter には過剰なので不使用）。
+      # Helper to expand the same config over 4 systems (flake-parts is overkill for a starter, so unused).
       forAllSystems = nixpkgs.lib.genAttrs [
         "x86_64-linux"
         "aarch64-linux"
@@ -35,52 +35,52 @@
       ];
     in
     {
-      # nput.<system>.<name> namespace。`nput apply <name>` がこの config をビルドして配置する。
-      # 標準 flake output ではないため `nix flake check` で
-      # `warning: unknown flake output 'nput'`（exit 0・無害）が出る。
+      # nput.<system>.<name> namespace. `nput apply <name>` builds and places this config.
+      # Since it is not a standard flake output, `nix flake check` emits
+      # `warning: unknown flake output 'nput'` (exit 0, harmless).
       nput = forAllSystems (
         system:
         let
           pkgs = nixpkgs.legacyPackages.${system};
         in
         {
-          # config 名 example は "rename me" の合図。`nput apply example` で配置する。
+          # The config name example signals "rename me". Place it with `nput apply example`.
           example = nput.lib.mkManifest {
             inherit pkgs;
 
-            # home 配下を root に取る（target は $HOME 相対）。
+            # Take the home tree as root (target is relative to $HOME).
             root = nput.lib.homeRoot;
 
-            # 属性キー = 配置先（root 相対 target）。ここでは nput 自身の docs/ を例示する。
-            # 実用では src を上の my-repo input へ、subpath を配置したいサブディレクトリへ差し替える。
+            # Attribute key = placement target (root-relative target). Here, nput's own docs/ is shown as an example.
+            # In practice, swap src to the my-repo input above and subpath to the subdirectory you want to place.
             entries.".config/nput-docs" = {
               src = nput;
               subpath = "docs";
             };
 
-            # ---- バリエーション例 ------------------------------------------------
+            # ---- Variation examples ------------------------------------------------
             #
-            # subpath 省略 = リポジトリ全体を配置:
+            # Omitting subpath = place the whole repository:
             #   entries.".config/my-repo" = { src = my-repo; };
             #
-            # method = "copy" = symlink ではなく通常ファイルとして配置（書込可・place-once）:
+            # method = "copy" = place as a regular file instead of a symlink (writable, place-once):
             #   entries.".config/editable" = {
             #     src = my-repo;
             #     subpath = "config";
             #     method = "copy";
             #   };
             #
-            # out-of-store symlink = store ではなくローカルの絶対パスへ直接 symlink:
+            # out-of-store symlink = symlink directly to a local absolute path instead of the store:
             #   entries.".config/live" = {
             #     src = nput.lib.mkOutOfStoreSymlink "/abs/path/to/dir";
             #   };
             #
-            # 複数 entry = 属性をそのまま増やす:
+            # Multiple entries = just add more attributes:
             #   entries.".config/a" = { src = my-repo; subpath = "a"; };
             #   entries.".config/b" = { src = my-repo; subpath = "b"; };
             #
-            # 動的 entry 化 = 既 realise の store パス / flake input を builtins.readDir で
-            # 走査して entry を組む（IFD 回避のため生 derivation / out-of-store marker は readDir 不可）:
+            # Dynamic entries = scan an already-realised store path / flake input with builtins.readDir
+            # to build entries (a raw derivation / out-of-store marker cannot be readDir'd, to avoid IFD):
             #   entries = builtins.mapAttrs
             #     (name: _: { src = my-repo; subpath = "skills/${name}"; })
             #     (builtins.readDir "${my-repo}/skills");


### PR DESCRIPTION
## 概要

Issue #54 対応。`cmd/ internal/ lib/ modules/ templates/` の全ソースコメントを英語化する。Go の exported 宣言（型・関数・メソッド・変数）は識別子名始まりの godoc 形式に揃えた。`→ ADR-NNNN` ポインタは言語中立のため残し、`docs/spec.md「…」` 等の節タイトル参照は英語表記に統一した。

制約どおりコメントのみを英語化し、コード・文字列リテラル・挙動は一切変えていない。日本語の `fmt.Errorf`/`Warnf` 等のメッセージ文字列やモジュールの `description`・`example` は文字列リテラルのため据え置き（別途の担当範囲）。設計ドキュメント（ADR / CONTEXT / spec / design / concept / publication-roadmap）も方針どおり日本語維持で未変更。

パッケージ単位でコミットを分割（docs(cmd) / docs(engine) / docs(planner) / docs(paths) / docs(gitutil) / docs(lock) / docs(manifest) / docs(lib) / docs(modules) / docs(templates)）。

i18n-cli-english に積む stacked PR。

## 関連 issue

Closes #54

## docs / ADR 影響

なし（設計ドキュメントは日本語維持の方針どおり据え置き）。

## 動作確認

- `go test ./...` 全パッケージ通過。
- `nix flake check` 全チェック通過（treefmt・go-vet・golangci-lint・nix-unit・hm-module）。
- 全ソースコメントに日本語が残らないことを確認（残存する日本語は文字列リテラルのみ）。
