### PR TITLE
i18n: translate user-visible internal strings to English (#53 補完)

### DIFF
--- a/cmd/nput/apply_test.go
+++ b/cmd/nput/apply_test.go
@@ -101,7 +101,7 @@ func TestAggregateDryRun(t *testing.T) {
 			}
 			// A successful config's plan goes to stdout (owns the machine-readable output; → ADR-0023).
 			if strings.Contains(c.name, "all clean") && !strings.Contains(out, "place\t/p/a") {
-				t.Errorf("stdout に plan が出ていない: %q", out)
+				t.Errorf("plan not emitted to stdout: %q", out)
 			}
 		})
 	}
@@ -127,7 +127,7 @@ func TestSelectedRootFilter(t *testing.T) {
 	t.Run("multiple → error", func(t *testing.T) {
 		flagProjectRoot, flagHomeRoot, flagSystemRoot = true, true, false
 		if _, err := selectedRootFilter(); err == nil {
-			t.Fatal("複数指定はエラーになるべき")
+			t.Fatal("specifying multiple should be an error")
 		}
 	})
 }

--- a/cmd/nput/init_test.go
+++ b/cmd/nput/init_test.go
@@ -26,7 +26,7 @@ func TestFlakeInitArgs(t *testing.T) {
 			want:     []string{"flake", "init", "-t", "github:yasunori0418/nput#standalone"},
 		},
 		{
-			name:     "env override ref（path: 局所参照）",
+			name:     "env override ref (path: local reference)",
 			template: "project",
 			ref:      "path:/tmp/nput",
 			want:     []string{"flake", "init", "-t", "path:/tmp/nput#project"},

--- a/cmd/nput/reset_test.go
+++ b/cmd/nput/reset_test.go
@@ -19,10 +19,10 @@ func TestConfirmPolicy(t *testing.T) {
 		wantPrompt  bool
 		wantErr     bool
 	}{
-		{"--yes はスキップ（非対話でも）", true, false, false, false},
-		{"--yes はスキップ（対話でも）", true, true, false, false},
-		{"対話 + --yes 無しはプロンプト", false, true, true, false},
-		{"非対話 + --yes 無しは拒否", false, false, false, true},
+		{"--yes skips (even non-interactive)", true, false, false, false},
+		{"--yes skips (even interactive)", true, true, false, false},
+		{"interactive + no --yes prompts", false, true, true, false},
+		{"non-interactive + no --yes refuses", false, false, false, true},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -56,7 +56,7 @@ func TestPromptYesNo(t *testing.T) {
 		t.Run(strings.TrimSpace(c.input)+"->"+boolStr(c.want), func(t *testing.T) {
 			restore := withStdin(t, c.input)
 			defer restore()
-			got, err := promptYesNo("続行しますか？")
+			got, err := promptYesNo("Continue?")
 			if err != nil {
 				t.Fatalf("promptYesNo err = %v", err)
 			}
@@ -73,7 +73,7 @@ func TestIsInteractiveNonTTY(t *testing.T) {
 	restore := withStdin(t, "")
 	defer restore()
 	if isInteractive() {
-		t.Error("パイプ stdin では isInteractive() は false であるべき")
+		t.Error("isInteractive() should be false for piped stdin")
 	}
 }
 
@@ -87,35 +87,35 @@ func TestResetOutputStreams(t *testing.T) {
 		KeptForeign:     []string{"/root/c"},
 	}
 
-	t.Run("printResetPlan は stdout 専有", func(t *testing.T) {
+	t.Run("printResetPlan owns stdout exclusively", func(t *testing.T) {
 		out, errOut := captureOutErr(t, func() { printResetPlan(res) })
 		if !strings.Contains(out, "remove-symlink\t/root/a") ||
 			!strings.Contains(out, "remove-copy\t/root/b") ||
 			!strings.Contains(out, "keep-foreign\t/root/c") {
-			t.Errorf("plan が stdout に出ていない: %q", out)
+			t.Errorf("plan not emitted to stdout: %q", out)
 		}
 		if errOut != "" {
-			t.Errorf("plan で stderr に出力があるべきでない: %q", errOut)
+			t.Errorf("plan should not write to stderr: %q", errOut)
 		}
 	})
 
-	t.Run("reportResetResult は stderr 専有", func(t *testing.T) {
+	t.Run("reportResetResult owns stderr exclusively", func(t *testing.T) {
 		out, errOut := captureOutErr(t, func() { reportResetResult(res, "name") })
 		if out != "" {
-			t.Errorf("レポートが stdout を汚している: %q", out)
+			t.Errorf("report pollutes stdout: %q", out)
 		}
 		if !strings.Contains(errOut, "removed-symlink") || !strings.Contains(errOut, "/root/a") {
-			t.Errorf("レポートが stderr に出ていない: %q", errOut)
+			t.Errorf("report not emitted to stderr: %q", errOut)
 		}
 	})
 
-	t.Run("reportResetTargets は stderr 専有", func(t *testing.T) {
+	t.Run("reportResetTargets owns stderr exclusively", func(t *testing.T) {
 		out, errOut := captureOutErr(t, func() { reportResetTargets(res, "name") })
 		if out != "" {
-			t.Errorf("確認表示が stdout を汚している: %q", out)
+			t.Errorf("confirmation prompt pollutes stdout: %q", out)
 		}
 		if !strings.Contains(errOut, "removal targets") {
-			t.Errorf("確認表示が stderr に出ていない: %q", errOut)
+			t.Errorf("confirmation prompt not emitted to stderr: %q", errOut)
 		}
 	})
 }

--- a/internal/engine/commit.go
+++ b/internal/engine/commit.go
@@ -12,7 +12,7 @@ import (
 // so nix output is routed to stderr (→ docs/spec.md stream discipline).
 func nixEnvCommit(profileLink, linkFarm string) error {
 	if _, err := exec.LookPath("nix-env"); err != nil {
-		return fmt.Errorf("nix-env が PATH にありません: %w", err)
+		return fmt.Errorf("nix-env is not on PATH: %w", err)
 	}
 	cmd := exec.Command("nix-env", "--profile", profileLink, "--set", linkFarm)
 	cmd.Stdout = os.Stderr

--- a/internal/engine/copy.go
+++ b/internal/engine/copy.go
@@ -29,10 +29,10 @@ func (a *applier) materializeCopies(plan planner.Plan, recopy bool) error {
 func (a *applier) placeCopies(actions []planner.CopyAction) error {
 	for _, act := range actions {
 		if err := os.MkdirAll(filepath.Dir(act.TargetAbs), 0o755); err != nil {
-			return fmt.Errorf("nput: 親ディレクトリを作成できません (%s): %w", filepath.Dir(act.TargetAbs), err)
+			return fmt.Errorf("nput: cannot create parent directory (%s): %w", filepath.Dir(act.TargetAbs), err)
 		}
 		if err := copyTree(act.Src, act.TargetAbs); err != nil {
-			return fmt.Errorf("nput: copy 配置に失敗しました (%s -> %s): %w", act.Src, act.TargetAbs, err)
+			return fmt.Errorf("nput: copy placement failed (%s -> %s): %w", act.Src, act.TargetAbs, err)
 		}
 		a.result.Copied = append(a.result.Copied, act.Entry.Target)
 	}
@@ -54,17 +54,17 @@ func (a *applier) recopyAll() error {
 		if _, err := os.Lstat(targetAbs); err == nil {
 			existed = true
 			if err := os.RemoveAll(targetAbs); err != nil {
-				return fmt.Errorf("nput: recopy 対象を削除できません (%s): %w", targetAbs, err)
+				return fmt.Errorf("nput: cannot remove recopy target (%s): %w", targetAbs, err)
 			}
 		} else if !os.IsNotExist(err) {
-			return fmt.Errorf("nput: recopy target を lstat できません (%s): %w", targetAbs, err)
+			return fmt.Errorf("nput: cannot lstat recopy target (%s): %w", targetAbs, err)
 		}
 
 		if err := os.MkdirAll(filepath.Dir(targetAbs), 0o755); err != nil {
-			return fmt.Errorf("nput: 親ディレクトリを作成できません (%s): %w", filepath.Dir(targetAbs), err)
+			return fmt.Errorf("nput: cannot create parent directory (%s): %w", filepath.Dir(targetAbs), err)
 		}
 		if err := copyTree(planner.LinkDest(e), targetAbs); err != nil {
-			return fmt.Errorf("nput: recopy に失敗しました (%s -> %s): %w", planner.LinkDest(e), targetAbs, err)
+			return fmt.Errorf("nput: recopy failed (%s -> %s): %w", planner.LinkDest(e), targetAbs, err)
 		}
 		if existed {
 			a.result.Recopied = append(a.result.Recopied, e.Target)
@@ -84,7 +84,7 @@ func (a *applier) recopyAll() error {
 func copyTree(src, dst string) error {
 	info, err := os.Lstat(src)
 	if err != nil {
-		return fmt.Errorf("copy src を lstat できません (%s): %w", src, err)
+		return fmt.Errorf("cannot lstat copy src (%s): %w", src, err)
 	}
 	switch {
 	case info.Mode()&os.ModeSymlink != 0:

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -167,7 +167,7 @@ func Apply(opts Options) (*Result, error) {
 			a.result.Skipped = true
 			return a.result, ErrSkipped
 		}
-		return nil, fmt.Errorf("nput: flock の取得に失敗しました (%s): %w", a.profile.Dir, err)
+		return nil, fmt.Errorf("nput: failed to acquire flock (%s): %w", a.profile.Dir, err)
 	}
 	defer func() { _ = l.Release() }()
 
@@ -214,7 +214,7 @@ func Apply(opts Options) (*Result, error) {
 		same, err := generationUnchanged(a.profile.Profile, a.opts.LinkFarm)
 		if err != nil {
 			// When the previous generation's link-farm cannot be resolved, fall back to the safe side: normal apply (commit a new generation).
-			a.opts.Warnf("nput: 前世代 link-farm を解決できませんでした。世代スキップせず再コミットします: %v", err)
+			a.opts.Warnf("nput: could not resolve the previous generation's link-farm; recommitting without a generation skip: %v", err)
 		} else if same {
 			if err := a.repairDrift(plan, opts.Recopy); err != nil {
 				return nil, err
@@ -244,7 +244,7 @@ func Apply(opts Options) (*Result, error) {
 		commit = nixEnvCommit
 	}
 	if err := commit(a.profile.Profile, a.opts.LinkFarm); err != nil {
-		return nil, fmt.Errorf("nput: 世代コミット（nix-env --set）に失敗しました: %w", err)
+		return nil, fmt.Errorf("nput: generation commit (nix-env --set) failed: %w", err)
 	}
 
 	// 10. remove .pending after --set succeeds (the generation link inherits the gcroot · → ADR-0011, ADR-0025).
@@ -260,7 +260,7 @@ func (a *applier) cleanupPending() {
 		return
 	}
 	if err := os.Remove(a.profile.Pending); err != nil && !os.IsNotExist(err) {
-		a.opts.Warnf("nput: .pending out-link を削除できませんでした (%s): %v", a.profile.Pending, err)
+		a.opts.Warnf("nput: could not remove the .pending out-link (%s): %v", a.profile.Pending, err)
 	}
 }
 
@@ -338,7 +338,7 @@ func resolveRoot(rootKind, fixedRoot, rootOverride, workDir string, git GitFunc)
 		if dir == "" {
 			cwd, err := os.Getwd()
 			if err != nil {
-				return "", fmt.Errorf("nput: cwd を取得できません: %w", err)
+				return "", fmt.Errorf("nput: cannot get cwd: %w", err)
 			}
 			dir = cwd
 		}
@@ -349,34 +349,34 @@ func resolveRoot(rootKind, fixedRoot, rootOverride, workDir string, git GitFunc)
 	case manifest.RootKindHome:
 		home, err := os.UserHomeDir()
 		if err != nil {
-			return "", fmt.Errorf("nput: $HOME を解決できません: %w", err)
+			return "", fmt.Errorf("nput: cannot resolve $HOME: %w", err)
 		}
 		return home, nil
 	case manifest.RootKindFixed:
 		if fixedRoot == "" {
-			return "", fmt.Errorf("nput: rootKind=fixed なのに root パスがありません")
+			return "", fmt.Errorf("nput: rootKind=fixed but no root path provided")
 		}
 		return filepath.Abs(fixedRoot)
 	case manifest.RootKindSystem:
-		return "", fmt.Errorf("nput: root = systemRoot (system mode) は未実装です（→ ADR-0013）")
+		return "", fmt.Errorf("nput: root = systemRoot (system mode) is not implemented (→ ADR-0013)")
 	case "":
-		return "", fmt.Errorf("nput: rootKind が未確定です（eval 先取りまたは manifest が必要）")
+		return "", fmt.Errorf("nput: rootKind is undetermined (eval prefetch or a manifest is required)")
 	default:
-		return "", fmt.Errorf("nput: 未知の rootKind: %q", rootKind)
+		return "", fmt.Errorf("nput: unknown rootKind: %q", rootKind)
 	}
 }
 
 func (a *applier) ensureProfileDir() error {
 	if err := os.MkdirAll(a.profile.Dir, 0o755); err != nil {
-		return fmt.Errorf("nput: profileDir を作成できません (%s): %w", a.profile.Dir, err)
+		return fmt.Errorf("nput: cannot create profileDir (%s): %w", a.profile.Dir, err)
 	}
 	// Place backref .root at the <roothash> level (reverse-lookup seam for orphan profiles · → ADR-0013).
 	if a.profile.Backref != "" {
 		if err := os.MkdirAll(a.profile.BackrefDir, 0o755); err != nil {
-			return fmt.Errorf("nput: backref ディレクトリを作成できません (%s): %w", a.profile.BackrefDir, err)
+			return fmt.Errorf("nput: cannot create backref directory (%s): %w", a.profile.BackrefDir, err)
 		}
 		if err := os.WriteFile(a.profile.Backref, []byte(a.root+"\n"), 0o644); err != nil {
-			return fmt.Errorf("nput: backref を書けません (%s): %w", a.profile.Backref, err)
+			return fmt.Errorf("nput: cannot write backref (%s): %w", a.profile.Backref, err)
 		}
 	}
 	return nil
@@ -392,7 +392,7 @@ func (a *applier) loadPrevManifest() *manifest.Manifest {
 	m, err := manifest.Load(a.profile.Profile)
 	if err != nil {
 		// Even if the previous generation cannot be read, do not block new placement (just give up stale removal).
-		a.opts.Warnf("nput: 前世代 manifest を読めませんでした。stale 除去をスキップします: %v", err)
+		a.opts.Warnf("nput: could not read the previous generation's manifest; skipping stale removal: %v", err)
 		return nil
 	}
 	return m
@@ -406,18 +406,18 @@ func (a *applier) emitWarnings(ws []planner.Warning, recopy bool) {
 	for _, w := range ws {
 		switch w.Kind {
 		case planner.WarnForeignReplace:
-			a.opts.Warnf("nput: 記録の無い symlink を上書きします (foreign・後勝ち): %s", w.Target)
+			a.opts.Warnf("nput: overwriting an unrecorded symlink (foreign; last-wins): %s", w.Target)
 		case planner.WarnStaleMismatch:
-			a.opts.Warnf("nput: stale symlink が記録と不一致のため残します: %s", w.Target)
+			a.opts.Warnf("nput: keeping stale symlink because it mismatches the record: %s", w.Target)
 		case planner.WarnStaleNonSymlink:
-			a.opts.Warnf("nput: stale target が symlink ではないため残します: %s", w.Target)
+			a.opts.Warnf("nput: keeping stale target because it is not a symlink: %s", w.Target)
 		case planner.WarnCopyOrphan:
-			a.opts.Warnf("nput: copy entry が消えましたが target は削除しません（orphan・reset で撤去）: %s", w.Target)
+			a.opts.Warnf("nput: copy entry vanished but the target is not removed (orphan; clear it with reset): %s", w.Target)
 		case planner.WarnCopyForeign:
 			if recopy {
 				continue
 			}
-			a.opts.Warnf("nput: copy target に既存の実ファイルがあるため copy をスキップしました（foreign・place-once）: %s", w.Target)
+			a.opts.Warnf("nput: skipped copy because a real file already exists at the copy target (foreign; place-once): %s", w.Target)
 		}
 	}
 }

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -795,7 +795,7 @@ func TestApplyRecopyForeignFileOverwrites(t *testing.T) {
 	}
 	// On the recopy path no foreign skip warning is emitted (it overwrites, so that would be a false report).
 	for _, w := range warns {
-		if strings.Contains(w, "スキップ") {
+		if strings.Contains(w, "skipped copy") {
 			t.Errorf("unexpected copy foreign skip warning during recopy: %q", w)
 		}
 	}

--- a/internal/engine/generations.go
+++ b/internal/engine/generations.go
@@ -125,13 +125,13 @@ func Rollback(opts RollbackOptions) (*RollbackResult, error) {
 
 	// If profileDir is absent, apply has never run → no generation to roll back to.
 	if _, err := os.Stat(prof.Dir); err != nil {
-		return nil, fmt.Errorf("nput: profile がありません（一度も apply していません）: %s", prof.Dir)
+		return nil, fmt.Errorf("nput: no profile (apply has never run): %s", prof.Dir)
 	}
 
 	// 2. serialize with concurrent apply / rollback via a blocking flock (→ ADR-0013).
 	l, err := lock.Acquire(prof.Dir, true)
 	if err != nil {
-		return nil, fmt.Errorf("nput: flock の取得に失敗しました (%s): %w", prof.Dir, err)
+		return nil, fmt.Errorf("nput: failed to acquire flock (%s): %w", prof.Dir, err)
 	}
 	defer func() { _ = l.Release() }()
 
@@ -147,10 +147,10 @@ func Rollback(opts RollbackOptions) (*RollbackResult, error) {
 		}
 	}
 	if curIdx < 0 {
-		return nil, fmt.Errorf("nput: 現世代を特定できません（profile: %s）", prof.Profile)
+		return nil, fmt.Errorf("nput: cannot identify the current generation (profile: %s)", prof.Profile)
 	}
 	if curIdx == 0 {
-		return nil, fmt.Errorf("nput: 前世代がありません（最古の世代のため rollback できません）")
+		return nil, fmt.Errorf("nput: no previous generation (this is the oldest generation, cannot rollback)")
 	}
 	cur := gens[curIdx]
 	prev := gens[curIdx-1]
@@ -158,11 +158,11 @@ func Rollback(opts RollbackOptions) (*RollbackResult, error) {
 	// 4. baseline = current generation N's manifest (current FS state) / target = previous generation N-1's manifest.
 	baseline, err := manifest.Load(prof.Profile)
 	if err != nil {
-		return nil, fmt.Errorf("nput: 現世代 manifest を読めません: %w", err)
+		return nil, fmt.Errorf("nput: cannot read the current generation's manifest: %w", err)
 	}
 	target, err := manifest.Load(paths.GenerationLink(prof.Profile, prev.Number))
 	if err != nil {
-		return nil, fmt.Errorf("nput: 前世代 manifest を読めません (世代 %d): %w", prev.Number, err)
+		return nil, fmt.Errorf("nput: cannot read the previous generation's manifest (generation %d): %w", prev.Number, err)
 	}
 
 	// 5. compute the plan for N∖N-1 stale removal · N-1 entry re-placement with the planner (reusing the apply engine with (baseline, target) substituted).
@@ -189,7 +189,7 @@ func Rollback(opts RollbackOptions) (*RollbackResult, error) {
 
 	// 7. finally move the profile pointer to N-1 (→ docs/spec.md rollback step 3).
 	if err := switchFn(prof.Profile, prev.Number); err != nil {
-		return nil, fmt.Errorf("nput: profile ポインタの移動に失敗しました（--switch-generation %d）: %w", prev.Number, err)
+		return nil, fmt.Errorf("nput: failed to move the profile pointer (--switch-generation %d): %w", prev.Number, err)
 	}
 
 	return &RollbackResult{Result: *a.result, From: cur.Number, To: prev.Number}, nil
@@ -199,7 +199,7 @@ func Rollback(opts RollbackOptions) (*RollbackResult, error) {
 // It captures and parses stdout (ingesting machine-readable output).
 func nixEnvListGenerations(profileLink string) ([]Generation, error) {
 	if _, err := exec.LookPath("nix-env"); err != nil {
-		return nil, fmt.Errorf("nix-env が PATH にありません: %w", err)
+		return nil, fmt.Errorf("nix-env is not on PATH: %w", err)
 	}
 	cmd := exec.Command("nix-env", "--profile", profileLink, "--list-generations")
 	var stdout, stderr bytes.Buffer
@@ -208,9 +208,9 @@ func nixEnvListGenerations(profileLink string) ([]Generation, error) {
 	if err := cmd.Run(); err != nil {
 		trimmed := strings.TrimSpace(stderr.String())
 		if trimmed != "" {
-			return nil, fmt.Errorf("nput: nix-env --list-generations に失敗しました: %w\n%s", err, trimmed)
+			return nil, fmt.Errorf("nput: nix-env --list-generations failed: %w\n%s", err, trimmed)
 		}
-		return nil, fmt.Errorf("nput: nix-env --list-generations に失敗しました: %w", err)
+		return nil, fmt.Errorf("nput: nix-env --list-generations failed: %w", err)
 	}
 	return parseGenerations(stdout.String())
 }
@@ -219,7 +219,7 @@ func nixEnvListGenerations(profileLink string) ([]Generation, error) {
 // nix output is routed to stderr (stdout is reserved for machine-readable output · → docs/spec.md stream discipline).
 func nixEnvSwitchGeneration(profileLink string, gen int) error {
 	if _, err := exec.LookPath("nix-env"); err != nil {
-		return fmt.Errorf("nix-env が PATH にありません: %w", err)
+		return fmt.Errorf("nix-env is not on PATH: %w", err)
 	}
 	cmd := exec.Command("nix-env", "--profile", profileLink, "--switch-generation", strconv.Itoa(gen))
 	cmd.Stdout = os.Stderr
@@ -238,7 +238,7 @@ func parseGenerations(out string) ([]Generation, error) {
 		}
 		n, err := strconv.Atoi(fields[0])
 		if err != nil {
-			return nil, fmt.Errorf("nput: 世代一覧の行を解析できません: %q", line)
+			return nil, fmt.Errorf("nput: cannot parse a line of the generation list: %q", line)
 		}
 		g := Generation{Number: n}
 		end := len(fields)

--- a/internal/engine/generations_test.go
+++ b/internal/engine/generations_test.go
@@ -157,7 +157,7 @@ func TestRollbackNoPreviousErrors(t *testing.T) {
 		ListGenerations:  func(string) ([]Generation, error) { return []Generation{{Number: 1, Current: true}}, nil },
 		SwitchGeneration: func(string, int) error { return nil },
 	})
-	if err == nil || !strings.Contains(err.Error(), "前世代") {
+	if err == nil || !strings.Contains(err.Error(), "no previous generation") {
 		t.Fatalf("expected no-previous-generation error, got %v", err)
 	}
 }

--- a/internal/engine/place.go
+++ b/internal/engine/place.go
@@ -17,7 +17,7 @@ func (a *applier) place(actions []planner.PlaceAction) error {
 	for _, act := range actions {
 		// Create the parent directory (ancestor symlinks are already rejected as conflicts by the planner · → ADR-0015).
 		if err := os.MkdirAll(filepath.Dir(act.TargetAbs), 0o755); err != nil {
-			return fmt.Errorf("nput: 親ディレクトリを作成できません (%s): %w", filepath.Dir(act.TargetAbs), err)
+			return fmt.Errorf("nput: cannot create parent directory (%s): %w", filepath.Dir(act.TargetAbs), err)
 		}
 
 		switch act.Kind {
@@ -27,13 +27,13 @@ func (a *applier) place(actions []planner.PlaceAction) error {
 			// Re-link is unlink + symlink (no rename-based atomic swap · → ADR-0017).
 			// The foreign-overwrite warning is already emitted via planner.Warnings by emitWarnings (→ ADR-0015).
 			if err := os.Remove(act.TargetAbs); err != nil {
-				return fmt.Errorf("nput: 既存 symlink を除去できません (%s): %w", act.TargetAbs, err)
+				return fmt.Errorf("nput: cannot remove existing symlink (%s): %w", act.TargetAbs, err)
 			}
 			a.result.Replaced = append(a.result.Replaced, act.Entry.Target)
 		}
 
 		if err := os.Symlink(act.Dest, act.TargetAbs); err != nil {
-			return fmt.Errorf("nput: symlink を作成できません (%s -> %s): %w", act.TargetAbs, act.Dest, err)
+			return fmt.Errorf("nput: cannot create symlink (%s -> %s): %w", act.TargetAbs, act.Dest, err)
 		}
 	}
 	return nil

--- a/internal/engine/preflight.go
+++ b/internal/engine/preflight.go
@@ -25,9 +25,9 @@ func (a *applier) checkOutOfStore() error {
 		dest := planner.LinkDest(e)
 		if _, err := os.Lstat(dest); err != nil {
 			if os.IsNotExist(err) {
-				return fmt.Errorf("nput: out-of-store のリンク先が存在しません (target: %s -> %s)。dangling symlink は張りません（→ ADR-0001）", e.Target, dest)
+				return fmt.Errorf("nput: out-of-store link target does not exist (target: %s -> %s); will not create a dangling symlink (→ ADR-0001)", e.Target, dest)
 			}
-			return fmt.Errorf("nput: out-of-store のリンク先を確認できません (target: %s -> %s): %w", e.Target, dest, err)
+			return fmt.Errorf("nput: cannot check out-of-store link target (target: %s -> %s): %w", e.Target, dest, err)
 		}
 	}
 	return nil

--- a/internal/engine/reset.go
+++ b/internal/engine/reset.go
@@ -90,7 +90,7 @@ func Reset(opts ResetOptions) (*ResetResult, error) {
 		if os.IsNotExist(err) {
 			return res, nil
 		}
-		return nil, fmt.Errorf("nput: profile を確認できません (%s): %w", prof.Profile, err)
+		return nil, fmt.Errorf("nput: cannot check profile (%s): %w", prof.Profile, err)
 	}
 
 	// 2. at run time, serialize with concurrent apply / reset via a blocking flock (→ ADR-0013, ADR-0021).
@@ -98,7 +98,7 @@ func Reset(opts ResetOptions) (*ResetResult, error) {
 	if !opts.DryRun {
 		l, err := lock.Acquire(prof.Dir, true)
 		if err != nil {
-			return nil, fmt.Errorf("nput: flock の取得に失敗しました (%s): %w", prof.Dir, err)
+			return nil, fmt.Errorf("nput: failed to acquire flock (%s): %w", prof.Dir, err)
 		}
 		defer func() { _ = l.Release() }()
 	}
@@ -137,7 +137,7 @@ func Reset(opts ResetOptions) (*ResetResult, error) {
 			copyTargets = append(copyTargets, targetAbs)
 			res.RemovedCopies = append(res.RemovedCopies, e.Target)
 		} else if !os.IsNotExist(err) {
-			return nil, fmt.Errorf("nput: copy target を lstat できません (%s): %w", targetAbs, err)
+			return nil, fmt.Errorf("nput: cannot lstat copy target (%s): %w", targetAbs, err)
 		}
 	}
 
@@ -182,7 +182,7 @@ func Reset(opts ResetOptions) (*ResetResult, error) {
 	removedCopies := make([]string, 0, len(copyTargets))
 	for i, targetAbs := range copyTargets {
 		if err := os.RemoveAll(targetAbs); err != nil {
-			return nil, fmt.Errorf("nput: copy target を削除できません (%s): %w", targetAbs, err)
+			return nil, fmt.Errorf("nput: cannot remove copy target (%s): %w", targetAbs, err)
 		}
 		removedCopies = append(removedCopies, res.RemovedCopies[i])
 	}
@@ -213,7 +213,7 @@ func selectResetEntries(entries []manifest.Entry, targets []string) ([]manifest.
 		out = append(out, e)
 	}
 	if len(unknown) > 0 {
-		return nil, fmt.Errorf("nput: reset 対象が前世代 manifest に見つかりません（nput が配置した target ではありません）: %v", unknown)
+		return nil, fmt.Errorf("nput: reset target not found in the previous generation's manifest (not a target nput placed): %v", unknown)
 	}
 	return out, nil
 }

--- a/internal/engine/staleremove.go
+++ b/internal/engine/staleremove.go
@@ -17,11 +17,11 @@ import (
 func (a *applier) removeStale(actions []planner.RemoveAction) error {
 	for _, act := range actions {
 		if !reverifyStale(act) {
-			a.opts.Warnf("nput: stale symlink が plan 後にドリフトしたため残します: %s", act.Entry.Target)
+			a.opts.Warnf("nput: keeping stale symlink because it drifted after planning: %s", act.Entry.Target)
 			continue
 		}
 		if err := os.Remove(act.TargetAbs); err != nil {
-			return fmt.Errorf("nput: stale symlink を除去できません (%s): %w", act.TargetAbs, err)
+			return fmt.Errorf("nput: cannot remove stale symlink (%s): %w", act.TargetAbs, err)
 		}
 		a.result.Removed = append(a.result.Removed, act.Entry.Target)
 	}

--- a/internal/gitutil/gitutil.go
+++ b/internal/gitutil/gitutil.go
@@ -11,10 +11,10 @@ import (
 )
 
 // ErrNotInRepo is returned when dir is outside a git repository and the toplevel cannot be resolved.
-var ErrNotInRepo = errors.New("nput: git リポジトリ外です（--root で root を明示してください）")
+var ErrNotInRepo = errors.New("nput: outside a git repository (pass --root to set root explicitly)")
 
 // ErrGitNotFound is returned when git is not on PATH.
-var ErrGitNotFound = errors.New("nput: git が PATH にありません")
+var ErrGitNotFound = errors.New("nput: git is not on PATH")
 
 // Toplevel runs `git rev-parse --show-toplevel` rooted at dir and returns the
 // resolved absolute root path (→ ADR-0005). It resolves to the same root no matter
@@ -35,7 +35,7 @@ func Toplevel(dir string) (string, error) {
 			// git started but exited non-zero; the representative case is being outside a repository.
 			return "", fmt.Errorf("%w: %s", ErrNotInRepo, strings.TrimSpace(stderr.String()))
 		}
-		return "", fmt.Errorf("nput: git rev-parse の実行に失敗しました: %w", err)
+		return "", fmt.Errorf("nput: failed to run git rev-parse: %w", err)
 	}
 
 	top := strings.TrimSpace(stdout.String())

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -17,7 +17,7 @@ import (
 
 // ErrSchemaVersionUnsupported indicates that a manifest newer than the engine's supported version (SchemaVersion) was read.
 // A sentinel so the caller (CLI) can detect schemaVersion skew between CLI/flake pin via errors.Is and add guidance (→ ADR-0006).
-var ErrSchemaVersionUnsupported = errors.New("nput: schemaVersion が engine の対応版より新しい")
+var ErrSchemaVersionUnsupported = errors.New("nput: schemaVersion is newer than the engine supports")
 
 // SchemaVersion is the latest manifest.json version the engine can interpret (→ ADR-0013).
 // The MVP accepts only v1 and rejects any newer version (→ ADR-0006, ADR-0015).
@@ -73,18 +73,18 @@ func Load(linkFarm string) (*Manifest, error) {
 func LoadFile(path string) (*Manifest, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return nil, fmt.Errorf("nput: manifest.json を読めません: %w", err)
+		return nil, fmt.Errorf("nput: cannot read manifest.json: %w", err)
 	}
 
 	var m Manifest
 	dec := json.NewDecoder(bytes.NewReader(data))
 	dec.DisallowUnknownFields()
 	if err := dec.Decode(&m); err != nil {
-		return nil, fmt.Errorf("nput: manifest.json を解析できません (%s): %w", path, err)
+		return nil, fmt.Errorf("nput: cannot parse manifest.json (%s): %w", path, err)
 	}
 
 	if err := m.validate(); err != nil {
-		return nil, fmt.Errorf("nput: manifest.json が不正です (%s): %w", path, err)
+		return nil, fmt.Errorf("nput: invalid manifest.json (%s): %w", path, err)
 	}
 	return &m, nil
 }
@@ -92,13 +92,13 @@ func LoadFile(path string) (*Manifest, error) {
 func (m *Manifest) validate() error {
 	// The engine rejects any schemaVersion newer than the version it supports (→ ADR-0006).
 	if m.SchemaVersion > SchemaVersion {
-		return fmt.Errorf("schemaVersion %d は未対応です（この engine は v%d まで対応）: %w", m.SchemaVersion, SchemaVersion, ErrSchemaVersionUnsupported)
+		return fmt.Errorf("schemaVersion %d is unsupported (this engine supports up to v%d): %w", m.SchemaVersion, SchemaVersion, ErrSchemaVersionUnsupported)
 	}
 	if m.SchemaVersion < 1 {
-		return fmt.Errorf("schemaVersion %d は不正です", m.SchemaVersion)
+		return fmt.Errorf("schemaVersion %d is invalid", m.SchemaVersion)
 	}
 	if m.Root.RootKind == "" {
-		return fmt.Errorf("root.rootKind が空です")
+		return fmt.Errorf("root.rootKind is empty")
 	}
 	return nil
 }

--- a/internal/paths/paths.go
+++ b/internal/paths/paths.go
@@ -30,7 +30,7 @@ func StateDir() (string, error) {
 	}
 	home, err := os.UserHomeDir()
 	if err != nil {
-		return "", fmt.Errorf("nput: $HOME を解決できません: %w", err)
+		return "", fmt.Errorf("nput: cannot resolve $HOME: %w", err)
 	}
 	return filepath.Join(home, ".local", "state"), nil
 }

--- a/internal/planner/planner.go
+++ b/internal/planner/planner.go
@@ -149,7 +149,7 @@ func Compute(prev, next *manifest.Manifest, root string, fs FS) (Plan, error) {
 			plan.Conflicts = append(plan.Conflicts, Conflict{
 				Entry:     e,
 				TargetAbs: targetAbs,
-				Reason:    fmt.Sprintf("祖先 %q が symlink です。配下にネストできません (→ ADR-0015)", offender),
+				Reason:    fmt.Sprintf("ancestor %q is a symlink; cannot nest beneath it (→ ADR-0015)", offender),
 			})
 			continue
 		}
@@ -162,7 +162,7 @@ func Compute(prev, next *manifest.Manifest, root string, fs FS) (Plan, error) {
 			continue
 		}
 		if e.Method != manifest.MethodSymlink {
-			return Plan{}, fmt.Errorf("nput: 未知の method: %q (target: %s)", e.Method, e.Target)
+			return Plan{}, fmt.Errorf("nput: unknown method: %q (target: %s)", e.Method, e.Target)
 		}
 
 		info, err := fs.Lstat(targetAbs)
@@ -180,12 +180,12 @@ func Compute(prev, next *manifest.Manifest, root string, fs FS) (Plan, error) {
 			plan.Conflicts = append(plan.Conflicts, Conflict{
 				Entry:     e,
 				TargetAbs: targetAbs,
-				Reason:    "target に既存のファイル/ディレクトリがあります（上書きしません）",
+				Reason:    "target already has an existing file/directory (will not overwrite)",
 			})
 		case os.IsNotExist(err):
 			plan.Place = append(plan.Place, PlaceAction{Entry: e, TargetAbs: targetAbs, Dest: LinkDest(e), Kind: PlaceNew})
 		default:
-			return Plan{}, fmt.Errorf("nput: target を lstat できません (%s): %w", targetAbs, err)
+			return Plan{}, fmt.Errorf("nput: cannot lstat target (%s): %w", targetAbs, err)
 		}
 	}
 
@@ -209,7 +209,7 @@ func Compute(prev, next *manifest.Manifest, root string, fs FS) (Plan, error) {
 			case err != nil && os.IsNotExist(err):
 				continue // already gone = no-op (no warning).
 			case err != nil:
-				return Plan{}, fmt.Errorf("nput: stale target を lstat できません (%s): %w", targetAbs, err)
+				return Plan{}, fmt.Errorf("nput: cannot lstat stale target (%s): %w", targetAbs, err)
 			case info.Mode()&os.ModeSymlink == 0:
 				// A regular file / directory is left untouched (→ docs/spec.md safety invariant).
 				plan.Warnings = append(plan.Warnings, Warning{Kind: WarnStaleNonSymlink, Target: pe.Target})
@@ -287,7 +287,7 @@ func classifyCopy(plan *Plan, e manifest.Entry, targetAbs string, prevByTarget m
 			plan.Conflicts = append(plan.Conflicts, Conflict{
 				Entry:     e,
 				TargetAbs: targetAbs,
-				Reason:    "copy の src 構造と target の種別が不一致です（dir↔file・上書きしません）",
+				Reason:    "copy src structure and target kind mismatch (dir↔file; will not overwrite)",
 			})
 			return nil
 		}
@@ -301,7 +301,7 @@ func classifyCopy(plan *Plan, e manifest.Entry, targetAbs string, prevByTarget m
 		plan.Copies = append(plan.Copies, CopyAction{Entry: e, TargetAbs: targetAbs, Src: LinkDest(e)})
 		return nil
 	default:
-		return fmt.Errorf("nput: copy target を lstat できません (%s): %w", targetAbs, err)
+		return fmt.Errorf("nput: cannot lstat copy target (%s): %w", targetAbs, err)
 	}
 }
 
@@ -312,7 +312,7 @@ func classifyCopy(plan *Plan, e manifest.Entry, targetAbs string, prevByTarget m
 func copyStructureMismatch(e manifest.Entry, targetInfo os.FileInfo, fs FS) (bool, error) {
 	srcInfo, err := fs.Lstat(LinkDest(e))
 	if err != nil {
-		return false, fmt.Errorf("nput: copy src を lstat できません (%s): %w", LinkDest(e), err)
+		return false, fmt.Errorf("nput: cannot lstat copy src (%s): %w", LinkDest(e), err)
 	}
 	return srcInfo.IsDir() != targetInfo.IsDir(), nil
 }
@@ -335,7 +335,7 @@ func ancestorSymlink(root, target string, fs FS) (string, error) {
 			if os.IsNotExist(err) {
 				return "", nil
 			}
-			return "", fmt.Errorf("nput: 祖先を lstat できません (%s): %w", cur, err)
+			return "", fmt.Errorf("nput: cannot lstat ancestor (%s): %w", cur, err)
 		}
 		if info.Mode()&os.ModeSymlink != 0 {
 			return cur, nil

--- a/lib/manifest.nix
+++ b/lib/manifest.nix
@@ -114,21 +114,23 @@ let
         # systemRoot is not implemented (→ ADR-0013).
         (lib.optional (
           rootInfo.rootKind == "system"
-        ) "nput: root = systemRoot (system mode) は未実装です（→ ADR-0013）")
+        ) "nput: root = systemRoot (system mode) is not implemented (→ ADR-0013)")
         # method = "copy" combined with an out-of-store marker is a contradiction of intent (→ ADR-0013).
         (map (
-          e: "nput: method = \"copy\" と out-of-store marker は同時指定できません（target: ${e.target}・→ ADR-0013）"
+          e:
+          "nput: method = \"copy\" cannot be combined with an out-of-store marker (target: ${e.target}; → ADR-0013)"
         ) (lib.filter (e: e.method == "copy" && e.srcKind == "outOfStore") normEntries))
         # Collision from explicitly overriding target to the same value under a different key (→ ADR-0024).
         (lib.optional (
           lib.length targets != lib.length (lib.unique targets)
-        ) "nput: 複数 entry が同一 target に解決されました（→ ADR-0024）")
+        ) "nput: multiple entries resolve to the same target (→ ADR-0024)")
         # Reject absolute paths / `..` escapes in target / subpath (→ ADR-0019).
-        (map (e: "nput: target が不正です（絶対パスまたは `..` で root の外）: ${e.target}（→ ADR-0019）") (
-          lib.filter (e: checks.isUnsafe e.target) normEntries
-        ))
         (map (
-          e: "nput: subpath が不正です（絶対パスまたは `..` で src の外）: ${e.subpath}（target: ${e.target}・→ ADR-0019）"
+          e: "nput: invalid target (absolute path or escapes root via `..`): ${e.target} (→ ADR-0019)"
+        ) (lib.filter (e: checks.isUnsafe e.target) normEntries))
+        (map (
+          e:
+          "nput: invalid subpath (absolute path or escapes src via `..`): ${e.subpath} (target: ${e.target}; → ADR-0019)"
         ) (lib.filter (e: checks.isUnsafe e.subpath) normEntries))
       ];
 

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -45,19 +45,19 @@ let
       options = {
         src = mkOption {
           type = srcType;
-          description = "配置元。store-backed（path / set）または out-of-store marker。";
+          description = "Placement source. A store-backed value (path / set) or an out-of-store marker.";
         };
         subpath = mkOption {
           type = types.str;
           default = ".";
-          description = "src 内の相対パス。省略 = リポジトリ全体（→ ADR-0008）。";
+          description = "Relative path inside src. Omitted = the whole repository (→ ADR-0008).";
         };
         target = mkOption {
           type = types.str;
           # Default = attribute key (→ ADR-0014).
           default = name;
-          defaultText = "属性キー";
-          description = "root 相対の配置先。省略時は属性キー。";
+          defaultText = "attribute key";
+          description = "Placement target relative to root. Defaults to the attribute key when omitted.";
         };
         method = mkOption {
           type = types.enum [
@@ -65,7 +65,7 @@ let
             "copy"
           ];
           default = "symlink";
-          description = "配置方法（旧名 mode・→ ADR-0015）。";
+          description = "Placement method (formerly named mode; → ADR-0015).";
         };
       };
     };

--- a/modules/common.nix
+++ b/modules/common.nix
@@ -24,7 +24,7 @@ in
       default = { };
       example = lib.literalExpression ''
         {
-          # 属性キー = root 相対 target（識別子・→ ADR-0014）
+          # attribute key = root-relative target (identifier; → ADR-0014)
           ".claude/skills/nix" = {
             src = inputs.claude-skills;
             subpath = "skills/nix";

--- a/modules/common.nix
+++ b/modules/common.nix
@@ -17,7 +17,7 @@ let
 in
 {
   options.nput = {
-    enable = lib.mkEnableOption "nput（フェッチ済み git リポジトリの symlink / copy 配置）";
+    enable = lib.mkEnableOption "nput (symlink / copy placement of fetched git repositories)";
 
     entries = lib.mkOption {
       type = nputTypes.entriesType;
@@ -32,9 +32,10 @@ in
         }
       '';
       description = ''
-        配置定義の attrset。属性キー = 配置先 target（識別子）で、各値は entry submodule
-        （src / subpath / target / method）。型は lib/types.nix と共有し、未知キーは eval
-        エラーになる（→ docs/spec.md「entries スキーマ仕様」）。
+        Attrset of placement definitions. The attribute key = the placement target
+        (identifier), and each value is an entry submodule (src / subpath / target /
+        method). The type is shared with lib/types.nix, and unknown keys are an eval
+        error (→ docs/spec.md "entries schema").
       '';
     };
   };

--- a/modules/flake-parts.nix
+++ b/modules/flake-parts.nix
@@ -25,10 +25,10 @@ mkTransposedPerSystemModule {
     type = types.lazyAttrsOf types.package;
     default = { };
     description = ''
-      nput の named manifest（`nput.lib.mkManifest` の結果＝derivation）を公開する属性集合（→ ADR-0007, ADR-0029）。
+      Attrset that exposes nput's named manifests (the result of `nput.lib.mkManifest` = a derivation) (→ ADR-0007, ADR-0029).
 
-      `perSystem.nput.<name>` に宣言すると top-level の `flake.nput.<system>.<name>` へ自動転置され、
-      CLI が `nix build .#nput.<system>.<name>` で叩く build 可能な derivation になる。
+      Declaring `perSystem.nput.<name>` automatically transposes it to the top-level `flake.nput.<system>.<name>`,
+      yielding a buildable derivation the CLI invokes via `nix build .#nput.<system>.<name>`.
 
       ```nix
       perSystem = { pkgs, ... }: {

--- a/templates/project/flake.nix
+++ b/templates/project/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "nput project config: フェッチ済み git リポジトリを repo 配下へ symlink / copy 配置する";
+  description = "nput project config: symlink / copy fetched git repositories under the repo";
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";

--- a/templates/standalone/flake.nix
+++ b/templates/standalone/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "nput standalone config: フェッチ済み git リポジトリを home 配下へ symlink / copy 配置する";
+  description = "nput standalone config: symlink / copy fetched git repositories under home";
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";

--- a/tests/nix-unit.nix
+++ b/tests/nix-unit.nix
@@ -218,7 +218,7 @@ in
         };
       }).entries;
     expectedError.type = "ThrownError";
-    expectedError.msg = "同一 target";
+    expectedError.msg = "same target";
   };
 
   # 未知キー（タイポ / 旧名）は submodule strict で弾く（→ ADR-0008, ADR-0010）。


### PR DESCRIPTION
## 概要

#53（出力文字列の英語化）の未達分を解消する。#54 でコメントは英語化済みのため、本 PR は **コメント以外のユーザー可視文字列**だけを対象にする。

- Go `internal/` の error / warning / `Reason:` 文字列（engine / planner / manifest / gitutil / paths）。`nput:` プレフィックスは維持。
- nix `lib/manifest.nix` の eval 時 throw メッセージ。
- nix module / template の description 系（`lib/types.nix` の mkOption description、`modules/common.nix` の mkEnableOption / description、`modules/flake-parts.nix` の description、`templates/{standalone,project}/flake.nix` の description）。

表記は `docs/glossary.md` の canonical 用語（store link / out-of-store / entry / target / subpath / root / generation 等）に準拠。`→ ADR-NNNN` ポインタは言語中立なので保持。文字列の意味・挙動は変えず翻訳のみ。

grep / 部分一致で文字列を検証していたテストも追従修正:
- `internal/engine/generations_test.go`（`前世代` → `no previous generation`）
- `internal/engine/engine_test.go`（`スキップ` → `skipped copy`）
- `tests/nix-unit.nix`（duplicate-target throw の `同一 target` → `same target`）

`cmd/nput` は #53 で対応済みのため非対象。

### 残課題（要判断）

`modules/common.nix:27` の `example` リテラル内に日本語コメント 1 行（`# 属性キー = root 相対 target...`）が残存。これは `example` として module ドキュメントに描画されうるがソース上は `#` コメントであり、本タスクの「コメントには触れない」方針に従い未翻訳のまま残した。翻訳要否を判断したい。

## 関連 issue

Refs #53（#53 の補完。残務解消のため Closes はしない）

## docs / ADR 影響

なし（翻訳のみ。配置動作・API・方針は不変。ADR ポインタは保持）。

## 検証

- `go test ./...` 通過
- `nix flake check` 通過（treefmt / nix-unit / go-vet / golangci-lint / hm-module 等）
- e2e（`nix develop '.?dir=dev#ci' -c tests/e2e/run.sh`）6 シナリオ全通過
