### PR TITLE
refactor(engine): エラー wrap 規約の明文化と監査

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -92,6 +92,12 @@ _Avoid_: 「stateless スクリプト」前提の語り（初期方針からは�
 **store マニフェスト (store manifest)**:
 「nput が配置した」記録を持つ世代由来のデータ。実体は link-farm derivation 内の **`manifest.json`**（`schemaVersion` 付き）で、Nix（`lib.mkManifest`）が生成し Go エンジンが読む **Nix↔Go の契約**。GC 参照は併存する symlink farm が明示的に張る。エンジンの保守的 stale 除去（記録通りを指す nput 管理 symlink だけ削除し、ユーザーの実ファイルには触れない）の不変条件を支える（→ ADR-0002, ADR-0003, ADR-0006）。
 
+### エラー処理
+
+**エラー wrap 規約 (error-wrap convention)**:
+`internal/engine/` のエラーは**発生源（syscall / exec / parse に最も近い箇所）で 1 回だけ** `fmt.Errorf("nput: cannot <op> (<target>): %w", ...)` の形で op（何をしようとしたか）と対象パスを付けて wrap する。呼び出し元は素通し（bare `return err`）が既定で、伝搬経路での再 wrap は `nput: ...: nput: ...` の二重 context ノイズと既存のエラー文字列 assert 破壊を招くため行わない。sentinel エラー（`ErrSkipped` = `lock.ErrLocked` 等）は常に `%w` で透過させ、呼び出し元が `errors.Is` で判定できる状態を保つ。監査の判定基準は「ユーザーに見える失敗が op＋対象を少なくとも 1 回含むか」であり、含まれていれば伝搬経路の途中に op＋対象が無くても規約違反ではない。
+_Avoid_: 境界を跨ぐたびに context を積み増すこと、sentinel を wrap で握り潰し `errors.Is` を辿れなくすること
+
 ## Flagged ambiguities
 
 - **「symlink」単独では曖昧**。必ず **store link** か **out-of-store symlink** のどちらかに寄せる。`entries` の `method = "symlink"`（旧名 `mode`・→ ADR-0015）+ out-of-store marker の `src` で out-of-store を指すが、デフォルトの store link も symlink で実現される。

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -132,7 +132,7 @@ func Apply(opts Options) (*Result, error) {
 	if opts.Build == nil {
 		m, err := manifest.Load(opts.LinkFarm)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("nput: cannot read the link-farm's manifest (%s): %w", opts.LinkFarm, err)
 		}
 		a.manifest = m
 		if rootKind == "" {
@@ -188,7 +188,7 @@ func Apply(opts Options) (*Result, error) {
 		}
 		m, err := manifest.Load(linkFarm)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("nput: cannot read the built link-farm's manifest (%s): %w", linkFarm, err)
 		}
 		a.opts.LinkFarm = linkFarm
 		a.manifest = m
@@ -296,7 +296,7 @@ func (a *applier) dryRun() (*Result, error) {
 		}
 		m, err := manifest.Load(linkFarm)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("nput: cannot read the built link-farm's manifest (%s): %w", linkFarm, err)
 		}
 		a.opts.LinkFarm = linkFarm
 		a.manifest = m

--- a/internal/engine/reset.go
+++ b/internal/engine/reset.go
@@ -105,7 +105,7 @@ func Reset(opts ResetOptions) (*ResetResult, error) {
 	// 3. read the previous generation's manifest (the recorded truth) and narrow the target entries.
 	prev, err := manifest.Load(prof.Profile)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("nput: cannot read the previous generation's manifest (%s): %w", prof.Profile, err)
 	}
 	entries, err := selectResetEntries(prev.Entries, opts.Targets)
 	if err != nil {


### PR DESCRIPTION
## 概要

engine のエラー wrap 規約を CONTEXT.md に明文化した（発生源で1回だけ op+対象パスを付けて wrap・伝搬経路は素通し・sentinel は %w で透過）。この規約に基づき internal/engine/ の全エラー経路を監査し、欠落箇所のみ修正した：Apply/dryRun/Reset の manifest.Load 失敗が bare `return err` で op・対象パス無しに伝搬していた（Rollback は既に同種の失敗を wrap 済みで非対称だった）ため、発生源に最も近い呼び出し点で wrap を追加。copyTree 内の filepath.Rel/d.Info() 等、他の bare return は上位（placeCopies/recopyAll 等）の既存 wrap で op+対象を満たすことを確認し、変更不要と判断した（全境界での再wrapはノイズになるため不採用）。

## 関連 issue

Closes #90
Refs #60

本PRのマージで issue #60 配下5件（#81/#84/#85/#88/#90）が全てマージ済みとなるため、#60 もクローズ可能な状態になる（クローズ自体は別途）。

## docs / ADR 影響

CONTEXT.md にエラー wrap 規約の段落を追加。既存規約の明文化であり方針転換を伴わないため ADR 追加は不要。