### PR TITLE
ci(go): go test カバレッジ計測を CI/devShell に組込

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,6 +46,33 @@ jobs:
       - name: Run nix flake check
         run: nix flake check -L
 
+  go-coverage:
+    needs: changes
+    if: needs.changes.outputs.run == 'true'
+    # buildGoModule の checkPhase が出力する coverprofile / func レポートを成果物（$out）から取り出し、
+    # Job Summary に表示する（計測・表示のみ。閾値ゲートは持たない → 他テスト追加 PR とのマージ順依存回避）。
+    # $out 同梱なので cachix の cache hit でも決定論的に同じレポートを参照できる。
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Setup Nix
+        uses: ./.github/actions/setup-nix
+        with:
+          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+
+      - name: Build nput (runs go test with coverage)
+        run: nix build '.#nput' -L
+
+      - name: Report coverage
+        run: |
+          {
+            echo '## Go test coverage'
+            echo '```'
+            cat result/share/nput/coverage/coverage-func.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
   e2e:
     needs: changes
     if: needs.changes.outputs.run == 'true'

--- a/dev/flake.nix
+++ b/dev/flake.nix
@@ -41,7 +41,17 @@
               nixd
               inputs'.root.formatter
               inputs'.root.packages.nput
+              go
               gopls
+              # ローカルでカバレッジ計測する coverage ツール（go test -coverprofile + go tool cover）。
+              # func サマリを出し、HTML を見たい場合のコマンドを案内する（閾値ゲートは持たない）。
+              (writeShellScriptBin "nput-coverage" ''
+                set -euo pipefail
+                profile="cover.out"
+                go test -coverprofile="$profile" ./...
+                go tool cover -func="$profile"
+                echo "HTML レポート: go tool cover -html=$profile"
+              '')
             ];
             shellHook = ''
               export REPO_ROOT=$(git rev-parse --show-superproject-working-tree --show-toplevel)

--- a/flake.nix
+++ b/flake.nix
@@ -120,6 +120,21 @@
             vendorHash = "sha256-7K17JaXFsjf163g5PXCb5ng2gYdotnZ2IDKk8KFjNj0=";
             doCheck = true;
             env.GOTOOLCHAIN = "local";
+            # 既存 go test と同じ対象（unit + tmpdir 統合）を -coverprofile 付きで回し、func サマリを
+            # build ログへ出す。計測・レポート出力のみで閾値ゲートは持たない（テスト追加 PR の
+            # マージ順依存を避ける → タスク規約）。`go test ./...` は default checkPhase と同等の対象。
+            checkPhase = ''
+              runHook preCheck
+              go test -coverprofile="$TMPDIR/cover.out" ./...
+              go tool cover -func="$TMPDIR/cover.out" | tee "$TMPDIR/coverage-func.txt"
+              runHook postCheck
+            '';
+            # coverprofile / func レポートを成果物へ同梱する。CI は cache hit でも $out から決定論的に
+            # 取り出して Step Summary に出せる（build ログ依存だと cache hit で消えるため）。
+            postInstall = ''
+              install -Dm644 "$TMPDIR/cover.out" "$out/share/nput/coverage/cover.out"
+              install -Dm644 "$TMPDIR/coverage-func.txt" "$out/share/nput/coverage/coverage-func.txt"
+            '';
             meta = {
               description = "Place fetched git repositories at arbitrary paths via symlink or copy.";
               mainProgram = "nput";


### PR DESCRIPTION
## 概要

go test のカバレッジを「計測・レポート出力」する経路を CI と devShell に追加する。
buildGoModule の `checkPhase` で `-coverprofile` を取得し func サマリを build ログへ出力。
生成物（`cover.out` / `coverage-func.txt`）を `$out/share/nput/coverage/` へ同梱し、CI の
`go-coverage` job が cachix の cache hit でも決定論的に Job Summary へ表示できるようにする。
devShell には `go` と `nput-coverage` ヘルパ（func サマリ表示 + HTML 案内）を追加。

方針として **計測・レポート出力のみで閾値ゲート（一定未満で CI 失敗）は持たない**。
テスト追加 PR 間のマージ順依存を避けるため。既存 go test の対象（`go test ./...`）は不変。

`go-coverage` job は flake-check / e2e と同じく `changes` job のゲート
（`if: needs.changes.outputs.run == 'true'`）配下に置き、docs-only PR ではスキップ
（required status checks 上は success）させる。

## 関連 issue

Refs #82

## docs / ADR 影響

なし（配置動作・lib API・方針には触れない。CI/開発環境の計測経路追加のみ）。
