### PR TITLE
refactor(engine): lock 取得ヘルパ抽出 (Apply/Rollback/Reset)

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -10,6 +10,7 @@
 package engine
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -99,6 +100,18 @@ type Result struct {
 // ErrSkipped indicates a skip on the NoWait path because another apply is in progress.
 var ErrSkipped = lock.ErrLocked
 
+// acquireProfileLock takes the profileDir flock and wraps the error, deduplicating the
+// acquire→wrap step shared by Apply / Rollback / Reset (→ ADR-0013). The NoWait/ErrSkipped
+// branch and defer Release stay with each caller since they differ (Apply short-circuits with
+// a Result; Rollback/Reset always block).
+func acquireProfileLock(dir string, wait bool) (*lock.Lock, error) {
+	l, err := lock.Acquire(dir, wait)
+	if err != nil {
+		return nil, fmt.Errorf("nput: failed to acquire flock (%s): %w", dir, err)
+	}
+	return l, nil
+}
+
 // Apply places store-symlinks in project mode and commits a generation on success.
 // It corresponds to the engine-driven part of docs/spec.md "execution flow" (2. drive the
 // engine), and the engine owns the order "flock → in-lock build → placement → --set →
@@ -161,13 +174,13 @@ func Apply(opts Options) (*Result, error) {
 	}
 
 	// 3. acquire a flock per resolved profileDir and serialize (→ ADR-0013).
-	l, err := lock.Acquire(a.profile.Dir, !opts.NoWait)
+	l, err := acquireProfileLock(a.profile.Dir, !opts.NoWait)
 	if err != nil {
-		if opts.NoWait && err == lock.ErrLocked {
+		if opts.NoWait && errors.Is(err, lock.ErrLocked) {
 			a.result.Skipped = true
 			return a.result, ErrSkipped
 		}
-		return nil, fmt.Errorf("nput: failed to acquire flock (%s): %w", a.profile.Dir, err)
+		return nil, err
 	}
 	defer func() { _ = l.Release() }()
 

--- a/internal/engine/generations.go
+++ b/internal/engine/generations.go
@@ -8,7 +8,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/yasunori0418/nput/internal/lock"
 	"github.com/yasunori0418/nput/internal/manifest"
 	"github.com/yasunori0418/nput/internal/paths"
 	"github.com/yasunori0418/nput/internal/planner"
@@ -129,9 +128,9 @@ func Rollback(opts RollbackOptions) (*RollbackResult, error) {
 	}
 
 	// 2. serialize with concurrent apply / rollback via a blocking flock (→ ADR-0013).
-	l, err := lock.Acquire(prof.Dir, true)
+	l, err := acquireProfileLock(prof.Dir, true)
 	if err != nil {
-		return nil, fmt.Errorf("nput: failed to acquire flock (%s): %w", prof.Dir, err)
+		return nil, err
 	}
 	defer func() { _ = l.Release() }()
 

--- a/internal/engine/reset.go
+++ b/internal/engine/reset.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/yasunori0418/nput/internal/lock"
 	"github.com/yasunori0418/nput/internal/manifest"
 	"github.com/yasunori0418/nput/internal/planner"
 )
@@ -96,9 +95,9 @@ func Reset(opts ResetOptions) (*ResetResult, error) {
 	// 2. at run time, serialize with concurrent apply / reset via a blocking flock (→ ADR-0013, ADR-0021).
 	//    dryrun is read-only, so it does not take a flock.
 	if !opts.DryRun {
-		l, err := lock.Acquire(prof.Dir, true)
+		l, err := acquireProfileLock(prof.Dir, true)
 		if err != nil {
-			return nil, fmt.Errorf("nput: failed to acquire flock (%s): %w", prof.Dir, err)
+			return nil, err
 		}
 		defer func() { _ = l.Release() }()
 	}


### PR DESCRIPTION
## 概要

lock acquire → エラー wrap の重複（Apply/Rollback/Reset の 3 箇所）を薄いヘルパ `acquireProfileLock` に抽出した。closure 型 `executeWithLock` は Apply の手順構造（番号コメント付きフラット構造・generation skip 早期 return・ErrSkipped 分岐）を崩すため不採用とし、「取得＋エラー wrap」のみを担うヘルパに限定。`defer Release` と ErrSkipped 分岐は各呼び元に残した。Apply の NoWait 判定はヘルパでラップ後のエラーを受けるため `err == lock.ErrLocked` から `errors.Is(err, lock.ErrLocked)` に変更している。

## 関連 issue

Closes #84
Refs #60

## docs / ADR 影響

なし（内部実装のリファクタリングのみ。ADR-0013 のロック仕様・API 挙動に変更なし）