### PR TITLE
docs(mkManifest): add missing pkgs argument to direct-write examples

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -112,6 +112,7 @@ nput init project      # projectRoot の例 ＋ devShell 配線 ＋ .gitignore �
     in
     {
       nput.${system}.skills = nput.lib.mkManifest {
+        inherit pkgs;
         root = nput.lib.projectRoot;        # 実行時に git toplevel へ解決される
         entries = {
           ".claude/skills/nix" = { src = inputs.claude-skills; subpath = "skills/nix"; };
@@ -146,6 +147,7 @@ nput gitignore skills >> .gitignore
 # flake.nix — 各役割が named manifest = 独立した profile
 outputs.nput.${system} = {
   vim-plugins = nput.lib.mkManifest {
+    inherit pkgs;
     root = nput.lib.homeRoot;
     entries = {
       ".local/share/nvim/site/pack/foo/start/foo" = { src = inputs.vim-foo; };
@@ -154,6 +156,7 @@ outputs.nput.${system} = {
   };
 
   zsh-plugins = nput.lib.mkManifest {
+    inherit pkgs;
     root = nput.lib.homeRoot;
     entries = {
       ".zsh/plugins/autosuggestions"     = { src = inputs.zsh-autosuggestions; };
@@ -298,6 +301,7 @@ subpath = "themes/dark.json";   # 単一ファイル
 ```nix
 let plugins = [ "telescope" "treesitter" "cmp" ]; in
 nput.lib.mkManifest {
+  inherit pkgs;
   root = nput.lib.homeRoot;
   entries = builtins.listToAttrs (map (n: {
     name  = ".local/share/nvim/site/pack/plugins/start/${n}";  # キー = target
@@ -314,6 +318,7 @@ let
   names  = builtins.attrNames (nixpkgs.lib.filterAttrs (_: t: t == "directory") skills);
 in
 nput.lib.mkManifest {
+  inherit pkgs;
   root = nput.lib.homeRoot;
   entries = builtins.listToAttrs (map (n: {
     name  = ".claude/skills/${n}";

--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ at arbitrary in-repo paths, kicked from a devShell.
     in
     {
       nput.${system}.skills = nput.lib.mkManifest {
+        inherit pkgs;
         root = nput.lib.projectRoot;        # resolves to the git toplevel at runtime
         entries = {
           ".claude/skills/nix" = { src = inputs.claude-skills; subpath = "skills/nix"; };
@@ -190,6 +191,7 @@ profile, committed every apply, with user-facing `rollback`.
 # flake.nix — each role is a named manifest = an independent profile
 outputs.nput.${system} = {
   vim-plugins = nput.lib.mkManifest {
+    inherit pkgs;
     root = nput.lib.homeRoot;
     entries = {
       ".local/share/nvim/site/pack/foo/start/foo" = { src = inputs.vim-foo; };
@@ -198,6 +200,7 @@ outputs.nput.${system} = {
   };
 
   zsh-plugins = nput.lib.mkManifest {
+    inherit pkgs;
     root = nput.lib.homeRoot;
     entries = {
       ".zsh/plugins/autosuggestions"     = { src = inputs.zsh-autosuggestions; };
@@ -368,6 +371,7 @@ not from `baseNameOf src` (a store path resolves to `/nix/store/<hash>-source`, 
 ```nix
 let plugins = [ "telescope" "treesitter" "cmp" ]; in
 nput.lib.mkManifest {
+  inherit pkgs;
   root = nput.lib.homeRoot;
   entries = builtins.listToAttrs (map (n: {
     name  = ".local/share/nvim/site/pack/plugins/start/${n}";  # key = target
@@ -386,6 +390,7 @@ let
   names  = builtins.attrNames (nixpkgs.lib.filterAttrs (_: t: t == "directory") skills);
 in
 nput.lib.mkManifest {
+  inherit pkgs;
   root = nput.lib.homeRoot;
   entries = builtins.listToAttrs (map (n: {
     name  = ".claude/skills/${n}";

--- a/docs/concept.md
+++ b/docs/concept.md
@@ -210,6 +210,7 @@ nput の**中心的な配置モード**が **root = プロジェクトルート*
 ```nix
 # entrypoint(flake.nix)が manifest を公開し、devShell で nput apply する
 nput.${system}.skills = nput.lib.mkManifest {
+  inherit pkgs;
   root = nput.lib.projectRoot;
   entries = {
     ".claude/skills/nix" = { src = inputs.claude-skills; subpath = "skills/nix"; };

--- a/docs/design.md
+++ b/docs/design.md
@@ -109,7 +109,7 @@ outputs = { ... }: {
 
   # 関数呼び出し（モジュールシステム不使用）
   lib = import ./lib;
-  # lib.mkManifest          { entries, root }   → derivation（manifest.json + symlink farm・純データ。root は必須）
+  # lib.mkManifest          { pkgs, entries, root }   → derivation（manifest.json + symlink farm・純データ。pkgs / root は必須）
   #                                               passthru.rootKind（+ fixed 時 passthru.root）を露出し CLI がビルド前 eval で読む（→ ADR-0023）
   # lib.mkOutOfStoreSymlink "/abs/path"         → marker（src に渡す）
   # lib.projectRoot                             → marker（root に渡す: project mode / git toplevel）
@@ -349,6 +349,7 @@ perSystem = { pkgs, ... }: {
 ```nix
 # flake.nix — repo に入ると .claude/skills を nix store から配置する
 outputs.nput.${system}.skills = nput.lib.mkManifest {
+  inherit pkgs;
   root = nput.lib.projectRoot;   # git toplevel を root に解決（project mode）
   entries = {
     ".claude/skills/nix" = { src = inputs.claude-skills; subpath = "skills/nix"; };
@@ -377,6 +378,7 @@ nput gitignore skills
 # flake.nix — entrypoint が役割ごとに named manifest を公開（それぞれ別 profile）
 outputs.nput.${system} = {
   vim-plugins = nput.lib.mkManifest {
+    inherit pkgs;
     root = nput.lib.homeRoot;
     entries = {
       ".local/share/nvim/site/pack/foo/start/foo" = { src = inputs.vim-foo; };
@@ -385,6 +387,7 @@ outputs.nput.${system} = {
   };
 
   zsh-plugins = nput.lib.mkManifest {
+    inherit pkgs;
     root = nput.lib.homeRoot;
     entries = {
       ".zsh/plugins/autosuggestions"     = { src = inputs.zsh-autosuggestions; };

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -29,13 +29,14 @@ config は **Nix で書き `nix build` で評価**される。CLI が発見す�
 entrypoint が `nput.<name>` に公開し、nput CLI が `nix build` してエンジンに渡す。Nix 評価テスト（nix-unit / namaka）の単体対象でもある。
 
 ```
-mkManifest :: { entries, root } -> derivation
+mkManifest :: { pkgs, entries, root } -> derivation
 ```
 
 **引数**
 
 | 引数 | 型 | デフォルト | 説明 |
 |---|---|---|---|
+| `pkgs` | attrset（nixpkgs） | **なし（必須）** | derivation ビルド（`runCommandLocal` 等）と `pkgs.lib` の取得に使う |
 | `entries` | attrset of entry | — | 配置定義の attrset。**属性キー = target パス**が識別子（後述・→ ADR-0014）|
 | `root` | string \| marker | **なし（必須）** | 配置先の基準。暗黙デフォルトを持たない（→ ADR-0007）|
 
@@ -81,6 +82,7 @@ entry の型定義（`lib/types.nix` の submodule）は `modules/common.nix` �
 ```nix
 # flake.nix
 outputs.nput.${system}.dotfiles = nput.lib.mkManifest {
+  inherit pkgs;
   root = nput.lib.projectRoot;
   entries = {
     # 属性キー = target。target フィールドは省略（キーから既定）
@@ -420,6 +422,7 @@ let
   plugins = [ "telescope" "treesitter" "cmp" ];
 in
 nput.lib.mkManifest {
+  inherit pkgs;
   root = nput.lib.homeRoot;
   entries = builtins.listToAttrs (map (n: {
     name  = ".local/share/nvim/site/pack/plugins/start/${n}";  # キー = target
@@ -452,6 +455,7 @@ let
   names  = builtins.attrNames (nixpkgs.lib.filterAttrs (_: t: t == "directory") skills);
 in
 nput.lib.mkManifest {
+  inherit pkgs;
   root = nput.lib.homeRoot;
   entries = builtins.listToAttrs (map (n: {
     name  = ".claude/skills/${n}";                                # キー = target（配置先）
@@ -808,6 +812,7 @@ let
   dotfiles = "${homeDir}/dotfiles";
 in
 nput.lib.mkManifest {
+  inherit pkgs;
   root = nput.lib.homeRoot;
   entries = {
     ".config/nvim" = { src = nput.lib.mkOutOfStoreSymlink dotfiles; subpath = "home/.config/nvim"; };
@@ -978,6 +983,7 @@ lib 層は home-manager / NixOS / nix-darwin に依存しない。配置ロジ�
     # パターン1: project mode（repo 内に配置・devShell キック）
     nput.${system} = {
       skills = nput.lib.mkManifest {
+        inherit pkgs;
         root = nput.lib.projectRoot;
         entries = {
           ".claude/skills/nix" = { src = inputs.claude-skills; subpath = "skills/nix"; };
@@ -992,6 +998,7 @@ lib 層は home-manager / NixOS / nix-darwin に依存しない。配置ロジ�
 
     # パターン2: home mode（標準的な dotfiles 配置・別 profile）
     # nput.${system}.vim-plugins = nput.lib.mkManifest {
+    #   inherit pkgs;
     #   root = nput.lib.homeRoot;
     #   entries = {
     #     ".local/share/nvim/site/pack/foo/start/foo" = { src = inputs.vim-plugin-foo; };


### PR DESCRIPTION
## 概要

公開ドキュメントの mkManifest 直書き例に必須引数 pkgs が抜けており、そのまま flake に貼ると `called without required argument 'pkgs'` で eval 失敗していた。README.md / README.ja.md / docs/concept.md / docs/design.md / docs/spec.md 内の全ての具体的な mkManifest 呼び出し例に `inherit pkgs;` を追加し、型注記も `mkManifest :: { pkgs, entries, root } -> derivation` に更新した（`<system>` / `<name>` / `...` のような概念的プレースホルダ例は対象外）。

## 関連issue

Closes #108（親 epic #107）

## docs / ADR 影響

concept.md / design.md / spec.md の mkManifest 使用例・型注記を修正。README.md / README.ja.md も同期。既存仕様の記述漏れの修正であり、方針転換は無いため ADR 追加は無し。