### PR TITLE
feat(cmd): support shell.nix/default.nix legacy entrypoints (mkShell passthru canonical)

### DIFF
--- a/cmd/nput/main.go
+++ b/cmd/nput/main.go
@@ -57,6 +57,9 @@ Internal nix commands (disclosed for transparency; you can run them by hand sele
   rollback /        nix eval <ep>#nput.<system>.<name>.rootKind --raw
   list-generations
 
+For a legacy entrypoint (shell.nix / default.nix; no per-system dimension; see ADR-0032), the
+above take the -f form instead: nix eval -f <ep> nput.<name>.rootKind / nix build -f <ep> nput.<name> ...
+
 Pass --debug to print the actual nix commands to stderr as they run.`
 
 func newRootCmd() *cobra.Command {

--- a/cmd/nput/nix.go
+++ b/cmd/nput/nix.go
@@ -12,15 +12,31 @@ import (
 	"strings"
 )
 
-// entrypoint is a discovered flake entrypoint. This slice supports only flake.nix
-// (legacy shell.nix / default.nix are a future slice; → ADR-0007, ADR-0023 §4).
+// entrypointKind distinguishes a flake entrypoint (`nput.<system>.<name>`, addressed via `<flakeRef>#...`)
+// from a legacy entrypoint (`nput.<name>`, addressed via `nix ... -f <path> ...`; → ADR-0007, ADR-0032).
+type entrypointKind int
+
+const (
+	entrypointFlake entrypointKind = iota
+	entrypointLegacy
+)
+
+// legacyEntrypointNames is the discovery order for legacy entrypoints, tried after flake.nix
+// (→ docs/spec.md "entrypoint discovery", ADR-0032).
+var legacyEntrypointNames = []string{"shell.nix", "default.nix"}
+
+// entrypoint is a discovered entrypoint: a flake (flake.nix) or a legacy file (shell.nix / default.nix).
+// Legacy has no per-system dimension (unlike the flake's `nput.<system>.<name>`; → ADR-0032).
 type entrypoint struct {
+	kind entrypointKind
 	// flakeRef is the flake ref passed to `nix build`/`nix eval` (the absolute path of the directory containing flake.nix).
 	flakeRef string
+	// legacyPath is the absolute path to the shell.nix / default.nix file, passed to `nix ... -f`.
+	legacyPath string
 }
 
 // discoverEntrypoint discovers the entrypoint in the order -f explicit → CWD autodiscovery
-// (→ docs/spec.md "entrypoint discovery"). This slice accepts only flake.nix.
+// (→ docs/spec.md "entrypoint discovery"). Discovery order is flake.nix → shell.nix → default.nix (→ ADR-0032).
 func discoverEntrypoint(fileFlag string) (*entrypoint, error) {
 	if fileFlag != "" {
 		abs, err := filepath.Abs(fileFlag)
@@ -33,15 +49,22 @@ func discoverEntrypoint(fileFlag string) (*entrypoint, error) {
 		}
 		if info.IsDir() {
 			if fileExists(filepath.Join(abs, "flake.nix")) {
-				return &entrypoint{flakeRef: abs}, nil
+				return &entrypoint{kind: entrypointFlake, flakeRef: abs}, nil
 			}
-			return nil, fmt.Errorf("nput: no flake.nix in the -f directory (%s). This slice supports only a flake entrypoint", abs)
+			for _, legacy := range legacyEntrypointNames {
+				if p := filepath.Join(abs, legacy); fileExists(p) {
+					return &entrypoint{kind: entrypointLegacy, legacyPath: p}, nil
+				}
+			}
+			return nil, fmt.Errorf("nput: no flake.nix / shell.nix / default.nix in the -f directory (%s)", abs)
 		}
 		switch filepath.Base(abs) {
 		case "flake.nix":
-			return &entrypoint{flakeRef: filepath.Dir(abs)}, nil
+			return &entrypoint{kind: entrypointFlake, flakeRef: filepath.Dir(abs)}, nil
+		case "shell.nix", "default.nix":
+			return &entrypoint{kind: entrypointLegacy, legacyPath: abs}, nil
 		default:
-			return nil, fmt.Errorf("nput: -f must point to a flake.nix (%s). shell.nix / default.nix are not supported in this slice", abs)
+			return nil, fmt.Errorf("nput: -f must point to a flake.nix, shell.nix, or default.nix (%s)", abs)
 		}
 	}
 
@@ -50,15 +73,14 @@ func discoverEntrypoint(fileFlag string) (*entrypoint, error) {
 		return nil, fmt.Errorf("nput: cannot get the current working directory: %w", err)
 	}
 	if fileExists(filepath.Join(cwd, "flake.nix")) {
-		return &entrypoint{flakeRef: cwd}, nil
+		return &entrypoint{kind: entrypointFlake, flakeRef: cwd}, nil
 	}
-	// If a legacy entrypoint is found, stop and make clear it is unsupported.
-	for _, legacy := range []string{"shell.nix", "default.nix"} {
-		if fileExists(filepath.Join(cwd, legacy)) {
-			return nil, fmt.Errorf("nput: %s is not supported in this slice (only flake.nix is supported; pass a flake with -f)", legacy)
+	for _, legacy := range legacyEntrypointNames {
+		if p := filepath.Join(cwd, legacy); fileExists(p) {
+			return &entrypoint{kind: entrypointLegacy, legacyPath: p}, nil
 		}
 	}
-	return nil, errors.New("nput: no entrypoint found (no flake.nix in the CWD; specify one with -f)")
+	return nil, errors.New("nput: no entrypoint found (no flake.nix / shell.nix / default.nix in the CWD; specify one with -f)")
 }
 
 func fileExists(p string) bool {
@@ -68,6 +90,7 @@ func fileExists(p string) bool {
 
 // currentSystem returns the nix system name of the runtime environment (e.g. aarch64-darwin).
 // Because the flake has a system dimension in `nput.<system>.<name>`, the CLI injects the current system (→ ADR-0007).
+// Legacy entrypoints have no system dimension and ignore it (→ ADR-0032).
 func currentSystem() (string, error) {
 	var arch string
 	switch runtime.GOARCH {
@@ -86,15 +109,40 @@ func currentSystem() (string, error) {
 	}
 }
 
-// installable builds the `<flakeRef>#nput.<system>.<name>` passed to `nix build`/`nix eval`.
-func (e *entrypoint) installable(system, name string) string {
-	return fmt.Sprintf("%s#nput.%s.%s", e.flakeRef, system, name)
+// installableArgs returns the nix args that select `nput.<name><suffix>` for this entrypoint, to be appended
+// right after the `eval`/`build` subcommand name. A flake entrypoint yields a single
+// "<flakeRef>#nput.<system>.<name><suffix>" installable; a legacy entrypoint (shell.nix / default.nix) has no
+// per-system dimension and yields "-f <legacyPath> nput.<name><suffix>" (→ ADR-0032, docs/spec.md addressing).
+func (e *entrypoint) installableArgs(system, name, suffix string) []string {
+	if e.kind == entrypointLegacy {
+		return []string{"-f", e.legacyPath, "nput." + name + suffix}
+	}
+	return []string{fmt.Sprintf("%s#nput.%s.%s%s", e.flakeRef, system, name, suffix)}
 }
 
-// namespace builds `<flakeRef>#nput.<system>` (the config set) without a config name.
-// It is used for the batch eval of apply --all / gitignore --all (config name → rootKind map; → ADR-0024).
-func (e *entrypoint) namespace(system string) string {
-	return fmt.Sprintf("%s#nput.%s", e.flakeRef, system)
+// namespaceArgs returns the nix args that select the `nput.<system>` (flake) or `nput` (legacy) namespace,
+// used for the batch eval of apply --all / gitignore --all (→ ADR-0024, ADR-0032).
+func (e *entrypoint) namespaceArgs(system string) []string {
+	if e.kind == entrypointLegacy {
+		return []string{"-f", e.legacyPath, "nput"}
+	}
+	return []string{fmt.Sprintf("%s#nput.%s", e.flakeRef, system)}
+}
+
+// label renders a human-readable attr path for error messages (→ wrapEvalErr).
+func (e *entrypoint) label(system, name string) string {
+	if e.kind == entrypointLegacy {
+		return "nput." + name
+	}
+	return fmt.Sprintf("nput.%s.%s", system, name)
+}
+
+// namespaceLabel renders a human-readable namespace path for error messages (→ wrapEvalAllErr).
+func (e *entrypoint) namespaceLabel(system string) string {
+	if e.kind == entrypointLegacy {
+		return "nput"
+	}
+	return fmt.Sprintf("nput.%s", system)
 }
 
 // rootInfo is one config's root info (the value from the batch eval). It has Root only when fixed.
@@ -109,13 +157,15 @@ type rootInfo struct {
 func evalAllRoots(e *entrypoint, system string) (map[string]rootInfo, error) {
 	// Extract only rootKind (+ root if fixed) from each config under nput.<system>.
 	apply := `cs: builtins.mapAttrs (_: c: { rootKind = c.rootKind; } // (if c ? root then { root = c.root; } else {})) cs`
-	out, err := runNixCapture("eval", e.namespace(system), "--apply", apply, "--json")
+	args := append([]string{"eval"}, e.namespaceArgs(system)...)
+	args = append(args, "--apply", apply, "--json")
+	out, err := runNixCapture(args...)
 	if err != nil {
-		return nil, wrapEvalAllErr(err, system)
+		return nil, wrapEvalAllErr(err, e.namespaceLabel(system))
 	}
 	var roots map[string]rootInfo
 	if err := json.Unmarshal([]byte(out), &roots); err != nil {
-		return nil, fmt.Errorf("nput: cannot parse the batch eval result for nput.%s: %w", system, err)
+		return nil, fmt.Errorf("nput: cannot parse the batch eval result for %s: %w", e.namespaceLabel(system), err)
 	}
 	return roots, nil
 }
@@ -124,13 +174,15 @@ func evalAllRoots(e *entrypoint, system string) (map[string]rootInfo, error) {
 // Because gitignore does no placement, it gets only the store path via `--no-link --print-out-paths` without laying down an out-link gcroot.
 // Progress goes to stderr and the store path to stdout (→ docs/spec.md output stream discipline).
 func buildManifestStorePath(e *entrypoint, system, name string) (string, error) {
-	out, err := runNixCapture("build", e.installable(system, name), "--no-link", "--print-out-paths")
+	args := append([]string{"build"}, e.installableArgs(system, name, "")...)
+	args = append(args, "--no-link", "--print-out-paths")
+	out, err := runNixCapture(args...)
 	if err != nil {
 		return "", err
 	}
 	store := strings.TrimSpace(out)
 	if store == "" {
-		return "", fmt.Errorf("nput: cannot obtain the build output path for nput.%s.%s", system, name)
+		return "", fmt.Errorf("nput: cannot obtain the build output path for %s", e.label(system, name))
 	}
 	return store, nil
 }
@@ -138,16 +190,19 @@ func buildManifestStorePath(e *entrypoint, system, name string) (string, error) 
 // evalRoot pre-resolves rootKind (+ the absolute path when fixed root) via a cheap nix eval before build
 // (→ docs/spec.md execution flow 1, ADR-0023). This resolves profileDir and establishes the order flock → build.
 func evalRoot(e *entrypoint, system, name string) (rootKind, fixedRoot string, err error) {
-	inst := e.installable(system, name)
-	out, err := runNixCapture("eval", inst+".rootKind", "--raw")
+	args := append([]string{"eval"}, e.installableArgs(system, name, ".rootKind")...)
+	args = append(args, "--raw")
+	out, err := runNixCapture(args...)
 	if err != nil {
-		return "", "", wrapEvalErr(err, system, name)
+		return "", "", wrapEvalErr(err, e.label(system, name))
 	}
 	rootKind = strings.TrimSpace(out)
 	if rootKind == "fixed" {
-		out, err := runNixCapture("eval", inst+".root", "--raw")
+		rootArgs := append([]string{"eval"}, e.installableArgs(system, name, ".root")...)
+		rootArgs = append(rootArgs, "--raw")
+		out, err := runNixCapture(rootArgs...)
 		if err != nil {
-			return "", "", wrapEvalErr(err, system, name)
+			return "", "", wrapEvalErr(err, e.label(system, name))
 		}
 		fixedRoot = strings.TrimSpace(out)
 	}
@@ -157,9 +212,10 @@ func evalRoot(e *entrypoint, system, name string) (rootKind, fixedRoot string, e
 // buildFunc returns the build callback injected into the engine (→ engine.BuildFunc).
 // Inside the lock it runs `nix build <installable> --out-link <pending>`, reads the out-link, and returns the store path.
 func buildFunc(e *entrypoint, system, name string) func(pending string) (string, error) {
-	inst := e.installable(system, name)
 	return func(pending string) (string, error) {
-		if err := runNixStream("build", inst, "--out-link", pending); err != nil {
+		args := append([]string{"build"}, e.installableArgs(system, name, "")...)
+		args = append(args, "--out-link", pending)
+		if err := runNixStream(args...); err != nil {
 			return "", err
 		}
 		store, err := os.Readlink(pending)
@@ -174,15 +230,16 @@ func buildFunc(e *entrypoint, system, name string) func(pending string) (string,
 // it gets the link-farm's store path via `nix build --no-link --print-out-paths` **without laying down a gcroot (out-link)**
 // (dryrun is side-effect-free and creates no pending out-link; → ADR-0011, ADR-0023). The pending argument is unused.
 func dryBuildFunc(e *entrypoint, system, name string) func(pending string) (string, error) {
-	inst := e.installable(system, name)
 	return func(string) (string, error) {
-		out, err := runNixCapture("build", inst, "--no-link", "--print-out-paths")
+		args := append([]string{"build"}, e.installableArgs(system, name, "")...)
+		args = append(args, "--no-link", "--print-out-paths")
+		out, err := runNixCapture(args...)
 		if err != nil {
 			return "", err
 		}
 		store := strings.TrimSpace(out)
 		if store == "" {
-			return "", fmt.Errorf("nput: nix build --print-out-paths was empty (%s)", inst)
+			return "", fmt.Errorf("nput: nix build --print-out-paths was empty (%s)", e.label(system, name))
 		}
 		// --print-out-paths may return multiple lines (multi-output). The link-farm is a single output, so take the last line.
 		lines := strings.Split(store, "\n")
@@ -261,21 +318,21 @@ Original nix error:
 
 // wrapEvalErr makes the "nput.<name> does not exist" case of an eval failure clearer
 // (experimental etc. are passed through as-is) (→ docs/spec.md error spec).
-func wrapEvalErr(err error, system, name string) error {
+func wrapEvalErr(err error, label string) error {
 	msg := err.Error()
 	if strings.Contains(msg, "does not provide attribute") ||
 		(strings.Contains(msg, "attribute") && strings.Contains(msg, "missing")) {
-		return fmt.Errorf("nput: nput.%s.%s not found in the entrypoint (check the config name and system)\n%s", system, name, msg)
+		return fmt.Errorf("nput: %s not found in the entrypoint (check the config name)\n%s", label, msg)
 	}
 	return err
 }
 
 // wrapEvalAllErr makes the "nput.<system> does not exist" case of a batch eval failure clearer.
-func wrapEvalAllErr(err error, system string) error {
+func wrapEvalAllErr(err error, label string) error {
 	msg := err.Error()
 	if strings.Contains(msg, "does not provide attribute") ||
 		(strings.Contains(msg, "attribute") && strings.Contains(msg, "missing")) {
-		return fmt.Errorf("nput: nput.%s not found in the entrypoint (no configs for this system)\n%s", system, msg)
+		return fmt.Errorf("nput: %s not found in the entrypoint (no configs found)\n%s", label, msg)
 	}
 	return err
 }

--- a/cmd/nput/nix_test.go
+++ b/cmd/nput/nix_test.go
@@ -1,0 +1,190 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+// writeFile creates an empty file at dir/name (content is irrelevant; discoverEntrypoint only checks existence).
+func writeFile(t *testing.T, dir, name string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), nil, 0o644); err != nil {
+		t.Fatalf("writeFile(%s): %v", name, err)
+	}
+}
+
+// TestDiscoverEntrypoint_FileFlag covers -f pointing directly at a file (→ ADR-0032 discovery order).
+func TestDiscoverEntrypoint_FileFlag(t *testing.T) {
+	cases := []struct {
+		name     string
+		file     string
+		wantKind entrypointKind
+	}{
+		{"flake.nix", "flake.nix", entrypointFlake},
+		{"shell.nix", "shell.nix", entrypointLegacy},
+		{"default.nix", "default.nix", entrypointLegacy},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			dir := t.TempDir()
+			writeFile(t, dir, c.file)
+			path := filepath.Join(dir, c.file)
+
+			ep, err := discoverEntrypoint(path)
+			if err != nil {
+				t.Fatalf("discoverEntrypoint(%s): %v", path, err)
+			}
+			if ep.kind != c.wantKind {
+				t.Errorf("kind = %v, want %v", ep.kind, c.wantKind)
+			}
+			switch c.wantKind {
+			case entrypointFlake:
+				if ep.flakeRef != dir {
+					t.Errorf("flakeRef = %q, want %q", ep.flakeRef, dir)
+				}
+			case entrypointLegacy:
+				if ep.legacyPath != path {
+					t.Errorf("legacyPath = %q, want %q", ep.legacyPath, path)
+				}
+			}
+		})
+	}
+}
+
+// TestDiscoverEntrypoint_FileFlagRejectsUnknownName covers -f pointing at a file that is none of the three.
+func TestDiscoverEntrypoint_FileFlagRejectsUnknownName(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "config.nix")
+	path := filepath.Join(dir, "config.nix")
+
+	if _, err := discoverEntrypoint(path); err == nil {
+		t.Fatal("expected an error for an unrecognized -f file name, got nil")
+	}
+}
+
+// TestDiscoverEntrypoint_FileFlagMissing covers -f pointing at a path that does not exist.
+func TestDiscoverEntrypoint_FileFlagMissing(t *testing.T) {
+	if _, err := discoverEntrypoint(filepath.Join(t.TempDir(), "nope.nix")); err == nil {
+		t.Fatal("expected an error for a missing -f path, got nil")
+	}
+}
+
+// TestDiscoverEntrypoint_FileFlagDir covers -f pointing at a directory, applying the same
+// flake.nix -> shell.nix -> default.nix priority as CWD autodiscovery (→ ADR-0032).
+func TestDiscoverEntrypoint_FileFlagDir(t *testing.T) {
+	cases := []struct {
+		name       string
+		files      []string
+		wantKind   entrypointKind
+		wantLegacy string // expected legacy file name, if wantKind == entrypointLegacy
+	}{
+		{"flake.nix only", []string{"flake.nix"}, entrypointFlake, ""},
+		{"flake.nix wins over shell.nix", []string{"flake.nix", "shell.nix"}, entrypointFlake, ""},
+		{"shell.nix only", []string{"shell.nix"}, entrypointLegacy, "shell.nix"},
+		{"default.nix only", []string{"default.nix"}, entrypointLegacy, "default.nix"},
+		{"shell.nix wins over default.nix", []string{"shell.nix", "default.nix"}, entrypointLegacy, "shell.nix"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			dir := t.TempDir()
+			for _, f := range c.files {
+				writeFile(t, dir, f)
+			}
+			ep, err := discoverEntrypoint(dir)
+			if err != nil {
+				t.Fatalf("discoverEntrypoint(%s): %v", dir, err)
+			}
+			if ep.kind != c.wantKind {
+				t.Errorf("kind = %v, want %v", ep.kind, c.wantKind)
+			}
+			if c.wantKind == entrypointLegacy {
+				want := filepath.Join(dir, c.wantLegacy)
+				if ep.legacyPath != want {
+					t.Errorf("legacyPath = %q, want %q", ep.legacyPath, want)
+				}
+			}
+		})
+	}
+}
+
+// TestDiscoverEntrypoint_FileFlagDirEmpty covers -f pointing at a directory with none of the three files.
+func TestDiscoverEntrypoint_FileFlagDirEmpty(t *testing.T) {
+	if _, err := discoverEntrypoint(t.TempDir()); err == nil {
+		t.Fatal("expected an error for a -f directory with no entrypoint file, got nil")
+	}
+}
+
+// TestDiscoverEntrypoint_CWD covers CWD autodiscovery priority flake.nix -> shell.nix -> default.nix (→ ADR-0032).
+func TestDiscoverEntrypoint_CWD(t *testing.T) {
+	cases := []struct {
+		name       string
+		files      []string
+		wantKind   entrypointKind
+		wantLegacy string
+		wantErr    bool
+	}{
+		{"flake.nix only", []string{"flake.nix"}, entrypointFlake, "", false},
+		{"flake.nix wins over shell.nix", []string{"flake.nix", "shell.nix"}, entrypointFlake, "", false},
+		{"shell.nix only", []string{"shell.nix"}, entrypointLegacy, "shell.nix", false},
+		{"default.nix only", []string{"default.nix"}, entrypointLegacy, "default.nix", false},
+		{"shell.nix wins over default.nix", []string{"shell.nix", "default.nix"}, entrypointLegacy, "shell.nix", false},
+		{"none", nil, 0, "", true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			dir := t.TempDir()
+			for _, f := range c.files {
+				writeFile(t, dir, f)
+			}
+			t.Chdir(dir)
+
+			ep, err := discoverEntrypoint("")
+			if c.wantErr {
+				if err == nil {
+					t.Fatal("expected an error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("discoverEntrypoint(\"\"): %v", err)
+			}
+			if ep.kind != c.wantKind {
+				t.Errorf("kind = %v, want %v", ep.kind, c.wantKind)
+			}
+			if c.wantKind == entrypointLegacy {
+				want := filepath.Join(dir, c.wantLegacy)
+				if ep.legacyPath != want {
+					t.Errorf("legacyPath = %q, want %q", ep.legacyPath, want)
+				}
+			}
+		})
+	}
+}
+
+// TestEntrypointInstallableArgs locks in the flake `<ep>#nput.<system>.<name><suffix>` form vs. the
+// legacy `-f <ep> nput.<name><suffix>` form (no per-system dimension; → ADR-0032).
+func TestEntrypointInstallableArgs(t *testing.T) {
+	flakeEp := &entrypoint{kind: entrypointFlake, flakeRef: "/proj"}
+	if got, want := flakeEp.installableArgs("x86_64-linux", "docs", ".rootKind"), []string{"/proj#nput.x86_64-linux.docs.rootKind"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("flake installableArgs = %v, want %v", got, want)
+	}
+	if got, want := flakeEp.namespaceArgs("x86_64-linux"), []string{"/proj#nput.x86_64-linux"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("flake namespaceArgs = %v, want %v", got, want)
+	}
+	if got, want := flakeEp.label("x86_64-linux", "docs"), "nput.x86_64-linux.docs"; got != want {
+		t.Errorf("flake label = %q, want %q", got, want)
+	}
+
+	legacyEp := &entrypoint{kind: entrypointLegacy, legacyPath: "/proj/shell.nix"}
+	if got, want := legacyEp.installableArgs("x86_64-linux", "docs", ".rootKind"), []string{"-f", "/proj/shell.nix", "nput.docs.rootKind"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("legacy installableArgs = %v, want %v", got, want)
+	}
+	if got, want := legacyEp.namespaceArgs("x86_64-linux"), []string{"-f", "/proj/shell.nix", "nput"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("legacy namespaceArgs = %v, want %v", got, want)
+	}
+	if got, want := legacyEp.label("x86_64-linux", "docs"), "nput.docs"; got != want {
+		t.Errorf("legacy label = %q, want %q", got, want)
+	}
+}

--- a/docs/adr/0007-cli-as-primary-ux-and-entrypoint-discovery.md
+++ b/docs/adr/0007-cli-as-primary-ux-and-entrypoint-discovery.md
@@ -1,6 +1,6 @@
 # ADR-0007: 汎用 nput CLI を一次 UX に昇格し、entrypoint 発見＋root 明示モデルへ移行する
 
-- ステータス: 採用（2026-06-14 追記: project mode の `nput` は devShell 同梱が canonical → ADR-0015）
+- ステータス: 採用（2026-06-14 追記: project mode の `nput` は devShell 同梱が canonical → ADR-0015／2026-07-03 改訂: legacy entrypoint の addressing を `nix build -f` に統一 → ADR-0032）
 - 日付: 2026-06-13
 - 関連: ADR-0002, ADR-0003, ADR-0004, ADR-0005, ADR-0006, ADR-0015, `docs/concept.md`, `docs/design.md`, `docs/spec.md`
 - 改訂対象: ADR-0006「nput の露出と環境セットアップ」節と棄却案（本 ADR が反転）、ADR-0004 / ADR-0005 の root モデル
@@ -15,6 +15,13 @@
 > `nput.<name>` を公開し `nput apply <name>` で build→配置）を指す。これとは別に、HM 等の**モジュールはビルド済み manifest を
 > `nput apply --manifest <link-farm>` で kick する**（モジュール評価時に `mkManifest` でビルドし、entrypoint output を持たない）。
 > モジュールの engine kick invocation は ADR-0026 で確定（→ ADR-0026）。
+
+> **2026-07-03 改訂（ADR-0032）**: 本 ADR §4 の「default.nix / shell.nix はトップレベル `{ nput.<name> = ...; }`・
+> CLI は `nix-build -A nput.<name>`」という addressing 記述を改訂した。**shell.nix / default.nix は nixpkgs `mkShell` と
+> 共存できる passthru 形（`passthru.nput.<name>`）を canonical** とする（トップレベル attrset 形も引き続き有効）。
+> passthru はホスト derivation の attrset にマージされるため、CLI の attr path はどちらの形でも同一の `nput.<name>`
+> （実装分岐なし）。CLI の addressing は **`nix build -f <ep> nput.<name>` / `nix eval -f <ep> nput.<name>.rootKind`**
+> （新 CLI に統一）へ置き換わった。§5 の「best-effort・再現性はユーザー責任」という decision 自体は不変。詳細は ADR-0032。
 
 ## 背景
 

--- a/docs/adr/0032-legacy-entrypoint-passthru-canonical.md
+++ b/docs/adr/0032-legacy-entrypoint-passthru-canonical.md
@@ -77,7 +77,21 @@ ADR-0007 §4/§5 は shell.nix / default.nix を entrypoint として受理す�
   （pure-eval はデフォルト無効で、flake 評価だけが暗黙に強制する）ため、`<nixpkgs>` の NIX_PATH 参照はそのまま解決できる
   （→ ADR-0007 §5 の「impure eval を許容」はこの意味）。
 
-### 5. entrypoint 発見順序に shell.nix / default.nix を追加する
+### 5. legacy では `src` の store 化は自動ではない（reproducibility は既存どおりユーザー責任）
+
+- flake entrypoint は評価前にディレクトリ全体（git 管理下のファイル）が store へコピーされるため、flake.nix 内の
+  相対 path リテラル（例: `src = ./srcrepo;`）は評価時点で既に store 内パスを指しており、`toString` だけで
+  store symlink になる。
+- **legacy（`-f` eval）にはこの事前コピーが無い**。相対 path リテラルは shell.nix / default.nix の実ファイル位置基準で
+  解決され、`resolveEntry` の `toString e.src`（→ `lib/__internal.nix`）は store への add-to-store を発生させない
+  （`"${e.src}"` のような文字列補間で初めて add-to-store が起きる）。そのため **legacy で素の相対 path を `src` に渡すと、
+  manifest.json 上は `srcKind = "store"` のまま、実体は生の（store 外・GC 非対象・可変な）作業木パスを指す symlink になる**。
+- これは §5（旧）の「NIX_PATH / channels 依存の impure eval を許容・再現性はユーザー責任」という decision の具体的帰結の一つとして扱う
+  （decision の追加ではなく、既存 decision の射程を明確化する）。reproducible / store-backed な配置を望むユーザーは、
+  `src` に `builtins.path { path = ./srcrepo; }` や `fetchTarball` / `builtins.fetchGit` など明示的に store へ
+  add する手段を使う（docs/spec.md に注記する）。
+
+### 6. entrypoint 発見順序に shell.nix / default.nix を追加する
 
 - 既定探索（CWD）: `flake.nix` → `shell.nix` → `default.nix` の優先順（ADR-0007 §3 の記述どおり）。
 - `-f` / `--file` はファイル直接指定（`flake.nix` / `shell.nix` / `default.nix` のいずれも受理）に加え、ディレクトリ指定時も

--- a/docs/adr/0032-legacy-entrypoint-passthru-canonical.md
+++ b/docs/adr/0032-legacy-entrypoint-passthru-canonical.md
@@ -1,0 +1,125 @@
+# ADR-0032: legacy entrypoint（shell.nix / default.nix）は mkShell passthru を canonical とし、addressing を `nix build -f` に統一する
+
+- ステータス: 採用
+- 日付: 2026-07-03
+- 関連: ADR-0007, ADR-0002, ADR-0011, ADR-0023, ADR-0024, ADR-0025, `docs/spec.md`, `docs/design.md`
+- 改訂対象: ADR-0007 §4 の legacy entrypoint addressing 記述（`nix-build -A nput.<name>`）を `nix build -f <ep> nput.<name>` へ改訂。§5（best-effort・再現性はユーザー責任）の decision 自体は不変
+- 起点 Issue: #112（親 epic #107）。ADR-0007 §5 で「採用済み」としつつ実装（`cmd/nput/nix.go`）が明示拒否していた乖離を解消する
+
+## 背景
+
+ADR-0007 §4/§5 は shell.nix / default.nix を entrypoint として受理する方針を採用済みとしていたが、実装（`discoverEntrypoint`）は
+「この slice では未対応」として明示的にエラーで拒否していた。2026-07-03 のセッションで「実装するか将来送りか」を再検討し、
+以下の理由で **A: 実装する** に確定した。
+
+- 将来送りは ADR-0007 §4/§5 という**採用済み decision の巻き戻し**になり、起点 Issue #4 のクローズ済み解決を覆す
+- #81（cmd orchestration 分離・DI seam 拡張）が先行してマージされ、単体テスト可能な形で実装できる土台が整った
+
+再検討にあたり、ADR-0007 §4 が置いていた 2 つの前提を精査した。
+
+1. **entrypoint の作り**: ADR-0007 §4 は「default.nix / shell.nix はトップレベル `{ nput.<name> = mkManifest { ... }; }`」とだけ書いていたが、
+   これは nixpkgs の `mkShell` 同梱と両立しない。同じ `shell.nix` が「project の devShell」と「nput entrypoint」を兼ねる典型ユースケース
+   （project mode の canonical・→ ADR-0015）では、`{ shell = ...; nput = ...; }` のようなトップレベル分離を強いるか、
+   素の `nix-shell` が壊れるかの二択を迫られていた。
+2. **nix コマンド形**: ADR-0007 §4 は legacy build に旧 CLI `nix-build -A nput.<name>` を挙げていたが、flake 側の eval は
+   ADR-0025 前提（`nix-command` experimental-features）に基づき新 CLI `nix eval` を使っており、legacy だけ旧 CLI を混在させる理由がない。
+
+## 決定
+
+### 1. entrypoint の作り = nixpkgs `mkShell` と共存できる passthru 形を canonical にする
+
+- **canonical**: `shell.nix` は**素の `mkShell` derivation を返し**、`passthru.nput.<name>` に named manifest を載せる。
+
+  ```nix
+  { pkgs ? import <nixpkgs> {}, nput ? import (fetchTarball "https://github.com/yasunori0418/nput/archive/....tar.gz") }:
+  pkgs.mkShell {
+    packages = [ ];
+    shellHook = "nput apply skills --no-wait";
+    passthru.nput = {
+      skills = nput.lib.mkManifest { inherit pkgs; root = nput.lib.projectRoot; entries = { }; };
+    };
+  }
+  ```
+
+- これにより **素の `nix-shell`（`-A` 不要）が壊れない**。`nix-shell` は返り値が derivation でありさえすれば入室でき、`passthru` は
+  無視される。project mode の devShell 同梱（→ ADR-0015）と legacy entrypoint 対応が同じファイルで両立する。
+- **トップレベル attrset 形（`{ shell = ...; nput = {...}; }`）も引き続き有効**（廃止しない）。`mkShell` を使わない・
+  devShell を兼ねない最小構成ではこちらの方が単純なため、docs に両形を併記する。
+
+### 2. CLI の attr path はどちらの形でも同一（実装分岐なし）
+
+- Nix の属性選択は `passthru` に透過的に届く（derivation は attrset であり、`passthru` の各フィールドはその attrset に
+  マージされる）。したがって passthru 形でもトップレベル attrset 形でも、**CLI が叩く attr path は同一の `nput.<name>`**。
+- CLI 実装は「entrypoint の**種別**（flake / legacy）」でのみ分岐し、legacy のうち「passthru か素の attrset か」では
+  分岐しない。ユーザーがどちらの形で書いても同じコードパスを通る。
+
+### 3. 複数 manifest 一括処理は既存の `apply --all` で充足する
+
+- `apply --all` の一括 eval（`nix eval -f <ep> nput --apply 'cs: ...' --json`）は passthru 形・トップレベル attrset 形の
+  どちらでも同一に動く（`nput` 直下 attrset を読むだけで、`mkShell` 本体の評価は要らない）。
+- **`mkShell` の `inputsFrom` で複数 manifest を合成するヘルパは採らない**。1 config = 1 profile の atomic 性（→ ADR-0002）と
+  衝突する（合成すると世代の単位が曖昧になる）。役割ごとの分離は既存どおり config 分割（`nput.<name>` を複数持つ）で担保する。
+
+### 4. nix コマンド形 = 新 CLI `-f` に統一する
+
+- legacy の eval / build は ADR-0007 §4 が挙げていた旧 CLI `nix-build -A` ではなく、**新 CLI の `-f` 形**を使う。
+
+  | 用途 | flake | legacy |
+  |---|---|---|
+  | rootKind 先取り eval | `nix eval <ep>#nput.<system>.<name>.rootKind --raw` | `nix eval -f <ep> nput.<name>.rootKind --raw` |
+  | build（apply 内） | `nix build <ep>#nput.<system>.<name> --out-link <pending>` | `nix build -f <ep> nput.<name> --out-link <pending>` |
+  | store path 取得（gitignore 等） | `nix build <ep>#nput.<system>.<name> --no-link --print-out-paths` | `nix build -f <ep> nput.<name> --no-link --print-out-paths` |
+  | 一括 rootKind eval（`--all`） | `nix eval <ep>#nput.<system> --apply '...' --json` | `nix eval -f <ep> nput --apply '...' --json` |
+
+- legacy には per-system 次元（`nput.<system>.<name>`）が無く、フラットな `nput.<name>` を直接叩く。
+- `runNixCapture` / `runNixStream` / `nixError`（experimental-features 未有効時の案内含む）は**そのまま再利用**する。
+  legacy 固有の追加フラグ（`--impure` 等）は要らない：`-f`/`--file` 評価は新 CLI でも pure-eval を強制しない
+  （pure-eval はデフォルト無効で、flake 評価だけが暗黙に強制する）ため、`<nixpkgs>` の NIX_PATH 参照はそのまま解決できる
+  （→ ADR-0007 §5 の「impure eval を許容」はこの意味）。
+
+### 5. entrypoint 発見順序に shell.nix / default.nix を追加する
+
+- 既定探索（CWD）: `flake.nix` → `shell.nix` → `default.nix` の優先順（ADR-0007 §3 の記述どおり）。
+- `-f` / `--file` はファイル直接指定（`flake.nix` / `shell.nix` / `default.nix` のいずれも受理）に加え、ディレクトリ指定時も
+  同じ優先順で探索する。
+
+## 根拠
+
+- **passthru を canonical にする理由**: トップレベル attrset を canonical にすると、`mkShell` を返さない前提になり、
+  project mode の devShell 同梱（→ ADR-0015）と同じファイルで両立しない。passthru は「nput の追加情報を乗せるだけ」で
+  ホスト側の derivation の型・振る舞いを変えない。素の `nix-shell` 互換を壊さない。
+- **属性選択の透過性で実装分岐を避ける**: `passthru` はホスト言語（Nix）機構としてトップレベル属性と区別なく参照できるため、
+  CLI 側に「passthru か直下か」の判定ロジックを持ち込む必要がない。実装をシンプルに保てる。
+- **`inputsFrom` 型合成を採らない理由**: 世代管理の単位を「1 profile = 1 config」（→ ADR-0002）に保つほうが、
+  rollback / stale 除去の意味論を単純に保てる。複数 manifest を 1 profile に混ぜると、どの manifest 由来の stale かが曖昧になる。
+- **新 CLI `-f` に統一する理由**: flake 側は ADR-0025 で `nix-command` experimental-features を前提にしており、
+  legacy だけ旧 CLI（`nix-build`）を使うと同一プロセスの二重海域（新旧 CLI 混在）になり、エラーハンドリング
+  （`nixError` の experimental-features 未有効判定等）を両対応させる必要が生じる。新 CLI `-f` に統一すれば
+  既存の `runNixCapture` / `runNixStream` / `nixError` をそのまま再利用でき、実装・テストの両方が単純になる。
+
+## 影響
+
+- **ADR-0007 改訂**: §4 の「legacy は `nix-build -A nput.<name>`」を本 ADR の記述へ改訂する旨のヘッダ注記を追加する。
+  §5（best-effort・再現性はユーザー責任）の decision 自体は不変。
+- **`docs/spec.md`**: アドレッシング表（`default.nix` / `shell.nix` 行）に passthru 形を追記し、`nix-build -A` の記述を
+  `nix build -f` へ改める。実行フロー節の legacy 行（rootKind 先取り eval / build / 一括 eval）を同様に改める。
+- **`docs/design.md`**: 該当するアドレッシング節・CLI 実行モデル節を spec.md と整合させる。
+- **実装（`cmd/nput/nix.go`）**: `entrypoint` を flake / legacy の 2 種別に拡張し、`discoverEntrypoint` に shell.nix /
+  default.nix の受理を追加、`evalRoot` / `evalAllRoots` / `buildFunc` / `dryBuildFunc` / `buildManifestStorePath` に
+  legacy 形（`nix eval -f` / `nix build -f`）を追加する。
+- **e2e**: legacy シナリオ（passthru 形 fixture + `NIX_PATH` を flake.lock の nixpkgs pin に固定）を追加する。
+
+## 棄却した代替案
+
+- **トップレベル attrset 形を canonical にし、passthru は補助的な代替案に留める**: 素の `nix-shell` が devShell 用途で
+  壊れうる（`{ nput = ...; }` だけを返すと `mkShell` にならない）。project mode の devShell 同梱という主要ユースケースと
+  相性が悪いため不採用。ただし引き続き**有効な代替形**として docs に残す（廃止ではない）。
+- **`mkShell` の `inputsFrom` で複数 manifest を合成するヘルパを提供する**: 1 profile = 1 config の atomic 性
+  （→ ADR-0002）と衝突する。役割分離は config 分割で担保する既存決定と一貫させるため不採用。
+- **legacy build を旧 CLI `nix-build -A` のまま存続させる**（ADR-0007 §4 原案）: flake 側は新 CLI 前提（→ ADR-0025）であり、
+  legacy だけ旧 CLI を混在させる利点がない。エラーハンドリング・experimental-features 前提の二重化を避けるため、
+  新 CLI `-f` 形に統一する。
+- **legacy eval/build に `--impure` を自動付与する**: `-f` 評価は pure-eval をデフォルトで強制しないため不要。
+  ユーザー環境の pure-eval 設定を黙って上書きしない（ADR-0025 §1 の `--extra-experimental-features` 自動付与拒否と同じ姿勢）。
+- **将来送り（本 issue を設計判断のまま据え置く）**: ADR-0007 §4/§5 という採用済み decision の巻き戻しになり、
+  起点 Issue #4 のクローズ済み解決を覆すため不採用。

--- a/docs/design.md
+++ b/docs/design.md
@@ -119,14 +119,12 @@ outputs = { ... }: {
 };
 ```
 
-ユーザーの entrypoint 側は `nput.<name>` に named manifest を公開する（→ ADR-0007）。直書きと flake-parts module の 2 経路があり、**いずれも同一の `flake.nput.<system>.<name>`（`mkManifest` の derivation）を生む**。CLI のアドレッシング（`nix build .#nput.<system>.<name>`）は両形で同一（→ ADR-0029）。
+ユーザーの entrypoint 側は `nput.<name>` に named manifest を公開する（→ ADR-0007）。flake は直書きと flake-parts module の 2 経路があり、**いずれも同一の `flake.nput.<system>.<name>`（`mkManifest` の derivation）を生む**。CLI のアドレッシング（`nix build .#nput.<system>.<name>`）は両形で同一（→ ADR-0029）。
 
 ```nix
-# 直書き（plain flake / default.nix / shell.nix の canonical・→ ADR-0007）
+# 直書き（plain flake の canonical・→ ADR-0007）
 # ユーザーの flake.nix
 outputs.nput.<system>.<name> = nput.lib.mkManifest { root = ...; entries = { ... }; };
-# ユーザーの default.nix / shell.nix
-{ nput.<name> = nput.lib.mkManifest { root = ...; entries = { ... }; }; }
 
 # flake-parts module 経由（flake-parts 利用者の canonical・→ ADR-0029）
 # imports = [ inputs.nput.flakeModules.default ];
@@ -134,13 +132,30 @@ outputs.nput.<system>.<name> = nput.lib.mkManifest { root = ...; entries = { ...
 #   nput.<name> = inputs.nput.lib.mkManifest { inherit pkgs; root = ...; entries = { ... }; };
 # };
 # → flake-parts が flake.nput.<system>.<name> へ transpose する。pkgs は perSystem 由来で
-#   packages.nput と一貫（将来の overlay / config も含む・二重解決なし）。
+#   packages.nput と一貫(将来の overlay / config も含む・二重解決なし)。
 ```
 
 > `nput.<system>.<name>` は `packages` を汚さない専用 namespace（→ ADR-0007）。`nix flake check` はこれを **unknown output として警告するが
 > exit 0・無害**で、配下の derivation は build / eval されない（`nput` 直下 attrset の eval だけは検査される）。**flake-parts module で transpose しても
 > この警告は消えない**（nix 本体が known-output を hardcode するため・→ ADR-0029）。警告は出力名変更でも消せない。成果物の主検証は
 > `nix build .#nput.<system>.<name>` で行う（→ ADR-0015）。
+
+`default.nix` / `shell.nix`（legacy entrypoint）は flake の per-system 次元を持たず、**nixpkgs `mkShell` と共存できる passthru 形を canonical**とする（→ ADR-0032）。トップレベル attrset 形も引き続き有効（`passthru` はホスト derivation の attrset にマージされるため、CLI が叩く attr path はどちらの形でも同一の `nput.<name>`）。
+
+```nix
+# passthru 形（canonical・shell.nix が mkShell を兼ねられる・project mode の devShell 同梱と両立・→ ADR-0015, ADR-0032）
+{ pkgs ? import <nixpkgs> {}, nput ? ... }:
+pkgs.mkShell {
+  packages = [ ];
+  shellHook = "nput apply skills --no-wait";
+  passthru.nput.skills = nput.lib.mkManifest { inherit pkgs; root = nput.lib.projectRoot; entries = { ... }; };
+}
+
+# トップレベル attrset 形（引き続き有効・mkShell を使わない最小構成向け）
+{ nput.<name> = nput.lib.mkManifest { inherit pkgs; root = ...; entries = { ... }; }; }
+```
+
+legacy の CLI アドレッシングは新 CLI の `-f` 形（`nix build -f <ep> nput.<name>` / `nix eval -f <ep> nput.<name>.rootKind`）で、flake の `<ep>#nput.<system>.<name>` 形とは別の実行パスを通るが、attr path の組み立て以外（`runNixCapture` / `runNixStream` / エラー処理）は共通のまま再利用する（→ ADR-0032）。
 
 ---
 
@@ -214,8 +229,8 @@ method = copy, subpath がファイル     → place-once: target 不在時の�
 ```
 nput apply <name> [-f <ep>] [--root <p>]
   0. entrypoint 発見（既定: CWD で flake.nix → shell.nix → default.nix。-f で上書き）
-  1. root kind を先取り eval（nix eval <ep>#nput.<system>.<name>.rootKind）→ root 解決 → profileDir 確定（→ ADR-0023）
-  2. 配置エンジン（import）を駆動: flock → ロック内で nix build --out-link → 前世代 diff → 配置 → stale 除去 → nix-env --set
+  1. root kind を先取り eval（nix eval <ep>#nput.<system>.<name>.rootKind。legacy は per-system 次元なし: nix eval -f <ep> nput.<name>.rootKind・→ ADR-0032）→ root 解決 → profileDir 確定（→ ADR-0023）
+  2. 配置エンジン（import）を駆動: flock → ロック内で nix build --out-link（legacy は nix build -f <ep> nput.<name> --out-link ...・→ ADR-0032）→ 前世代 diff → 配置 → stale 除去 → nix-env --set
 ```
 
 > 順序は **eval 先行 → flock → build**（→ ADR-0023）。profileDir は root 解決後にしか確定しない（project / `--root` / fixed 時は `<roothash>`・→ ADR-0024）ため、`mkManifest` が passthru する `rootKind` を安価な `nix eval` で先取りし、flock を取ってから build をロック内で行う。これで profileDir 未確定の循環と、ロック外 build の `.pending` out-link 競合が同時に解消する（`profileDir` は config 専用ディレクトリ・profile リンクは `<profileDir>/profile`・→ ADR-0025）。**非 build コマンド（`reset` / `rollback` / `list-generations`）も profileDir 確定のため rootKind eval を先行する**。**`apply --all` は rootKind を 1 回の一括 eval（`--apply` で config 名 → rootKind マップ）で取り**、build だけ config ごとに回す（→ ADR-0024）。
@@ -441,6 +456,7 @@ E2E は `tests/e2e/`（bash ハーネス・実 nix 使用・偽 src は fixture 
 - **stale 除去**: entry を config から削除 → 再 apply で旧 symlink が消える（保守的不変条件）
 - **copy place-once / out-of-store**: copy が通常ファイル（書込可）・place-once 冪等（ローカル編集を破棄しない）・out-of-store の live symlink
 - **HM module**: home-manager standalone configuration を非 NixOS で評価・activate し、activation が engine を起動して配置する
+- **legacy entrypoint**: `shell.nix`（passthru 形・`NIX_PATH` を flake.lock の nixpkgs に pin）で `nput apply` / `apply --all` / 素の `nix-shell` 互換を検証（→ ADR-0032）
 
 NixOS VM テスト（`runNixOSTest`）はモジュール経路を実装する段で追加する（上記 E2E ハーネスのスコープ外・将来拡張）。
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -184,6 +184,8 @@ entrypoint は `nput.<name>` に named manifest（`mkManifest` の結果）を�
 > ```
 >
 > legacy entrypoint には flake の `<system>` に相当する次元が無く、addressing はフラットな `nput.<name>` になる（→ 下記「アドレッシング」表）。複数 manifest の一括処理は既存の `apply --all` の一括 eval（`nix eval -f <ep> nput --apply … --json`）でそのまま充足し、`mkShell` の `inputsFrom` で manifest を合成するヘルパは持たない（1 profile = 1 config の atomic 性・→ ADR-0002 と衝突するため）。
+>
+> **`src` の store 化は自動ではない**: flake は評価前にディレクトリ全体が store へコピーされるため相対 path リテラル（`src = ./foo;`）がそのまま store symlink になるが、legacy（`-f` eval）にはこの事前コピーが無く、相対 path はファイルの実位置基準で解決される live な作業木パスのまま manifest に載る（→ ADR-0032）。reproducible / store-backed にしたい場合は `src` に `builtins.path { path = ./foo; }` や `fetchTarball` / `builtins.fetchGit` など明示的に store へ add する手段を使う。
 
 `<name>` = `default` は flake の `default` 慣例に倣う特別な名前で、`nput apply`（name 省略）が解決先に使う。専用 `nput` 名前空間を使い `packages` を汚さない（manifest が通常パッケージとして `nix flake show` / `nix build` に混ざらない・→ ADR-0007）。
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -164,9 +164,26 @@ entrypoint は `nput.<name>` に named manifest（`mkManifest` の結果）を�
 |---|---|---|
 | `flake.nix`（直書き）| `outputs.nput.<system>.<name> = mkManifest { ... }` | `nix build <ep>#nput.<system>.<name>`（CLI が現行 `<system>` を差し込む）|
 | `flake.nix`（flake-parts）| `perSystem.nput.<name> = mkManifest { inherit pkgs; ... }`（flakeModule 経由）| `nix build <ep>#nput.<system>.<name>`（同上）|
-| `default.nix` / `shell.nix` | `{ nput.<name> = mkManifest { ... }; }`（トップレベル）| `nix-build <ep> -A nput.<name>` |
+| `default.nix` / `shell.nix`（passthru・canonical・→ ADR-0032）| `pkgs.mkShell { ...; passthru.nput.<name> = mkManifest { ... }; }` | `nix build -f <ep> nput.<name>` |
+| `default.nix` / `shell.nix`（トップレベル attrset）| `{ nput.<name> = mkManifest { ... }; }` | `nix build -f <ep> nput.<name>` |
 
 > **flake-parts 経路（→ ADR-0029）**: flake-parts を使う repo は `imports = [ inputs.nput.flakeModules.default ]` の上で `perSystem.nput.<name> = mkManifest { inherit pkgs; ... }` を宣言する。flake-parts が `flake.nput.<system>.<name>` へ **transpose** し、直書きと**同一の derivation を生む**（CLI のアドレッシングは不変）。`pkgs` が perSystem 由来になり `packages.nput` と一貫する（二重解決なし）。flake-parts 利用者にはこちらが canonical で、直書きは plain flake と `shell.nix` / `default.nix` の canonical。`mkManifest` は両形で唯一の公開 API（flakeModule の option は `mkManifest` の derivation を格納するだけ）。
+
+> **legacy entrypoint の canonical 形（→ ADR-0032）**: `shell.nix` / `default.nix` は **nixpkgs `mkShell` と共存できる passthru 形**を canonical とする。`shell.nix` は素の `mkShell` derivation を返し、`passthru.nput.<name>` に named manifest を載せる（`project` template の devShell 同梱・→ ADR-0015 と両立する）。`passthru` はホスト derivation の attrset にマージされるため、**CLI が叩く attr path（`nput.<name>`）はトップレベル attrset 形と同一**で実装分岐を持たない。素の `nix-shell`（`-A` 不要）はどちらの形でも壊れない。
+>
+> ```nix
+> # shell.nix（canonical: passthru 形）
+> { pkgs ? import <nixpkgs> {}, nput ? import (fetchTarball "https://github.com/yasunori0418/nput/archive/....tar.gz") }:
+> pkgs.mkShell {
+>   packages = [ ];
+>   shellHook = "nput apply skills --no-wait";
+>   passthru.nput = {
+>     skills = nput.lib.mkManifest { inherit pkgs; root = nput.lib.projectRoot; entries = { }; };
+>   };
+> }
+> ```
+>
+> legacy entrypoint には flake の `<system>` に相当する次元が無く、addressing はフラットな `nput.<name>` になる（→ 下記「アドレッシング」表）。複数 manifest の一括処理は既存の `apply --all` の一括 eval（`nix eval -f <ep> nput --apply … --json`）でそのまま充足し、`mkShell` の `inputsFrom` で manifest を合成するヘルパは持たない（1 profile = 1 config の atomic 性・→ ADR-0002 と衝突するため）。
 
 `<name>` = `default` は flake の `default` 慣例に倣う特別な名前で、`nput apply`（name 省略）が解決先に使う。専用 `nput` 名前空間を使い `packages` を汚さない（manifest が通常パッケージとして `nix flake show` / `nix build` に混ざらない・→ ADR-0007）。
 
@@ -291,7 +308,7 @@ nput init project      # nix flake init -t github:yasunori0418/nput#project の�
 nput apply <name> [-f <ep>] [--root <p>]
   0. entrypoint 発見（-f 上書き）
   1. root kind を先取り eval:
-     nix eval <ep>#nput.<system>.<name>.rootKind（legacy は nix eval -f <ep> nput.<name>.rootKind）
+     nix eval <ep>#nput.<system>.<name>.rootKind（legacy は per-system 次元なし: nix eval -f <ep> nput.<name>.rootKind・→ ADR-0032）
      → root 解決（kind: project=git rev-parse / home=$HOME / system=/ / 固定パス、--root 上書き）
      → profileDir 確定（home: <name> / project: <roothash>/<name>。--root 明示時は全モード <roothash>/<name>・→ ADR-0023）
        ※ rootKind は mkManifest の passthru として eval 時に確定（git toplevel / $HOME の実体解決は engine 実行時）
@@ -302,7 +319,7 @@ nput apply <name> [-f <ep>] [--root <p>]
         （例: `nput: another apply in progress, skipped (run \`nput apply\` manually)`・シェル入室はブロックしない・→ ADR-0022）。
         同一 profileDir への同時実行はユーザー責任で衝突時は後勝ち（→ ADR-0013）
      b. ロック内で nix build <ep>#nput.<system>.<name> --out-link <profileDir>/.pending
-        （legacy は nix-build <ep> -A nput.<name> --out-link <profileDir>/.pending）
+        （legacy は nix build -f <ep> nput.<name> --out-link <profileDir>/.pending・→ ADR-0032）
         → os.Readlink で link-farm store path を得る。out-link が indirect gcroot を張り
           配置〜--set の GC 窓を塞ぐ（→ ADR-0011）。build がロック内なので out-link 競合は構造的に起きない（→ ADR-0023）
      c. profileDir の前世代 manifest.json を読む（無ければ初回 = 削除対象ゼロ）
@@ -314,7 +331,7 @@ nput apply <name> [-f <ep>] [--root <p>]
 ```
 
 - **非 build コマンド（`reset` / `rollback` / `list-generations`）も eval 先行を共通前段に持つ**（→ ADR-0024）。build はしないが、profileDir 単位の flock / 前世代 manifest 読みのため profileDir 確定（= rootKind 先取り eval → root 解決）が前提になる。`--root` 上書き時は §「root の解決」と同じ roothash キーで profileDir を引く（`--root` を付けた世代を操作するには同じ `--root` が要る）。`reset` はさらに entries 読みのため entrypoint eval も行う。
-- **`apply --all` は rootKind を 1 回の一括 eval で取る**（→ ADR-0024）。`nix eval <ep>#nput.<system> --apply 'cs: builtins.mapAttrs (_: c: c.rootKind) cs' --json`（legacy は対応する `-f` 形）で config 名 → rootKind マップを 1 回で取得し、各 profileDir を確定する。`--project-root` 等のフィルタもこの結果で振り分ける。build だけは atomic 性のため config ごと N 回。eval プロセス起動コストを N→1 に固定する。
+- **`apply --all` は rootKind を 1 回の一括 eval で取る**（→ ADR-0024）。`nix eval <ep>#nput.<system> --apply 'cs: builtins.mapAttrs (_: c: c.rootKind) cs' --json`（legacy は per-system 次元なし: `nix eval -f <ep> nput --apply 'cs: …' --json`・→ ADR-0032）で config 名 → rootKind マップを 1 回で取得し、各 profileDir を確定する。`--project-root` 等のフィルタもこの結果で振り分ける。build だけは atomic 性のため config ごと N 回。eval プロセス起動コストを N→1 に固定する。
 - `--dryrun` は root kind を eval し root を解決するが（プラン表示のため）、link-farm を build しても配置しない読み取り専用なので、flock も pending gcroot（out-link）も取らない（→ ADR-0011, ADR-0023）。
 - `--set`（f）到達前に apply が失敗すると `<profileDir>/.pending` gcroot が残り、ビルド済み未使用 link-farm を掴み続けるが、次回 apply が**同名**（`.pending`）で上書きするため config あたり最大 1 個に有界。回収処理は持たず許容する（→ ADR-0016）。
 - **`apply --manifest <link-farm>` は 0〜1（entrypoint 発見・rootKind 先取り eval）と 2b（ロック内 `nix build`）を skip する**（→ ADR-0026）。ビルド済み link-farm を engine へ直接渡し、rootKind は link-farm 内 `manifest.json` から engine が読む。2a（flock 取得）以降〜2g は通常 apply と同一。pending out-link は build しないため張らない。host / module activation（HM 等）が switch 時に使う経路で、`-f` / `--all` とは取得元衝突で併用エラー。

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -31,6 +31,7 @@ fixture flake は `nput` を `path:<repo>` input で参照し、`nixpkgs` / `hom
 | `04-copy`    | copy place-once / out-of-store。copy が通常ファイル（書込可）・place-once 冪等（ローカル編集を破棄しない）・out-of-store の live symlink |
 | `05-hm`      | HM module。home-manager standalone configuration を非 NixOS で評価・activate し、activation が engine を起動して配置すること |
 | `06-init-templates` | init + templates。`nput init <t>` で standalone / project テンプレを展開し、展開後 flake が `nix flake check`（nput を局所 override）を通ること |
+| `07-legacy`  | legacy entrypoint（shell.nix・passthru canonical 形・→ ADR-0032）。`NIX_PATH` を flake.lock の nixpkgs に pin し、`nput apply` / `apply --all` / 素の `nix-shell` 互換を検証 |
 
 ## 将来拡張
 

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -129,3 +129,21 @@ e2e_flake_inputs() {
 
 # nput を実行する（dirty git tree 警告など stderr ノイズは通すが、結果はアサーションで判定）。
 nput() { command "$NPUT" "$@"; }
+
+# legacy（shell.nix / default.nix）シナリオ用: flake.lock がピン留めした nixpkgs の store path を
+# NIX_PATH にエクスポートする（legacy entrypoint は `<nixpkgs>` を NIX_PATH 経由で解決する best-effort
+# impure eval のため・→ ADR-0007 §5, ADR-0032）。使い捨ての probe flake で他 fixture と同じ
+# `inputs.nixpkgs.follows = "nput/nixpkgs"` pin を再利用し、offline で解決する。
+e2e_pin_nix_path() {
+	local probe="$E2E_WORK/nixpkgs-probe"
+	mkdir -p "$probe"
+	cat >"$probe/flake.nix" <<EOF
+{
+$(e2e_flake_inputs)
+  outputs = { self, nixpkgs, nput }: { nixpkgsPath = nixpkgs.outPath; };
+}
+EOF
+	local path
+	path="$(nix eval --raw "$probe#nixpkgsPath")"
+	export NIX_PATH="nixpkgs=$path"
+}

--- a/tests/e2e/scenarios/07-legacy.sh
+++ b/tests/e2e/scenarios/07-legacy.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# legacy entrypoint (shell.nix, passthru canonical form): `nput apply` / `apply --all` /
+# plain `nix-shell` compatibility (→ ADR-0032).
+set -euo pipefail
+source "$(dirname "$0")/../lib.sh"
+e2e_isolate
+e2e_pin_nix_path
+
+PROJ="$E2E_WORK/proj"
+mkdir -p "$PROJ/srcrepo/skills/nix"
+echo "SKILLBODY" >"$PROJ/srcrepo/skills/nix/SKILL.md"
+
+cat >"$PROJ/shell.nix" <<EOF
+{ pkgs ? import <nixpkgs> {}
+, nput ? { lib = import $REPO_ROOT/lib; }
+}:
+pkgs.mkShell {
+  packages = [ ];
+  shellHook = "nput apply docs --no-wait";
+  passthru.nput = {
+    docs = nput.lib.mkManifest {
+      inherit pkgs;
+      root = nput.lib.projectRoot;
+      entries.".nput-out/docs" = { src = ./srcrepo; subpath = "skills/nix"; };
+    };
+    extra = nput.lib.mkManifest {
+      inherit pkgs;
+      root = nput.lib.projectRoot;
+      entries.".nput-out/extra" = { src = ./srcrepo; subpath = "skills/nix"; };
+    };
+  };
+}
+EOF
+
+cd "$PROJ"
+git init -q
+git -c user.email=e2e@nput.test -c user.name=e2e add -A
+git -c user.email=e2e@nput.test -c user.name=e2e commit -qm init
+
+e2e_step "nput apply docs（legacy shell.nix・passthru 形）"
+nput apply docs
+
+e2e_step "git toplevel 配下に配置されたか"
+TARGET="$PROJ/.nput-out/docs"
+assert_symlink "$TARGET"
+assert_file_eq "$TARGET/SKILL.md" "SKILLBODY"
+# flake（01-project.sh）と異なり、legacy -f eval には flake の事前 store コピーが無いため、素の相対
+# path リテラル `src = ./srcrepo` は toString でも store へコピーされず生の作業木パスのまま解決される
+# （→ ADR-0007 §5「impure eval を許容」の具体的帰結。reproducible にしたいユーザーは builtins.path /
+# fetchTarball 等で明示的に store 化する）。よってここでは store symlink であることまでは assert しない。
+
+e2e_step "nput apply --all（passthru.nput.* を一括適用）"
+nput apply --all
+assert_symlink "$PROJ/.nput-out/extra"
+assert_file_eq "$PROJ/.nput-out/extra/SKILL.md" "SKILLBODY"
+
+e2e_step "素の nix-shell がそのまま動く（passthru に壊されない）＋ shellHook が apply を kick する"
+rm -rf "$PROJ/.nput-out"
+nix-shell --run true "$PROJ/shell.nix"
+assert_symlink "$TARGET"
+assert_file_eq "$TARGET/SKILL.md" "SKILLBODY"
+
+e2e_finish


### PR DESCRIPTION
## 概要

shell.nix / default.nix（legacy entrypoint）対応を実装した(#112、親 epic #107)。ADR-0007 §5 で
採用済みだった decision に対し、実装(cmd/nput/nix.go)が明示的に拒否していた乖離を解消する。
entrypoint の作りは nixpkgs mkShell と共存できる passthru 形(`passthru.nput.<name>`)を canonical
とし、CLI の attr path はトップレベル attrset 形と同一の `nput.<name>`(実装分岐なし)。nix コマンド
は新 CLI `-f` 形(`nix build -f <ep> nput.<name>` / `nix eval -f <ep> nput.<name>.rootKind`)に統一。

## 関連 issue

Closes #112

## docs / ADR 影響

- **ADR-0032 新規追加**(`docs/adr/0032-legacy-entrypoint-passthru-canonical.md`): passthru canonical /
  attr path 共通性 / `nix build -f` 統一の decision。ADR-0007 に back-ref 注記を追加(§4 の
  `nix-build -A` 記述を改訂)。
- `docs/spec.md` / `docs/design.md`: アドレッシング表・実行フロー・legacy canonical 形(passthru)の
  使用例を反映。あわせて、e2e で実際に検証して判明した「legacy では `src` の相対 path が flake と異なり
  自動で store コピーされない(`toString` では add-to-store が起きない)」という Nix の挙動差を明記
  (ADR-0007 §5「reproducibility はユーザー責任」の decision 自体は不変、その射程の明確化)。
- `tests/e2e/`: legacy シナリオ `07-legacy`(passthru 形 fixture + `NIX_PATH` を flake.lock の
  nixpkgs に pin)を追加し、`apply` / `apply --all` / 素の `nix-shell` 互換を検証。README にも追記。

## 動作確認

- `go build ./... && go vet ./... && go test ./...` — 全て pass(`discoverEntrypoint` の legacy 分岐・
  `installableArgs`/`namespaceArgs` の nix 引数組み立てを table-driven でカバー)
- `nix flake check`(treefmt / go-vet / golangci-lint / nix-unit / namaka / hm-module 含む) — pass
- `nix develop '.?dir=dev#ci' -c tests/e2e/run.sh` — 既存 6 シナリオ + 新規 `07-legacy` の計 7 シナリオ
  すべて pass(regression なし)

https://claude.ai/code/session_01TBJuRk9ceDZnkE6gWRZvzz