### PR TITLE
test(lib): assert anchorName sha256 output invariants

### DIFF
--- a/tests/nix-unit/anchor-name.nix
+++ b/tests/nix-unit/anchor-name.nix
@@ -1,0 +1,67 @@
+# nix-unit: GC anchor 名（`__internal.anchorName`）の不変条件をアサートする（→ #58, #73, ADR-0016）。
+#
+# anchorName = sha256(target) の先頭 32 hex。symlink farm の衝突しない FS-safe な anchor 名として使う。
+# 検証する性質: (1) 常に 32 文字の hex / (2) 同一 target は同一 hash（決定性）/ (3) 特殊文字を
+# 含む target でも安定して 32 hex を返す。
+#
+# 期待 hash は `lib.substring 0 32 (builtins.hashString "sha256" target)` を nix で評価した実値を
+# 直書きする（関数の再実装ではなく外部に固定した ground-truth との一致を見る）。
+{ lib, nput }:
+let
+  an = nput.__internal.anchorName lib;
+
+  # cyrillic / 日本語 / 空白 / 記号（& * " |）を含む target。FS 名として直に使えない文字を含んでも
+  # sha256 経由で安定した hex に潰れることを確認する。
+  specialTarget = ".config/нвим/ファイル space&sym*\"|";
+
+  isHex32 = s: builtins.match "[0-9a-f]{32}" s != null;
+in
+{
+  # 出力は常に 32 文字。
+  testAnchorNameLength = {
+    expr = lib.stringLength (an ".claude/skills/nix");
+    expected = 32;
+  };
+
+  # 出力は 32 桁の小文字 hex のみで構成される。
+  testAnchorNameAllHex = {
+    expr = isHex32 (an ".claude/skills/nix");
+    expected = true;
+  };
+
+  # 同一 target は外部固定の既知 hash に一致する（決定性 + 値の正しさ）。
+  testAnchorNameDeterministic = {
+    expr = an ".claude/skills/nix";
+    expected = "6742682e75579724615f6b3800237eb4";
+  };
+
+  # 同じ target を 2 回適用しても同値（純粋関数としての決定性を明示）。
+  testAnchorNameStableAcrossCalls = {
+    expr = an ".claude/skills/nix" == an ".claude/skills/nix";
+    expected = true;
+  };
+
+  # 異なる target は異なる hash になる（衝突しない anchor 名であることの示唆）。
+  testAnchorNameDistinctTargets = {
+    expr = an ".claude/a" == an ".claude/b";
+    expected = false;
+  };
+
+  # 特殊文字を含む target でも既知 hash に安定一致する。
+  testAnchorNameSpecialCharsStable = {
+    expr = an specialTarget;
+    expected = "84bbba52edcecff0154de08d41a8259e";
+  };
+
+  # 特殊文字を含む target でも長さ 32 を保つ。
+  testAnchorNameSpecialCharsLength = {
+    expr = lib.stringLength (an specialTarget);
+    expected = 32;
+  };
+
+  # 特殊文字を含む target でも 32 桁 hex のまま。
+  testAnchorNameSpecialCharsAllHex = {
+    expr = isHex32 (an specialTarget);
+    expected = true;
+  };
+}


### PR DESCRIPTION
## 概要

#71 で `nput.__internal.anchorName`（`lib: target: ...`）が unit-test seam として露出したので、その sha256 出力の不変条件を nix-unit で固める。検証する性質:

- 出力は常に 32 文字の小文字 hex
- 同一 target は同一 hash（決定性）
- cyrillic / 日本語 / 空白 / 記号（`& * " |`）を含む target でも安定して 32 hex を返す

編集範囲は `tests/nix-unit/anchor-name.nix`（新規）のみ。#71 のアグリゲータ形式（`{ lib, nput }: { testXxx = { expr; expected; }; }`）に従い、`testAnchorName*` 接頭辞で命名。期待 hash は nix で評価した実値を ground-truth として直書きしている（関数の再実装はしない）。

動作確認: `nix flake check` 通過 / `nix-unit --flake .#tests.systems.aarch64-darwin` で 26/26 成功（うち本 PR の `testAnchorName*` 8 件）。

## 関連 issue

Closes #73
Refs #58

## docs / ADR 影響

なし（テスト追加のみ。配置動作・API・方針の変更なし）
