### PR TITLE
docs(engine): fix stale --quiet reference in emitWarnings comment

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -399,7 +399,7 @@ func (a *applier) loadPrevManifest() *manifest.Manifest {
 }
 
 // emitWarnings emits the non-fatal warnings computed by the planner to stderr (opts.Warnf).
-// Warnings are not silenced even by --quiet (→ docs/spec.md stream discipline · ADR-0015, ADR-0024).
+// Warnings are always emitted, regardless of the silent-on-success default or -v (→ docs/spec.md stream discipline · ADR-0015, ADR-0024, ADR-0031).
 // When recopy=true it suppresses the copy foreign skip warning (recopy overwrites foreign too, so
 // "skipped" would be a false report · → ADR-0020).
 func (a *applier) emitWarnings(ws []planner.Warning, recopy bool) {


### PR DESCRIPTION
## 概要
`--quiet` は silent-on-success の CLI 再設計（ADR-0031）で削除済みだが、`internal/engine/engine.go` の `emitWarnings` godoc コメントに参照が残っていた（i18n 翻訳時に取り残された stale 記述）。

現行モデルに即して言い換え: warning はデフォルト沈黙・`-v` に関わらず常時出力する。

## 影響
- 挙動変更なし（コメントのみ）