### PR TITLE
refactor(cmd): apply --all 集約ループの seam 抽出（aggregateApply）

### DIFF
--- a/cmd/nput/apply.go
+++ b/cmd/nput/apply.go
@@ -238,28 +238,10 @@ func runApplyAll() error {
 	}
 
 	// 3. Apply each config independently. Continue on partial failure and aggregate failures (each config is independently atomic).
-	var failures, skipped, applied int
-	for _, name := range selected {
+	applied, skipped, failures := aggregateApply(selected, func(name string) (*engine.Result, error) {
 		ri := roots[name]
-		res, err := applyOne(ep, system, name, ri.RootKind, ri.Root)
-		if err != nil {
-			if errors.Is(err, engine.ErrSkipped) {
-				skipped++
-				if flagVerbose {
-					fmt.Fprintf(os.Stderr, "nput: skipped apply %s (another apply is in progress)\n", name)
-				}
-				continue
-			}
-			failures++
-			// Do not swallow partial failures; print to stderr and continue (→ docs/spec.md "continue on partial failure").
-			fmt.Fprintf(os.Stderr, "nput: apply %s failed: %v\n", name, err)
-			continue
-		}
-		applied++
-		if flagVerbose {
-			reportResult(res, name)
-		}
-	}
+		return applyOne(ep, system, name, ri.RootKind, ri.Root)
+	})
 
 	// 4. Aggregate report and exit code (priority error(1) > conflict(2) > 0; → docs/spec.md, ADR-0024).
 	if flagVerbose {
@@ -295,6 +277,35 @@ func runApplyAllDryRun(ep *entrypoint, system string, selected []string, roots m
 		return nil
 	}
 	return &exitError{code: code}
+}
+
+// aggregateApply runs each selected config via applyFn and aggregates applied / skipped / failure counts,
+// continuing on partial failure (each config is independently atomic; → docs/spec.md "continue on partial
+// failure"). It does not swallow ErrSkipped (a try-lock skip is normal) or other errors; a skip is counted
+// and reported to stderr under flagVerbose, a failure is counted and always reported to stderr, and either
+// way the loop continues (a seam that injects the apply implementation for testability, mirroring aggregateDryRun).
+func aggregateApply(selected []string, applyFn func(name string) (*engine.Result, error)) (applied, skipped, failures int) {
+	for _, name := range selected {
+		res, err := applyFn(name)
+		if err != nil {
+			if errors.Is(err, engine.ErrSkipped) {
+				skipped++
+				if flagVerbose {
+					fmt.Fprintf(os.Stderr, "nput: skipped apply %s (another apply is in progress)\n", name)
+				}
+				continue
+			}
+			failures++
+			// Do not swallow partial failures; print to stderr and continue (→ docs/spec.md "continue on partial failure").
+			fmt.Fprintf(os.Stderr, "nput: apply %s failed: %v\n", name, err)
+			continue
+		}
+		applied++
+		if flagVerbose {
+			reportResult(res, name)
+		}
+	}
+	return applied, skipped, failures
 }
 
 // aggregateDryRun runs each selected config read-only via applyDry, prints the plan to stdout,

--- a/cmd/nput/apply_test.go
+++ b/cmd/nput/apply_test.go
@@ -107,6 +107,62 @@ func TestAggregateDryRun(t *testing.T) {
 	}
 }
 
+// Verifies aggregateApply's applied/skipped/failure counts and continue-on-partial-failure behavior by
+// injecting the apply implementation, without nix. This is the regression guard for the real path of
+// docs/spec.md "continue on partial failure" and ErrSkipped-as-normal-skip.
+func TestAggregateApply(t *testing.T) {
+	clean := func(name string) (*engine.Result, error) {
+		return &engine.Result{Placed: []string{"/p/" + name}}, nil
+	}
+	skipped := func(string) (*engine.Result, error) {
+		return nil, engine.ErrSkipped
+	}
+	failed := func(string) (*engine.Result, error) {
+		return nil, io.EOF
+	}
+
+	cases := []struct {
+		name         string
+		apply        func(string) (*engine.Result, error)
+		selected     []string
+		wantApplied  int
+		wantSkipped  int
+		wantFailures int
+	}{
+		{"all succeed → 0 failures", clean, []string{"a", "b"}, 2, 0, 0},
+		{"ErrSkipped counts as skip, not failure", func(n string) (*engine.Result, error) {
+			if n == "b" {
+				return skipped(n)
+			}
+			return clean(n)
+		}, []string{"a", "b"}, 1, 1, 0},
+		{"error counts as failure and continues", func(n string) (*engine.Result, error) {
+			if n == "b" {
+				return failed(n)
+			}
+			return clean(n)
+		}, []string{"a", "b", "c"}, 2, 0, 1},
+		{"mixed skip and failure both continue", func(n string) (*engine.Result, error) {
+			switch n {
+			case "a":
+				return skipped(n)
+			case "b":
+				return failed(n)
+			}
+			return clean(n)
+		}, []string{"a", "b", "c"}, 1, 1, 1},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			applied, skippedCount, failures := aggregateApply(c.selected, c.apply)
+			if applied != c.wantApplied || skippedCount != c.wantSkipped || failures != c.wantFailures {
+				t.Errorf("aggregateApply() = (applied=%d, skipped=%d, failures=%d), want (applied=%d, skipped=%d, failures=%d)",
+					applied, skippedCount, failures, c.wantApplied, c.wantSkipped, c.wantFailures)
+			}
+		})
+	}
+}
+
 func TestSelectedRootFilter(t *testing.T) {
 	defer func() { flagProjectRoot, flagHomeRoot, flagSystemRoot = false, false, false }()
 


### PR DESCRIPTION
## 概要

`runApplyAll` の非 dryrun ループ（部分失敗継続・ErrSkipped カウント・exit code 集約）を、`aggregateDryRun` と同型の注入 seam `aggregateApply` に抽出した。applyFn を差し替え可能にすることで、nix build を経由せずにこのループの動作を単体テストできるようにする。挙動（skip/失敗カウント・部分失敗時の継続・stderr 出力）は変更していない。

## 関連 issue

Closes #81
Refs #60

## docs / ADR 影響

なし（内部実装のリファクタリングのみ。exit code 表・配置動作・API に変更なし）。
