### PR TITLE
refactor(engine): route Apply prelude through ProfileFor

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -131,21 +131,16 @@ func Apply(opts Options) (*Result, error) {
 	}
 
 	// 1. resolve root → fix profileDir (→ docs/spec.md "root resolution").
-	root, err := a.resolveRoot(rootKind, fixedRoot)
+	prof, root, err := ProfileFor(ProfileOptions{
+		Name: opts.Name, RootKind: rootKind, FixedRoot: fixedRoot,
+		RootOverride: opts.RootOverride, WorkDir: opts.WorkDir, StateDir: opts.StateDir, Git: opts.Git,
+	})
 	if err != nil {
 		return nil, err
 	}
 	a.root = root
 	a.result.Root = root
-
-	stateDir := opts.StateDir
-	if stateDir == "" {
-		stateDir, err = paths.StateDir()
-		if err != nil {
-			return nil, err
-		}
-	}
-	a.profile = paths.Resolve(stateDir, opts.Name, rootKind, root, opts.RootOverride != "")
+	a.profile = prof
 	a.result.ProfileDir = a.profile.Dir
 
 	// 1.5 dryrun is a side-effect-free read-only short-circuit (→ ADR-0006, ADR-0023, docs/spec.md execution flow).
@@ -319,10 +314,6 @@ func (a *applier) dryRun() (*Result, error) {
 		a.result.Conflicts = append(a.result.Conflicts, fmt.Sprintf("%s: %s", c.Entry.Target, c.Reason))
 	}
 	return a.result, nil
-}
-
-func (a *applier) resolveRoot(rootKind, fixedRoot string) (string, error) {
-	return resolveRoot(rootKind, fixedRoot, a.opts.RootOverride, a.opts.WorkDir, a.opts.Git)
 }
 
 // resolveRoot resolves the absolute placement root from rootKind (+ the absolute path when


### PR DESCRIPTION
## 概要

Apply の前段(手順1: root解決→StateDirフォールバック→paths.Resolve相当のinline重複実装)を `ProfileFor` 呼び出しに統合し、root解決→profile layout確定の経路を1本化した。Apply固有の前処理(pre-builtパスでmanifestからrootKind/fixedRootを補完する部分・engine.go:117-131)は `ProfileFor` 呼び出しの前に残している。`a.root`/`a.result.Root`/`a.profile`/`a.result.ProfileDir` は `ProfileFor` の戻り値から詰め替える。呼び出し元を失った `applier.resolveRoot` ラッパーメソッドは削除。`resolveRoot` / `paths.Resolve` 自体には手を入れていない。

## 関連 issue

Closes #88
Refs #60

## docs / ADR 影響

なし。内部実装の重複解消のみで、配置動作・API・方針に変更はない。