### PR TITLE
feat(engine): 自己記録の祖先 symlink 配下ネストを許可（前世代 manifest 判定の祖先拡張 + 配置前除去・ADR-0046）

### DIFF
--- a/docs/adr/0015-pre-impl-remaining-semantics.md
+++ b/docs/adr/0015-pre-impl-remaining-semantics.md
@@ -15,6 +15,12 @@
 > **同一 entrypoint 内**（`apply --all` の対象 config 間）の衝突は、`--all` の前段（一括 eval + CLI 検査）で検出して **error 停止**
 > するよう改訂した。別 entrypoint・別ツール・project と fixed の偶然の一致など**検出不能な衝突は本 ADR の実行時後勝ち + warning の
 > まま不変**（→ ADR-0038）。
+>
+> **2026-07-12 改訂注記（ADR-0046）**: 本 ADR §4 の「target の祖先 component が symlink なら配置前に一律 error 停止」は、
+> **foreign 祖先のみ error / 自己記録 stale 祖先（前世代 manifest が記録し on-disk が記録 dest と一致し、かつ次世代に無い symlink）は
+> migration** へ改訂した。§2 の「前世代 manifest 記録の symlink は置換可（silent・後勝ち）」判定を祖先へ拡張し、緩和対象の祖先は配置**前**に
+> 除去（`Plan.PreRemove`）してから配下子を新規配置する。foreign 祖先・自己矛盾（次世代にも祖先が残る）・`prev == nil` は**従来通り
+> error 停止**で store 汚染の担保は不変（→ ADR-0046）。
 
 ## 背景
 

--- a/docs/adr/0046-self-recorded-ancestor-nest-migration.md
+++ b/docs/adr/0046-self-recorded-ancestor-nest-migration.md
@@ -42,7 +42,7 @@ foreign（他 nput profile / 他ツール / 手動作成 = 記録 dest と不一
 - `Plan` に **`PreRemove []RemoveAction`** を新設。planner が緩和対象の祖先を PreRemove に載せる（複数の子が同一祖先を検出しても **dedup** して 1 件）。
 - 既存 stale ループは、同 target が PreRemove 済みなら**スキップ**（二重除去回避）。
 - engine は **PreRemove → place → copies → removeStale** の順で流す。ADR-0006 の本流（新を先に置いてから旧を消す）は不変で、**局所例外のみ**を明示的に前段へ置く。順序決定が planner に閉じるため純粋・テスト可能（ADR-0003 の役割分担と一致）。
-- 除去は removeStale と同じ**保守的不変条件を配置直前に再検証**してから unlink する（planning と実行の間のドリフトに対する安全確認は共通）。
+- 除去は removeStale と同じ**保守的不変条件を配置直前に再検証**してから unlink する。ただしドリフト時の扱いは非対称: removeStale は最終段なので残置して warning にとどめるが、**PreRemove は前段**で走り後続 place が「祖先除去済み」を前提に子を無条件配置するため、祖先がドリフト（例: foreign symlink へ張替え）していたら skip せず **error 停止**する（skip して子配置を続行すると drift 後の祖先 symlink 経由で foreign 配下へ子を書き ADR-0015 §4 の汚染を再び開くため）。冪等再実行で現状の FS に対し再計画され収束する（ADR-0017）。
 
 ### 4. 報告は既定 silent・`-v` で可視・warning にはしない
 

--- a/docs/adr/0046-self-recorded-ancestor-nest-migration.md
+++ b/docs/adr/0046-self-recorded-ancestor-nest-migration.md
@@ -1,0 +1,81 @@
+# ADR-0046: 自己記録の祖先 symlink 配下ネストを許可する — 前世代 manifest 判定の祖先拡張 + 配置前除去（PreRemove）
+
+- ステータス: 採用
+- 日付: 2026-07-12
+- 関連: ADR-0002, ADR-0003, ADR-0006, ADR-0013, ADR-0015, ADR-0017, ADR-0031, ADR-0038, `docs/spec.md`, GitHub Issue #170
+- 改訂対象: **ADR-0015 §4**「target の祖先 component が symlink なら配置前に一律 error 停止」を「**foreign 祖先のみ error / 自己記録 stale 祖先は migration（配置前除去）**」へ改訂。**ADR-0015 §2**「前世代 manifest 記録の symlink は置換可（silent・後勝ち）」の判定を祖先へ拡張。
+- 起点: dotfiles 側での実遭遇（#170）と、次期マイルストーンの grilling セッション（2026-07-11）で設計確定
+
+## 背景
+
+`.claude/skills` のような**全体 symlink** entry を、配下に子 entry をネストする形（`.claude/skills/foo`, `.claude/skills/bar`, …）へ移行しようとすると、apply が丸ごと失敗する。原因は 2 段に分かれる。
+
+1. **判定**: `ancestorSymlink`（`internal/planner/planner.go`）が祖先 symlink を検出すると、それが**自 profile の前世代 manifest が記録した symlink**であっても `Compute` が一律 conflict を積む（ADR-0015 §4）。
+2. **収束不能**: `len(plan.Conflicts) > 0` で engine の `Apply()` が早期 return し、`place` も `removeStale` も走らない。結果、旧世代の全体 symlink も除去されず、新旧どちらの状態にも収束しない（`nixos-rebuild switch` しても新 entries が 1 つも配置されない）。
+
+実運用では、親 entry → 子 entry 群への定義変更のたびに apply 前に対象 symlink を手動 `rm` する回避策が要り、「設定を宣言的に管理する」という nput の思想と相性が悪い。
+
+一方で ADR-0015 §4 の一律停止は「foreign symlink 配下へネストすると `os.MkdirAll` が symlink-to-store を既存 dir と見なし read-only store へ書く / dangling を作る」汚染を防ぐための安全策であり、**未知の祖先に対しては維持したい**。緩和したいのは「自分が前世代に置いた symlink を、自分が次世代で消して子へ張り替える」既知・安全なケースだけである。
+
+## 決定
+
+### 1. 緩和条件は recorded ∧ stale の AND
+
+祖先 symlink の conflict を外して migration へ振るのは、下記を**すべて**満たすときに限る。
+
+1. **recorded**: 前世代 manifest がその祖先 target を entry として記録し、on-disk symlink が記録 dest と一致（`recordedLink` 相当の保守的不変条件・ADR-0002 / ADR-0015 §2）。
+2. **stale**: その祖先 target が**次世代 manifest に無い**（＝除去予定）。
+3. **帰結**: 次世代にも祖先 entry が残る**自己矛盾 manifest**（`.claude/skills` symlink と `.claude/skills/foo` を同時に持つ）は緩和せず **true conflict のまま維持**する。親 symlink を消せない以上ネストできないため。
+
+foreign（他 nput profile / 他ツール / 手動作成 = 記録 dest と不一致 or 前世代に無い）・`prev == nil`・初回 apply は**従来通り error 停止**を維持する。**既知（自己記録 stale）のみ silent 移行・未知は安全停止**という非対称を保ち、store 汚染の担保を損なわない。
+
+### 2. 子 entry は lstat を経ず無条件に absent 配置する
+
+祖先 symlink が緩和対象のとき、配下子 entry は **lstat 結果を使わず「target 不在」として配置**する（symlink → `PlaceNew` / copy → place-once の `CopyAction`）。
+
+理由: OS の lstat は中間 component（緩和対象の祖先 symlink）を辿るため、`root/.claude/skills/foo` は前世代 farm の中身 `store/…/skills/foo` を指して**存在するように見える**。通常分類に落とすと `PlaceForeign` / 構造衝突と誤認して **store 内へ書き込もうとする**（ADR-0015 §4 が防いでいた汚染そのもの）。祖先を配置前に除去する前提なので、子は不在として新規配置してよい。
+
+### 3. 順序例外は `Plan.PreRemove` で planner に閉じる
+
+「自己記録 stale 祖先 symlink を配置**前**に除去」を純粋関数 planner の中でデータとして表現する。
+
+- `Plan` に **`PreRemove []RemoveAction`** を新設。planner が緩和対象の祖先を PreRemove に載せる（複数の子が同一祖先を検出しても **dedup** して 1 件）。
+- 既存 stale ループは、同 target が PreRemove 済みなら**スキップ**（二重除去回避）。
+- engine は **PreRemove → place → copies → removeStale** の順で流す。ADR-0006 の本流（新を先に置いてから旧を消す）は不変で、**局所例外のみ**を明示的に前段へ置く。順序決定が planner に閉じるため純粋・テスト可能（ADR-0003 の役割分担と一致）。
+- 除去は removeStale と同じ**保守的不変条件を配置直前に再検証**してから unlink する（planning と実行の間のドリフトに対する安全確認は共通）。
+
+### 4. 報告は既定 silent・`-v` で可視・warning にはしない
+
+自己記録祖先の移行は**意図された安全操作**なので、除去した祖先を warning としては出さず、通常の配置レポートと同じ経路（`result.Removed`）に畳む。既定沈黙・`-v` で可視というレポート規律（ADR-0031・#52 の -v opt-in）と一貫させる。`--dryrun` では自己記録 stale 祖先を**非 conflict の removal** として、foreign 祖先を conflict として報告する。
+
+### 5. 失敗時の意味論（#168 と独立）
+
+PreRemove で親 symlink を除去した後に子配置が途中失敗すると世代未コミットのまま中間状態が残るが、**冪等再実行で FS は正しい最終状態へ収束する**（ADR-0017 と一貫）。再実行時、親は実 dir 化して `ancestorSymlink` は offender を返さず、既配置子は張替え、旧 stale 記録は放置される。#168（undo ジャーナル・ADR-0044）マージ後は中間失敗が atomic に巻き戻るが、**#168 に hard 依存させず本 ADR 単独で出荷**する（PreRemove 段を #168 の undo 対象に含める seam だけ用意する）。
+
+### 6. 前提（前世代 manifest の取得）は全 mode 共通で成立する
+
+緩和は「前世代 manifest が祖先 target を記録している」ことを前提とする。これは特定 mode の性質ではなく**全 mode 共通**に成立する。緩和ロジックは mode 非依存の純粋関数 `planner.Compute`（rootKind を受け取らない）に閉じ、前世代 manifest 読み込みは mode 固有分岐（project の世代スキップ等）**より前**に走る。profile + manifest は store でも ephemeral でもなく state dir に**永続**するため、前世代が同一 profile に commit 済みなら HM / standalone / devShells（project）いずれでも読める。親→子は derivation が変わるため project でも**世代スキップされず**通常 apply（PreRemove + place）が走る。config 名の改名・repo の別パス移動・初回 apply では `prev == nil` → foreign 扱いで**従来通り conflict 停止**（安全側フォールバック）。これは本 ADR で新設する挙動ではなく既存の世代モデルの帰結。
+
+## 根拠
+
+- **recorded ∧ stale の AND** は「自分が置いて自分が消す」ケースだけを最小の条件で切り出す。recorded だけだと自己矛盾 manifest まで緩和してしまい親を消せないのに子を置く矛盾に陥る。stale だけだと foreign を緩和して store 汚染が復活する。
+- **子の無条件 absent 配置**は ADR-0015 §4 の汚染防止を維持したまま migration を成立させる唯一の手段。除去前の lstat は祖先 symlink を辿るため信用できない、という事実に対する正しい対処。
+- **PreRemove を planner に閉じる**のは ADR-0003（planner=純粋にプラン決定 / engine=FS 反映）の役割分担に沿う。engine 側で暗黙に順序を解決すると純粋性・テスト可能性が崩れる。
+- **warning にしない**のは ADR-0031 の成功時沈黙と一貫。意図された安全操作を warning にすると本当に注意すべき foreign 上書きの警告が埋もれる。
+- **#168 への非依存**は本 epic を独立に出荷可能にする。冪等再実行で収束する（ADR-0017）ため、atomic 巻き戻しは品質改善であって前提条件ではない。
+
+## 影響
+
+- **`internal/planner/planner.go`**: `Plan.PreRemove` 追加。`Compute` の祖先 conflict 生成部を緩和条件で分岐（recorded ∧ stale ∧ ¬kept → PreRemove + 子 absent 配置 / それ以外 → conflict）。`ancestorSymlink` が offender の root 相対 target も返す。stale ループが PreRemove 済み target を skip。
+- **`internal/engine/`**: PreRemove を place の前段で実行。除去祖先を `result.Removed` へ畳む。dryrun も PreRemove を Removed としてパック。gen-skip 経路では PreRemove が構造的に空になる旨を明記。
+- **`docs/adr/0015-*.md`**: §4 に本 ADR への改訂注記（back-ref）を追記。本文は当時のまま（ADR-0008 の慣例）。
+- **`docs/spec.md`**: 配置動作（祖先 symlink 非対称）・エラー仕様表（祖先 symlink を foreign 限定の error へ・自己記録 stale は migration）・実行フロー（PreRemove 段）を反映。
+- **cross-epic**: #168（undo・ADR-0044）は PreRemove 段を undo 対象に含める。#167 / #149 は `planner.go` / `engine.go` を共有するため同時着手時は rebase 調整（hard 依存なし）。#126（--json）/ #131（変更系 niface）は PreRemove を出力サーフェスへどう表すかで接触（先行側が seam を用意）。
+
+## 棄却した代替案
+
+- **運用回避（apply 前の手動 `rm`）を維持**: 移行のたびに手作業が要り宣言的管理の思想に反する。
+- **engine 側で暗黙に順序解決 / グローバル順序反転**: ADR-0006 の本流（新を先に・旧を最後に）を壊し、純粋 planner の外に順序判断が漏れる。局所例外を PreRemove として明示する方が安全。
+- **祖先 symlink 検出時に常時 warning を出して置換**: foreign symlink 配下への誤 nest（store 汚染）まで通してしまう。ADR-0015 §4 の安全策が失われる。
+- **#170 で自前 undo を実装 / #168 へ hard 依存**: 冪等再実行で収束する（ADR-0017）ため自前 undo は不要。#168 へ hard 依存させると独立出荷できない。
+- **recorded のみ（stale 条件を外す）で緩和**: 自己矛盾 manifest（次世代に祖先が残る）まで緩和し、親を消せないのに子を置く矛盾を生む。

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -332,7 +332,7 @@ nput apply <name> [-f <ep>] [--root <p>]
      c. profileDir の前世代 manifest.json を読む（無ければ初回 = 削除対象ゼロ）
      d. project mode かつ新 link-farm が前世代と同一なら新世代は積まない（世代スキップ）。ただし各 target を lstat 検査し、
         ドリフトした entry だけ再張りする（完全 no-op にしない・→ ADR-0017）
-     e. manifest.json を新旧 diff → 新規/張替を配置 → 保守的 stale 除去（ネイティブ FS）
+     e. manifest.json を新旧 diff → 自己記録 stale 祖先 symlink を配置前除去（PreRemove・ネスト移行・→ ADR-0046）→ 新規/張替を配置 → 保守的 stale 除去（ネイティブ FS）
      f. nix-env --profile <profileDir>/profile --set <link-farm>（サブプロセス・コミット点）
      g. --set 成功後に <profileDir>/.pending を削除（世代リンクが gcroot を引き継ぐ・→ ADR-0011）
 ```
@@ -565,9 +565,12 @@ engine が**ネイティブ FS 操作**で行う（`ln` / `rsync` は使わな�
 ### symlink モード
 
 ```
-0. target の各祖先 component を lstat で walk。いずれかが symlink ならエラーで停止（→ ADR-0015）
-   （祖先が全体 symlink 配置のとき、その配下にネストできない。store 汚染 / dangling を防ぐ）
-1. target の親ディレクトリを作成（mkdir -p 相当。祖先 symlink は 0 で弾き済み）
+0. target の各祖先 component を lstat で walk。symlink の祖先があれば非対称に扱う:
+   - 自己記録 stale（自身の前世代 manifest が記録・on-disk が記録 dest と一致・次世代に無い）
+     → その祖先を配置前に除去（PreRemove）し、配下子を新規配置してネスト移行する（silent・`-v` で可視・→ ADR-0046）
+   - foreign（記録なし / 記録 dest と不一致 / 前世代なし）または次世代にも祖先が残る自己矛盾
+     → エラーで停止（配下にネストできない。store 汚染 / dangling を防ぐ・→ ADR-0015 §4, ADR-0046）
+1. target の親ディレクトリを作成（mkdir -p 相当。緩和対象の祖先 symlink は PreRemove 除去済み・foreign は 0 で弾き済み）
 2. target が既存 symlink のとき:
    - 自身の前世代 manifest が記録した symlink → そのまま置き換える（silent）
    - 記録の無い symlink（foreign = 他 nput profile / 他ツール / 手動）→ warning を出して置き換える（後勝ち・→ ADR-0015）
@@ -913,7 +916,8 @@ devShells.default = pkgs.mkShell {
 | `src` が marker でローカルパスが存在しない | engine 実行時にエラーで停止 |
 | `subpath` が `src` 内に存在しないパス | engine 実行時にエラーで停止 |
 | `target` に通常ファイル・ディレクトリが既存（symlink モード）| エラーで停止（上書きしない）|
-| `target` の祖先 component が symlink（全体 symlink 配置の配下にネスト）| engine 実行時にエラーで停止（lstat walk・`--dryrun` は conflict・→ ADR-0015）|
+| `target` の祖先 component が foreign symlink（記録なし / 記録 dest と不一致 / 前世代なし）、または次世代にも祖先が残る自己矛盾 | engine 実行時にエラーで停止（lstat walk・`--dryrun` は conflict・→ ADR-0015 §4, ADR-0046）|
+| `target` の祖先 component が自己記録 stale symlink（前世代 manifest が記録・on-disk 一致・次世代に無い）| 祖先を配置前に除去（PreRemove）し配下子を新規配置してネスト移行（silent・`-v` で可視・`--dryrun` は非 conflict の remove・→ ADR-0046）|
 | `target` に foreign symlink が既存（自身の前世代 manifest に記録なし・別 config / 別ツール / 手動）| warning を出して後勝ちで置き換える（→ ADR-0015）|
 | `subpath` がディレクトリのとき `target` に通常ファイルが既存（copy モード）| エラーで停止 |
 | `subpath` がファイルのとき `target` がディレクトリとして既存（copy モード）| エラーで停止 |

--- a/internal/engine/drift.go
+++ b/internal/engine/drift.go
@@ -45,6 +45,10 @@ func generationUnchanged(profileLink, newLinkFarm string) (bool, error) {
 //     edits) produce no CopyAction and are left untouched (→ docs/spec.md "project mode
 //     generations" · ADR-0022). On --recopy, recopyAll overwrites unconditionally (recopy is
 //     an opt-in outside generations).
+//
+// plan.PreRemove is structurally empty on this path: an ancestor→children migration changes the
+// manifest, hence the link-farm derivation, so generationUnchanged is never true and the gen-skip
+// branch is not taken (→ ADR-0046). The drift repair therefore has no pre-removal to run.
 func (a *applier) repairDrift(plan planner.Plan, recopy bool) error {
 	drifted := make([]planner.PlaceAction, 0, len(plan.Place))
 	for _, act := range plan.Place {

--- a/internal/engine/drift.go
+++ b/internal/engine/drift.go
@@ -1,6 +1,7 @@
 package engine
 
 import (
+	"fmt"
 	"path/filepath"
 
 	"github.com/yasunori0418/nput/internal/planner"
@@ -50,6 +51,13 @@ func generationUnchanged(profileLink, newLinkFarm string) (bool, error) {
 // manifest, hence the link-farm derivation, so generationUnchanged is never true and the gen-skip
 // branch is not taken (→ ADR-0046). The drift repair therefore has no pre-removal to run.
 func (a *applier) repairDrift(plan planner.Plan, recopy bool) error {
+	// Defensive guard for the invariant the doc comment relies on: a migration changes the manifest
+	// (hence the derivation), so it can never reach the gen-skip path with a non-empty PreRemove.
+	// If that ever breaks, silently dropping the pre-removal would let place nest children through a
+	// live ancestor symlink — fail loudly instead (→ ADR-0046).
+	if len(plan.PreRemove) > 0 {
+		return fmt.Errorf("nput: internal invariant violated: generation-skip drift repair received %d ancestor pre-removal(s) (→ ADR-0046)", len(plan.PreRemove))
+	}
 	drifted := make([]planner.PlaceAction, 0, len(plan.Place))
 	for _, act := range plan.Place {
 		if act.Kind == planner.PlaceReplace {

--- a/internal/engine/dryrun_test.go
+++ b/internal/engine/dryrun_test.go
@@ -76,3 +76,48 @@ func TestApplyDryRunConflict(t *testing.T) {
 		t.Errorf("conflicting entry should not be planned for place, Placed = %v", res.Placed)
 	}
 }
+
+// TestApplyDryRunAncestorMigration verifies that apply --dryrun reports a self-recorded stale
+// ancestor migration as a (non-conflict) removal plus child placements and leaves the FS
+// untouched (→ ADR-0046).
+func TestApplyDryRunAncestorMigration(t *testing.T) {
+	root := realTempDir(t)
+	state := realTempDir(t)
+
+	// First apply commits a whole-tree symlink at .claude/skills (sets up the previous generation).
+	// srcOld deliberately does not contain "foo", so lstat of the child through the still-present
+	// ancestor symlink resolves to nothing and the "FS untouched" check below is meaningful.
+	srcOld := makeSrc(t, "other")
+	lf1 := writeLinkFarm(t, projectManifest(storeEntry(srcOld, ".", ".claude/skills")))
+	if _, err := Apply(Options{
+		LinkFarm: lf1, Name: "c", RootOverride: root, StateDir: state, Commit: fakeCommit(nil),
+	}); err != nil {
+		t.Fatalf("first Apply: %v", err)
+	}
+
+	// Dryrun the migration to nested children.
+	srcNew := makeSrc(t, "foo")
+	lf2 := writeLinkFarm(t, projectManifest(storeEntry(srcNew, "foo", ".claude/skills/foo")))
+	res, err := Apply(Options{
+		LinkFarm: lf2, Name: "c", RootOverride: root, StateDir: state, DryRun: true,
+	})
+	if err != nil {
+		t.Fatalf("dryrun Apply: %v", err)
+	}
+	if len(res.Conflicts) != 0 {
+		t.Errorf("Conflicts = %v, want none (a self-recorded ancestor is a migration, not a conflict)", res.Conflicts)
+	}
+	if len(res.Removed) != 1 || res.Removed[0] != ".claude/skills" {
+		t.Errorf("Removed = %v, want [.claude/skills]", res.Removed)
+	}
+	if len(res.Placed) != 1 || res.Placed[0] != ".claude/skills/foo" {
+		t.Errorf("Placed = %v, want [.claude/skills/foo]", res.Placed)
+	}
+	// FS untouched: the ancestor symlink is still present and the child was not created.
+	if got, err := os.Readlink(filepath.Join(root, ".claude", "skills")); err != nil || got != srcOld {
+		t.Errorf(".claude/skills should be untouched in dryrun = %q (err %v); want symlink to %q", got, err, srcOld)
+	}
+	if _, err := os.Lstat(filepath.Join(root, ".claude", "skills", "foo")); !os.IsNotExist(err) {
+		t.Errorf("child should not be created in dryrun, lstat err = %v", err)
+	}
+}

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -233,9 +233,13 @@ func Apply(opts Options) (*Result, error) {
 		}
 	}
 
-	// 8. reflect the plan onto the real FS (new / re-link first, stale removal last · → ADR-0006).
-	//    symlinks are plan-driven. copy branches: on --recopy overwrite all copy targets unconditionally,
-	//    normally place-once (new copy only when target is absent) (→ ADR-0020).
+	// 8. reflect the plan onto the real FS. PreRemove first (unlink self-recorded stale ancestor
+	//    symlinks so nested children land in a real dir · local exception to ADR-0006 · → ADR-0046),
+	//    then new / re-link, then stale removal last (→ ADR-0006). copy branches: on --recopy overwrite
+	//    all copy targets unconditionally, normally place-once (new copy only when target is absent) (→ ADR-0020).
+	if err := a.preRemove(plan.PreRemove); err != nil {
+		return nil, err
+	}
 	if err := a.place(plan.Place); err != nil {
 		return nil, err
 	}
@@ -319,6 +323,9 @@ func (a *applier) dryRun() (*Result, error) {
 	}
 	for _, c := range plan.Copies {
 		a.result.Copied = append(a.result.Copied, c.Entry.Target)
+	}
+	for _, r := range plan.PreRemove {
+		a.result.Removed = append(a.result.Removed, r.Entry.Target)
 	}
 	for _, r := range plan.Remove {
 		a.result.Removed = append(a.result.Removed, r.Entry.Target)

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -272,11 +272,17 @@ func TestApplyAncestorSelfRecordedMigration(t *testing.T) {
 		storeEntry(srcNew, "foo", ".claude/skills/foo"),
 		storeEntry(srcNew, "bar", ".claude/skills/bar"),
 	))
+	var warns []string
 	res, err := Apply(Options{
-		LinkFarm: lf2, Name: "c", RootOverride: root, StateDir: state, Commit: fakeCommit(&commits),
+		LinkFarm: lf2, Name: "c", RootOverride: root, StateDir: state,
+		Commit: fakeCommit(&commits), Warnf: collectWarnings(&warns),
 	})
 	if err != nil {
 		t.Fatalf("second Apply (migration): %v", err)
+	}
+	// The migration is a silent, intended operation: it must not surface any warning (→ ADR-0046 §4, ADR-0031).
+	if len(warns) != 0 {
+		t.Errorf("migration emitted warnings, want none: %v", warns)
 	}
 
 	// .claude/skills is now a real directory (the ancestor symlink was pre-removed).

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -233,6 +233,83 @@ func TestApplyAncestorSymlinkError(t *testing.T) {
 	}
 }
 
+// TestApplyAncestorSelfRecordedMigration verifies that a whole-tree symlink recorded by this
+// profile's own previous generation migrates to nested child entries without a manual rm: the
+// ancestor symlink is pre-removed and the children are placed fresh against the new src, not
+// misclassified through the still-present ancestor into the old farm (→ ADR-0046).
+func TestApplyAncestorSelfRecordedMigration(t *testing.T) {
+	root := realTempDir(t)
+	state := realTempDir(t)
+
+	// Previous generation: a whole-tree symlink at .claude/skills → srcOld. srcOld itself holds
+	// foo/bar, so a naive lstat through the ancestor symlink would find them and misclassify the
+	// children (the store-pollution risk the relaxation avoids by placing them unconditionally).
+	srcOld := realTempDir(t)
+	for _, name := range []string{"foo", "bar"} {
+		if err := os.WriteFile(filepath.Join(srcOld, name), []byte("old"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	lf1 := writeLinkFarm(t, projectManifest(storeEntry(srcOld, ".", ".claude/skills")))
+	var commits [][2]string
+	if _, err := Apply(Options{
+		LinkFarm: lf1, Name: "c", RootOverride: root, StateDir: state, Commit: fakeCommit(&commits),
+	}); err != nil {
+		t.Fatalf("first Apply: %v", err)
+	}
+	if got, err := os.Readlink(filepath.Join(root, ".claude", "skills")); err != nil || got != srcOld {
+		t.Fatalf(".claude/skills after first apply = %q (err %v); want symlink to %q", got, err, srcOld)
+	}
+
+	// New generation: replace the whole-tree symlink with nested children pointing at srcNew.
+	srcNew := realTempDir(t)
+	for _, name := range []string{"foo", "bar"} {
+		if err := os.WriteFile(filepath.Join(srcNew, name), []byte("new"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	lf2 := writeLinkFarm(t, projectManifest(
+		storeEntry(srcNew, "foo", ".claude/skills/foo"),
+		storeEntry(srcNew, "bar", ".claude/skills/bar"),
+	))
+	res, err := Apply(Options{
+		LinkFarm: lf2, Name: "c", RootOverride: root, StateDir: state, Commit: fakeCommit(&commits),
+	})
+	if err != nil {
+		t.Fatalf("second Apply (migration): %v", err)
+	}
+
+	// .claude/skills is now a real directory (the ancestor symlink was pre-removed).
+	info, err := os.Lstat(filepath.Join(root, ".claude", "skills"))
+	if err != nil {
+		t.Fatalf(".claude/skills lstat: %v", err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		t.Errorf(".claude/skills is still a symlink after migration, want a real directory")
+	}
+	// Each child is a fresh symlink into srcNew, not a srcOld leftover.
+	for _, name := range []string{"foo", "bar"} {
+		got, err := os.Readlink(filepath.Join(root, ".claude", "skills", name))
+		if err != nil {
+			t.Fatalf("child %s readlink: %v", name, err)
+		}
+		if wantDest := filepath.Join(srcNew, name); got != wantDest {
+			t.Errorf("child %s → %q, want %q", name, got, wantDest)
+		}
+	}
+	// The ancestor is reported removed and both children placed.
+	if len(res.Removed) != 1 || res.Removed[0] != ".claude/skills" {
+		t.Errorf("Removed = %v, want [.claude/skills]", res.Removed)
+	}
+	placed := map[string]bool{}
+	for _, p := range res.Placed {
+		placed[p] = true
+	}
+	if len(res.Placed) != 2 || !placed[".claude/skills/foo"] || !placed[".claude/skills/bar"] {
+		t.Errorf("Placed = %v, want [.claude/skills/foo .claude/skills/bar]", res.Placed)
+	}
+}
+
 func TestApplyExistingRegularFileError(t *testing.T) {
 	root := realTempDir(t)
 	src := makeSrc(t, "x")

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -310,6 +310,69 @@ func TestApplyAncestorSelfRecordedMigration(t *testing.T) {
 	}
 }
 
+// TestApplyAncestorSelfRecordedMigrationCopyChild verifies the migration when the nested child is
+// a copy entry: the ancestor symlink is pre-removed, .claude/skills becomes a real directory, and
+// the child is materialized as a real (owner-writable) copied file, not a symlink (→ ADR-0046).
+func TestApplyAncestorSelfRecordedMigrationCopyChild(t *testing.T) {
+	root := realTempDir(t)
+	state := realTempDir(t)
+
+	// Previous generation: whole-tree symlink at .claude/skills → srcOld (holds foo, so a naive
+	// lstat through the ancestor would find it and misclassify the copy child).
+	srcOld := realTempDir(t)
+	if err := os.WriteFile(filepath.Join(srcOld, "foo"), []byte("old"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	lf1 := writeLinkFarm(t, projectManifest(storeEntry(srcOld, ".", ".claude/skills")))
+	var commits [][2]string
+	if _, err := Apply(Options{
+		LinkFarm: lf1, Name: "c", RootOverride: root, StateDir: state, Commit: fakeCommit(&commits),
+	}); err != nil {
+		t.Fatalf("first Apply: %v", err)
+	}
+
+	// New generation: nest a copy child under the (now stale) ancestor symlink.
+	srcNew := makeSrc(t, "foo") // srcNew/foo = "content"
+	lf2 := writeLinkFarm(t, projectManifest(copyEntry(srcNew, "foo", ".claude/skills/foo")))
+	res, err := Apply(Options{
+		LinkFarm: lf2, Name: "c", RootOverride: root, StateDir: state, Commit: fakeCommit(&commits),
+	})
+	if err != nil {
+		t.Fatalf("second Apply (copy-child migration): %v", err)
+	}
+
+	// .claude/skills is now a real directory (ancestor symlink pre-removed).
+	info, err := os.Lstat(filepath.Join(root, ".claude", "skills"))
+	if err != nil {
+		t.Fatalf(".claude/skills lstat: %v", err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		t.Errorf(".claude/skills is still a symlink, want a real directory")
+	}
+	// The child is a real copied file (not a symlink) carrying the new content.
+	child := filepath.Join(root, ".claude", "skills", "foo")
+	ci, err := os.Lstat(child)
+	if err != nil {
+		t.Fatalf("child lstat: %v", err)
+	}
+	if ci.Mode()&os.ModeSymlink != 0 {
+		t.Errorf("copy child is a symlink, want a real file")
+	}
+	data, err := os.ReadFile(child)
+	if err != nil {
+		t.Fatalf("child read: %v", err)
+	}
+	if string(data) != "content" {
+		t.Errorf("child content = %q, want \"content\"", data)
+	}
+	if len(res.Removed) != 1 || res.Removed[0] != ".claude/skills" {
+		t.Errorf("Removed = %v, want [.claude/skills]", res.Removed)
+	}
+	if len(res.Copied) != 1 || res.Copied[0] != ".claude/skills/foo" {
+		t.Errorf("Copied = %v, want [.claude/skills/foo]", res.Copied)
+	}
+}
+
 func TestApplyExistingRegularFileError(t *testing.T) {
 	root := realTempDir(t)
 	src := makeSrc(t, "x")

--- a/internal/engine/staleremove.go
+++ b/internal/engine/staleremove.go
@@ -30,15 +30,21 @@ func (a *applier) removeStale(actions []planner.RemoveAction) error {
 
 // preRemove unlinks the self-recorded stale ancestor symlinks the planner scheduled for
 // migration, re-verifying the conservative invariant against the real FS right before each
-// unlink (the same check removeStale uses). It runs *before* place so nested children land in
-// a real directory instead of resolving through the previous farm's symlink (local ordering
-// exception to ADR-0006 · → ADR-0046). Removed ancestors are folded into result.Removed: the
-// migration is silent by default and surfaced only under -v, never as a warning (→ ADR-0031).
+// unlink. It runs *before* place so nested children land in a real directory instead of
+// resolving through the previous farm's symlink (local ordering exception to ADR-0006 · → ADR-0046).
+// Removed ancestors are folded into result.Removed: the migration is silent by default and
+// surfaced only under -v, never as a warning (→ ADR-0031).
+//
+// Unlike removeStale — the last stage, where keeping a drifted link is harmless — a drifted
+// ancestor here is *not* safe to skip: the children under it were planned as unconditional new
+// placements that assume the ancestor is gone, so continuing would nest them through the drifted
+// symlink (e.g. one swapped to a foreign, writable dir) and re-open the ADR-0015 §4 pollution that
+// place/ensureParentDir do not re-guard. So on drift it aborts loudly instead of skipping; an
+// idempotent re-run re-plans against the current FS and converges (→ ADR-0017, ADR-0046).
 func (a *applier) preRemove(actions []planner.RemoveAction) error {
 	for _, act := range actions {
 		if !reverifyStale(act) {
-			a.opts.Warnf("nput: skipping ancestor migration because it drifted after planning: %s", act.Entry.Target)
-			continue
+			return fmt.Errorf("nput: ancestor symlink changed after planning; cannot migrate its nesting safely (%s); re-run apply to converge", act.Entry.Target)
 		}
 		if err := os.Remove(act.TargetAbs); err != nil {
 			return fmt.Errorf("nput: cannot remove ancestor symlink for migration (%s): %w", act.TargetAbs, err)

--- a/internal/engine/staleremove.go
+++ b/internal/engine/staleremove.go
@@ -28,6 +28,26 @@ func (a *applier) removeStale(actions []planner.RemoveAction) error {
 	return nil
 }
 
+// preRemove unlinks the self-recorded stale ancestor symlinks the planner scheduled for
+// migration, re-verifying the conservative invariant against the real FS right before each
+// unlink (the same check removeStale uses). It runs *before* place so nested children land in
+// a real directory instead of resolving through the previous farm's symlink (local ordering
+// exception to ADR-0006 · → ADR-0046). Removed ancestors are folded into result.Removed: the
+// migration is silent by default and surfaced only under -v, never as a warning (→ ADR-0031).
+func (a *applier) preRemove(actions []planner.RemoveAction) error {
+	for _, act := range actions {
+		if !reverifyStale(act) {
+			a.opts.Warnf("nput: skipping ancestor migration because it drifted after planning: %s", act.Entry.Target)
+			continue
+		}
+		if err := os.Remove(act.TargetAbs); err != nil {
+			return fmt.Errorf("nput: cannot remove ancestor symlink for migration (%s): %w", act.TargetAbs, err)
+		}
+		a.result.Removed = append(a.result.Removed, act.Entry.Target)
+	}
+	return nil
+}
+
 // reverifyStale re-checks the conservative invariant on the real FS right before
 // unlink: the target must still be a symlink pointing to the recorded dest.
 func reverifyStale(act planner.RemoveAction) bool {

--- a/internal/planner/planner.go
+++ b/internal/planner/planner.go
@@ -160,6 +160,11 @@ func Compute(prev, next *manifest.Manifest, root string, fs FS) (Plan, error) {
 			return Plan{}, err
 		}
 		if offenderAbs != "" {
+			// offenderRel is the cleaned root-relative ancestor path; matching it against
+			// nextByTarget / prevByTarget (keyed by the raw manifest target) relies on targets being
+			// canonical — the same convention the rest of the planner already assumes (byTarget keys,
+			// placement's filepath.Clean). A non-canonical ancestor target simply fails to match here
+			// and degrades safely to a conflict; it never mis-migrates.
 			_, keptInNext := nextByTarget[offenderRel]
 			if !keptInNext && recordedLink(offenderRel, offenderAbs, prevByTarget, fs) {
 				if !preRemoved[offenderRel] {

--- a/internal/planner/planner.go
+++ b/internal/planner/planner.go
@@ -110,12 +110,19 @@ type Warning struct {
 }
 
 // Plan is the computed place/replace/remove plan plus non-fatal warnings and
-// fatal conflicts. The engine executes Place / Copies then Remove ("new/re-link
-// first, stale removal last"; → ADR-0006); a non-empty Conflicts means apply must stop.
+// fatal conflicts. The engine executes PreRemove → Place / Copies → Remove
+// ("new/re-link first, stale removal last"; PreRemove is a local ordering exception
+// that unlinks self-recorded stale ancestor symlinks *before* placement so children
+// nest into a real directory; → ADR-0006, ADR-0046); a non-empty Conflicts means apply must stop.
 type Plan struct {
-	Place     []PlaceAction
-	Copies    []CopyAction
-	Remove    []RemoveAction
+	Place  []PlaceAction
+	Copies []CopyAction
+	Remove []RemoveAction
+	// PreRemove unlinks self-recorded stale ancestor symlinks before placement, so a
+	// previous-generation whole-tree symlink can migrate to nested child entries without a
+	// manual rm. Populated only for ancestors the previous generation recorded and the new
+	// generation drops (recorded ∧ stale); foreign or still-kept ancestors stay Conflicts (→ ADR-0046).
+	PreRemove []RemoveAction
 	Conflicts []Conflict
 	Warnings  []Warning
 }
@@ -137,19 +144,43 @@ func Compute(prev, next *manifest.Manifest, root string, fs FS) (Plan, error) {
 
 	// --- place / replace side: classify each new-generation entry against the current FS ---
 	prevByTarget := byTarget(prev)
+	nextByTarget := byTarget(next)
+	// preRemoved dedups ancestors scheduled for pre-removal migration: several children can
+	// detect the same ancestor symlink, but it is unlinked once (→ ADR-0046).
+	preRemoved := map[string]bool{}
 	for _, e := range entriesOf(next) {
 		targetAbs := filepath.Join(root, filepath.Clean(e.Target))
 
-		// If an ancestor component is a symlink, nesting is forbidden: conflict (common to all methods; → ADR-0015).
-		offender, err := ancestorSymlink(root, e.Target, fs)
+		// If an ancestor component is a symlink, nesting is normally forbidden (→ ADR-0015). The one
+		// exception is a symlink this profile's own previous generation recorded and the new generation
+		// drops (recorded ∧ stale): migrate it — schedule a pre-removal and place the child as new —
+		// instead of stopping (→ ADR-0046).
+		offenderAbs, offenderRel, err := ancestorSymlink(root, e.Target, fs)
 		if err != nil {
 			return Plan{}, err
 		}
-		if offender != "" {
+		if offenderAbs != "" {
+			_, keptInNext := nextByTarget[offenderRel]
+			if !keptInNext && recordedLink(offenderRel, offenderAbs, prevByTarget, fs) {
+				if !preRemoved[offenderRel] {
+					preRemoved[offenderRel] = true
+					plan.PreRemove = append(plan.PreRemove, RemoveAction{Entry: prevByTarget[offenderRel], TargetAbs: offenderAbs})
+				}
+				// The child currently resolves *through* the ancestor symlink into the previous farm,
+				// so an lstat here would misclassify it against store content (the pollution ADR-0015 §4
+				// guarded). After PreRemove the ancestor is gone and the child is absent, so place it as
+				// new unconditionally without probing the FS (→ ADR-0046).
+				if err := appendAbsentPlacement(&plan, e, targetAbs); err != nil {
+					return Plan{}, err
+				}
+				continue
+			}
+			// foreign ancestor, or the new generation still keeps the ancestor (self-contradictory):
+			// the ancestor symlink cannot be removed, so nesting stays a conflict (→ ADR-0015, ADR-0046).
 			plan.Conflicts = append(plan.Conflicts, Conflict{
 				Entry:     e,
 				TargetAbs: targetAbs,
-				Reason:    fmt.Sprintf("ancestor %q is a symlink; cannot nest beneath it (→ ADR-0015)", offender),
+				Reason:    fmt.Sprintf("ancestor %q is a symlink; cannot nest beneath it (→ ADR-0015)", offenderAbs),
 			})
 			continue
 		}
@@ -192,9 +223,12 @@ func Compute(prev, next *manifest.Manifest, root string, fs FS) (Plan, error) {
 	// --- remove side: compute stale entries (prev ∖ next) under the conservative invariant ---
 	// On first apply (prev == nil) nothing is removed (→ ADR-0006).
 	if prev != nil {
-		nextByTarget := byTarget(next)
 		for _, pe := range prev.Entries {
 			if _, kept := nextByTarget[pe.Target]; kept {
+				continue
+			}
+			if preRemoved[pe.Target] {
+				// Already scheduled for pre-removal migration; do not remove it twice (→ ADR-0046).
 				continue
 			}
 			if pe.Method == manifest.MethodCopy {
@@ -305,6 +339,23 @@ func classifyCopy(plan *Plan, e manifest.Entry, targetAbs string, prevByTarget m
 	}
 }
 
+// appendAbsentPlacement records the placement for an entry whose target is known to be absent
+// (a child nesting under a to-be-pre-removed ancestor symlink): a new symlink, or a place-once
+// copy. It mirrors the "target absent" arms of the normal per-method classification without
+// probing the FS, which would misread store content through the still-present ancestor symlink
+// (→ ADR-0046).
+func appendAbsentPlacement(plan *Plan, e manifest.Entry, targetAbs string) error {
+	switch e.Method {
+	case manifest.MethodSymlink:
+		plan.Place = append(plan.Place, PlaceAction{Entry: e, TargetAbs: targetAbs, Dest: LinkDest(e), Kind: PlaceNew})
+	case manifest.MethodCopy:
+		plan.Copies = append(plan.Copies, CopyAction{Entry: e, TargetAbs: targetAbs, Src: LinkDest(e)})
+	default:
+		return fmt.Errorf("nput: unknown method: %q (target: %s)", e.Method, e.Target)
+	}
+	return nil
+}
+
 // copyStructureMismatch reports whether the dir/file kind of src (<src>/<subpath>)
 // disagrees with the kind of the existing target (subpath dir × target file /
 // subpath file × target dir; → docs/spec.md). A symlink target has IsDir()=false
@@ -317,11 +368,13 @@ func copyStructureMismatch(e manifest.Entry, targetInfo os.FileInfo, fs FS) (boo
 	return srcInfo.IsDir() != targetInfo.IsDir(), nil
 }
 
-// ancestorSymlink walks the target's ancestor components under root and returns
-// the first existing ancestor that is a symlink (cannot nest under a whole-tree
-// symlink placement; → ADR-0015). A non-existent ancestor stops the walk (its descendants don't exist
-// either), returning "" with no error.
-func ancestorSymlink(root, target string, fs FS) (string, error) {
+// ancestorSymlink walks the target's ancestor components under root and returns the first
+// existing ancestor that is a symlink, as both its absolute path and its root-relative
+// (cleaned) target. The caller needs the relative target to look the offender up in the
+// prev/next manifests and decide whether it is a self-recorded stale link eligible for
+// pre-removal migration (→ ADR-0015, ADR-0046). A non-existent ancestor stops the walk (its
+// descendants don't exist either), returning "", "" with no error.
+func ancestorSymlink(root, target string, fs FS) (abs, rel string, err error) {
 	clean := filepath.Clean(target)
 	comps := strings.Split(clean, string(os.PathSeparator))
 	cur := root
@@ -330,16 +383,21 @@ func ancestorSymlink(root, target string, fs FS) (string, error) {
 			continue
 		}
 		cur = filepath.Join(cur, comps[i])
-		info, err := fs.Lstat(cur)
-		if err != nil {
-			if os.IsNotExist(err) {
-				return "", nil
+		if rel == "" {
+			rel = comps[i]
+		} else {
+			rel = filepath.Join(rel, comps[i])
+		}
+		info, lerr := fs.Lstat(cur)
+		if lerr != nil {
+			if os.IsNotExist(lerr) {
+				return "", "", nil
 			}
-			return "", fmt.Errorf("nput: cannot lstat ancestor (%s): %w", cur, err)
+			return "", "", fmt.Errorf("nput: cannot lstat ancestor (%s): %w", cur, lerr)
 		}
 		if info.Mode()&os.ModeSymlink != 0 {
-			return cur, nil
+			return cur, rel, nil
 		}
 	}
-	return "", nil
+	return "", "", nil
 }

--- a/internal/planner/planner_test.go
+++ b/internal/planner/planner_test.go
@@ -86,6 +86,7 @@ type want struct {
 	placeForeign []string
 	copies       []string
 	remove       []string
+	preRemove    []string
 	warns        []WarnKind
 	conflicts    int
 }
@@ -103,6 +104,14 @@ func placeTargets(p Plan, kind PlaceKind) []string {
 func removeTargets(p Plan) []string {
 	var out []string
 	for _, a := range p.Remove {
+		out = append(out, a.Entry.Target)
+	}
+	return out
+}
+
+func preRemoveTargets(p Plan) []string {
+	var out []string
+	for _, a := range p.PreRemove {
 		out = append(out, a.Entry.Target)
 	}
 	return out
@@ -209,6 +218,60 @@ func TestComputeTableDriven(t *testing.T) {
 			next: mani(sl(srcB, ".claude/skills/nix")),
 			fs:   fakeFS{abs(".claude"): sym("/some/store")},
 			want: want{conflicts: 1},
+		},
+		{
+			// Self-recorded stale ancestor symlink (prev recorded .claude/skills, on-disk matches, next
+			// drops it for children): migrate — pre-remove the ancestor and place children as new,
+			// deduping the ancestor across multiple children (→ ADR-0046).
+			name: "self-recorded stale ancestor → migrate (preRemove + child PlaceNew)",
+			prev: mani(sl(srcA, ".claude/skills")),
+			next: mani(sl(srcB, ".claude/skills/foo"), sl(srcB, ".claude/skills/bar")),
+			fs: fakeFS{
+				abs(".claude"):        dir(),
+				abs(".claude/skills"): sym(srcA),
+			},
+			want: want{
+				placeNew:  []string{".claude/skills/foo", ".claude/skills/bar"},
+				preRemove: []string{".claude/skills"},
+			},
+		},
+		{
+			// Recorded ancestor but the on-disk symlink points elsewhere (mismatch = foreign / user-swapped):
+			// not eligible for migration, the child stays a conflict; the ancestor is kept with a stale-mismatch
+			// warning by the remove side (→ ADR-0046).
+			name: "foreign ancestor (recorded mismatch) → conflict",
+			prev: mani(sl(srcA, ".claude/skills")),
+			next: mani(sl(srcB, ".claude/skills/foo")),
+			fs: fakeFS{
+				abs(".claude"):        dir(),
+				abs(".claude/skills"): sym("/foreign"),
+			},
+			want: want{conflicts: 1, warns: []WarnKind{WarnStaleMismatch}},
+		},
+		{
+			// The new generation keeps the ancestor whole-tree symlink AND a nested child
+			// (self-contradictory): the ancestor cannot be removed, so the child stays a conflict while
+			// the ancestor entry itself re-links as a recorded replace (→ ADR-0046).
+			name: "self-contradictory ancestor (kept in next) → conflict",
+			prev: mani(sl(srcA, ".claude/skills")),
+			next: mani(sl(srcB, ".claude/skills"), sl(srcB, ".claude/skills/foo")),
+			fs: fakeFS{
+				abs(".claude"):        dir(),
+				abs(".claude/skills"): sym(srcA),
+			},
+			want: want{
+				placeReplace: []string{".claude/skills"},
+				conflicts:    1,
+			},
+		},
+		{
+			// Recorded stale ancestor but already gone on disk: ancestorSymlink stops at the missing
+			// component, so the child classifies normally as a new placement and nothing is pre-removed.
+			name: "recorded ancestor already gone → plain place",
+			prev: mani(sl(srcA, ".claude/skills")),
+			next: mani(sl(srcB, ".claude/skills/foo")),
+			fs:   fakeFS{abs(".claude"): dir()},
+			want: want{placeNew: []string{".claude/skills/foo"}},
 		},
 		{
 			// stale matches record: satisfies the conservative invariant, so remove.
@@ -348,6 +411,7 @@ func TestComputeTableDriven(t *testing.T) {
 			sortedEq(t, "placeForeign", placeTargets(plan, PlaceForeign), tt.want.placeForeign)
 			sortedEq(t, "copies", copyTargets(plan), tt.want.copies)
 			sortedEq(t, "remove", removeTargets(plan), tt.want.remove)
+			sortedEq(t, "preRemove", preRemoveTargets(plan), tt.want.preRemove)
 			warnEq(t, warnKinds(plan), tt.want.warns)
 			if len(plan.Conflicts) != tt.want.conflicts {
 				t.Errorf("conflicts = %d, want %d (%v)", len(plan.Conflicts), tt.want.conflicts, plan.Conflicts)

--- a/internal/planner/planner_test.go
+++ b/internal/planner/planner_test.go
@@ -236,6 +236,21 @@ func TestComputeTableDriven(t *testing.T) {
 			},
 		},
 		{
+			// Same migration but the nested child is a copy entry: it becomes a place-once CopyAction
+			// (the "target absent" copy arm), not a symlink placement (→ ADR-0046).
+			name: "self-recorded stale ancestor, copy child → migrate (preRemove + copy)",
+			prev: mani(sl(srcA, ".claude/skills")),
+			next: mani(cp(srcB, ".claude/skills/foo")),
+			fs: fakeFS{
+				abs(".claude"):        dir(),
+				abs(".claude/skills"): sym(srcA),
+			},
+			want: want{
+				copies:    []string{".claude/skills/foo"},
+				preRemove: []string{".claude/skills"},
+			},
+		},
+		{
 			// Recorded ancestor but the on-disk symlink points elsewhere (mismatch = foreign / user-swapped):
 			// not eligible for migration, the child stays a conflict; the ancestor is kept with a stale-mismatch
 			// warning by the remove side (→ ADR-0046).

--- a/internal/planner/planner_test.go
+++ b/internal/planner/planner_test.go
@@ -229,6 +229,12 @@ func TestComputeTableDriven(t *testing.T) {
 			fs: fakeFS{
 				abs(".claude"):        dir(),
 				abs(".claude/skills"): sym(srcA),
+				// The child keys stand in for the files a real lstat would find by resolving through the
+				// ancestor symlink into the previous farm. The relaxation must place children as new
+				// WITHOUT probing them; if the code regressed to normal lstat classification it would see
+				// these regular files and emit conflicts, so their presence keeps this case honest (→ ADR-0046).
+				abs(".claude/skills/foo"): reg(),
+				abs(".claude/skills/bar"): reg(),
 			},
 			want: want{
 				placeNew:  []string{".claude/skills/foo", ".claude/skills/bar"},
@@ -244,9 +250,44 @@ func TestComputeTableDriven(t *testing.T) {
 			fs: fakeFS{
 				abs(".claude"):        dir(),
 				abs(".claude/skills"): sym(srcA),
+				// Stand-in for the file a real lstat would resolve through the ancestor symlink; the copy
+				// child must be planned as a place-once new copy without probing it (→ ADR-0046).
+				abs(".claude/skills/foo"): reg(),
 			},
 			want: want{
 				copies:    []string{".claude/skills/foo"},
+				preRemove: []string{".claude/skills"},
+			},
+		},
+		{
+			// Two distinct stale ancestors dropped and re-nested in the same generation: PreRemove
+			// accumulates both (the slice/dedup map grow across multiple keys, not just repeat one) (→ ADR-0046).
+			name: "two distinct self-recorded stale ancestors → migrate both",
+			prev: mani(sl(srcA, ".claude/skills"), sl(srcA, ".config/nvim")),
+			next: mani(sl(srcB, ".claude/skills/foo"), sl(srcB, ".config/nvim/init.lua")),
+			fs: fakeFS{
+				abs(".claude"):        dir(),
+				abs(".claude/skills"): sym(srcA),
+				abs(".config"):        dir(),
+				abs(".config/nvim"):   sym(srcA),
+			},
+			want: want{
+				placeNew:  []string{".claude/skills/foo", ".config/nvim/init.lua"},
+				preRemove: []string{".claude/skills", ".config/nvim"},
+			},
+		},
+		{
+			// Child nested two levels below the stale ancestor symlink (.claude/skills/sub/foo): the walk
+			// stops at the ancestor and the deeper child is placed new via appendAbsentPlacement (→ ADR-0046).
+			name: "self-recorded stale ancestor, deep child → migrate",
+			prev: mani(sl(srcA, ".claude/skills")),
+			next: mani(sl(srcB, ".claude/skills/sub/foo")),
+			fs: fakeFS{
+				abs(".claude"):        dir(),
+				abs(".claude/skills"): sym(srcA),
+			},
+			want: want{
+				placeNew:  []string{".claude/skills/sub/foo"},
 				preRemove: []string{".claude/skills"},
 			},
 		},


### PR DESCRIPTION
## 概要

自 profile の前世代 manifest が記録した祖先 symlink（例: `.claude/skills` の全体 symlink）配下へ、次世代で子 entry 群（`.claude/skills/foo` 等）をネストする移行を、apply 前の手動 `rm` なしに収束させる。

従来は ADR-0015 §4 が祖先 symlink を一律 conflict とし、`plan.Conflicts` が 1 件でも `Apply()` が早期 return するため、旧世代の全体 symlink も除去されず新旧どちらの状態にも収束しなかった（`nixos-rebuild switch` しても新 entries が 1 つも配置されない）。

本 PR は ADR-0015 §2 の「前世代記録 symlink は置換可（silent・後勝ち）」判定を祖先へ拡張し、**recorded ∧ stale ∧ ¬(次世代にも残る)** を満たす自己記録 stale 祖先のみ緩和する。緩和対象は `Plan.PreRemove` として配置**前**に除去（ADR-0006 本流への局所例外）、配下子は lstat を経ず無条件に新規配置し、除去前の祖先 symlink を辿って store 実体を誤認する ADR-0015 §4 の汚染を構造的に回避する。foreign 祖先・自己矛盾 manifest（次世代にも祖先が残る）・初回 apply は従来通り error 停止で安全側を維持する。

報告は既定 silent・`-v` で可視・warning にはしない（ADR-0031）。`--dryrun` は自己記録 stale 祖先を非 conflict の remove、foreign 祖先を conflict として報告する。#168（undo）へは hard 依存せず、途中失敗しても冪等再実行で収束する（ADR-0017）。

## 関連 issue

Closes #170
Refs #147

## docs / ADR 影響

- **ADR 追加**: ADR-0046（自己記録の祖先 symlink 配下ネストを許可 — 前世代 manifest 判定の祖先拡張 + 配置前除去 PreRemove）を新規起票。
- **ADR 改訂注記**: ADR-0015 §4 の「祖先 symlink 一律 error」を「foreign 祖先のみ error / 自己記録 stale 祖先は migration」へ改訂した旨の back-ref を ADR-0015 側に追記（本文は当時のまま・ADR-0008 慣例）。
- **spec.md**: 配置動作仕様（symlink モード step 0 の foreign/自己記録 非対称）・エラー仕様表（foreign 限定の error 行 + 自己記録 stale の migration 行に分割）・実行フロー e（PreRemove 段）を更新。
