### PR TITLE
test(go): cover paths StateDir and GenerationLink

### DIFF
--- a/internal/paths/paths_test.go
+++ b/internal/paths/paths_test.go
@@ -1,11 +1,64 @@
 package paths
 
 import (
+	"fmt"
 	"path/filepath"
 	"testing"
 
 	"github.com/yasunori0418/nput/internal/manifest"
 )
+
+func TestStateDirUsesXDGStateHome(t *testing.T) {
+	// $XDG_STATE_HOME takes precedence regardless of $HOME.
+	t.Setenv("XDG_STATE_HOME", "/xdg/state")
+	t.Setenv("HOME", "/home/me")
+	got, err := StateDir()
+	if err != nil {
+		t.Fatalf("StateDir() error = %v", err)
+	}
+	if got != "/xdg/state" {
+		t.Errorf("StateDir() = %q, want %q", got, "/xdg/state")
+	}
+}
+
+func TestStateDirFallsBackToHome(t *testing.T) {
+	// Without $XDG_STATE_HOME, fall back to $HOME/.local/state.
+	t.Setenv("XDG_STATE_HOME", "")
+	t.Setenv("HOME", "/home/me")
+	got, err := StateDir()
+	if err != nil {
+		t.Fatalf("StateDir() error = %v", err)
+	}
+	want := filepath.Join("/home/me", ".local", "state")
+	if got != want {
+		t.Errorf("StateDir() = %q, want %q", got, want)
+	}
+}
+
+func TestStateDirErrorsWhenHomeUnresolvable(t *testing.T) {
+	// With neither $XDG_STATE_HOME nor $HOME set, os.UserHomeDir fails and the
+	// error is surfaced (no fallback path is returned).
+	t.Setenv("XDG_STATE_HOME", "")
+	t.Setenv("HOME", "")
+	got, err := StateDir()
+	if err == nil {
+		t.Fatalf("StateDir() error = nil, want non-nil (got %q)", got)
+	}
+	if got != "" {
+		t.Errorf("StateDir() = %q on error, want empty string", got)
+	}
+}
+
+func TestGenerationLinkFormat(t *testing.T) {
+	profileLink := filepath.Join("/state", "nix", "profiles", "nput", "vim", "profile")
+	for _, gen := range []int{0, 1, 42} {
+		got := GenerationLink(profileLink, gen)
+		want := fmt.Sprintf("%s-%d-link", profileLink, gen)
+		if got != want {
+			t.Errorf("GenerationLink(%q, %d) = %q, want %q", profileLink, gen, got, want)
+		}
+	}
+}
 
 func TestRootHashDeterministicAndFixedLen(t *testing.T) {
 	a := RootHash("/home/me/proj")


### PR DESCRIPTION
## 概要

`internal/paths/paths.go` の `StateDir()` / `GenerationLink()` はカバレッジ 0% だったため、ユニットテストを追加する（#59 配下のテスト整備タスク）。

- `StateDir()`: `$XDG_STATE_HOME` 優先 / `$HOME/.local/state` フォールバック / `$HOME` 解決不能時のエラー伝播（`os.UserHomeDir` 失敗系。`t.Setenv` で `HOME=""` を誘発）
- `GenerationLink()`: `<profileLink>-<gen>-link` のパス形式

実装には手を加えず、テストファイル（`internal/paths/paths_test.go`）の追加のみ。

## 関連 issue

Closes #76 / Refs #59

## docs / ADR 影響

なし（テスト追加のみ。配置動作・API・方針に変更なし）

https://claude.ai/code/session_01KMNTLXiNj7UACM99ZJYT5U