### PR TITLE
refactor(engine): extract ensureParentDir helper

### DIFF
--- a/internal/engine/copy.go
+++ b/internal/engine/copy.go
@@ -28,8 +28,8 @@ func (a *applier) materializeCopies(plan planner.Plan, recopy bool) error {
 // only "new copies" onto the real FS.
 func (a *applier) placeCopies(actions []planner.CopyAction) error {
 	for _, act := range actions {
-		if err := os.MkdirAll(filepath.Dir(act.TargetAbs), 0o755); err != nil {
-			return fmt.Errorf("nput: cannot create parent directory (%s): %w", filepath.Dir(act.TargetAbs), err)
+		if err := ensureParentDir(act.TargetAbs); err != nil {
+			return err
 		}
 		if err := copyTree(act.Src, act.TargetAbs); err != nil {
 			return fmt.Errorf("nput: copy placement failed (%s -> %s): %w", act.Src, act.TargetAbs, err)
@@ -60,8 +60,8 @@ func (a *applier) recopyAll() error {
 			return fmt.Errorf("nput: cannot lstat recopy target (%s): %w", targetAbs, err)
 		}
 
-		if err := os.MkdirAll(filepath.Dir(targetAbs), 0o755); err != nil {
-			return fmt.Errorf("nput: cannot create parent directory (%s): %w", filepath.Dir(targetAbs), err)
+		if err := ensureParentDir(targetAbs); err != nil {
+			return err
 		}
 		if err := copyTree(planner.LinkDest(e), targetAbs); err != nil {
 			return fmt.Errorf("nput: recopy failed (%s -> %s): %w", planner.LinkDest(e), targetAbs, err)

--- a/internal/engine/place.go
+++ b/internal/engine/place.go
@@ -8,6 +8,17 @@ import (
 	"github.com/yasunori0418/nput/internal/planner"
 )
 
+// ensureParentDir creates targetAbs's parent directory (ancestor symlinks are already
+// rejected as conflicts by the planner · → ADR-0015), wrapping any failure with the
+// target path for diagnosability. Shared by all place-execution entry points that write
+// to targetAbs (place, placeCopies, recopyAll).
+func ensureParentDir(targetAbs string) error {
+	if err := os.MkdirAll(filepath.Dir(targetAbs), 0o755); err != nil {
+		return fmt.Errorf("nput: cannot create parent directory (%s): %w", filepath.Dir(targetAbs), err)
+	}
+	return nil
+}
+
 // place materializes the planner's Place actions as native symlinks
 // (new / re-link before stale removal · → ADR-0006). The plan is already computed by
 // planner.Compute from the current FS state, so this stays a thin executor that reflects
@@ -15,9 +26,8 @@ import (
 // (copy is a future slice · → Issue #6).
 func (a *applier) place(actions []planner.PlaceAction) error {
 	for _, act := range actions {
-		// Create the parent directory (ancestor symlinks are already rejected as conflicts by the planner · → ADR-0015).
-		if err := os.MkdirAll(filepath.Dir(act.TargetAbs), 0o755); err != nil {
-			return fmt.Errorf("nput: cannot create parent directory (%s): %w", filepath.Dir(act.TargetAbs), err)
+		if err := ensureParentDir(act.TargetAbs); err != nil {
+			return err
 		}
 
 		switch act.Kind {


### PR DESCRIPTION
## 概要

place / placeCopies / recopyAll に重複していた「親ディレクトリ生成（os.MkdirAll）+ エラー wrap」を `ensureParentDir` ヘルパーに抽出し重複を排除した。Executor interface による統一 dispatch は、実行系が既に責務分離済み（symlink/copy/drift）で抽象コストが利益を上回るため不採用（詳細は #91 / issue #85 本文参照）。repairDrift の呼び出し API・drift.go は不変。

## 関連 issue

Closes #85
Refs #60

## docs / ADR 影響

なし（内部実装の重複排除のみ。配置動作・API・エラーメッセージ文言に変更なし）