### PR TITLE
feat(engine): 空親ディレクトリ剪定 — 全除去経路（removeStale / preRemove / reset）

### DIFF
--- a/cmd/nput/apply.go
+++ b/cmd/nput/apply.go
@@ -392,7 +392,10 @@ func reportResult(res *engine.Result, name string) {
 	for _, t := range res.Removed {
 		fmt.Fprintf(os.Stderr, "  removed  %s\n", t)
 	}
-	if len(res.Placed)+len(res.Replaced)+len(res.Copied)+len(res.Recopied)+len(res.Removed) == 0 {
+	for _, t := range res.Pruned {
+		fmt.Fprintf(os.Stderr, "  pruned   %s\n", t)
+	}
+	if len(res.Placed)+len(res.Replaced)+len(res.Copied)+len(res.Recopied)+len(res.Removed)+len(res.Pruned) == 0 {
 		fmt.Fprintln(os.Stderr, "  no-op")
 	}
 }

--- a/cmd/nput/reset.go
+++ b/cmd/nput/reset.go
@@ -146,6 +146,9 @@ func reportResetResult(res *engine.ResetResult, name string) {
 	for _, t := range res.KeptForeign {
 		fmt.Fprintf(os.Stderr, "  kept            %s (foreign / record mismatch)\n", t)
 	}
+	for _, t := range res.Pruned {
+		fmt.Fprintf(os.Stderr, "  pruned          %s\n", t)
+	}
 	if len(res.RemovedSymlinks)+len(res.RemovedCopies) == 0 {
 		fmt.Fprintln(os.Stderr, "  no-op")
 	}

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -240,7 +240,7 @@ nput init <template>           # nix flake init -t <nput>#<template> のラッ�
 - `rollback` は **名指し必須**（`--all` 非対応）。全 config を一斉に戻すのは破壊的で footgun、途中失敗で状態が不揃いになり得るため（→ ADR-0018）。
 - `list-generations --all` は home mode の全 config の世代を一覧（読み取り専用）。`gitignore --all` は projectRoot の全 config の target を **ソート + 重複除去**して出力する（repo の `.gitignore` は 1 つなので一括列挙が自然・→ ADR-0018）。
 - `apply <name> --recopy` は通常 apply に加え **config 内の全 copy target を現 `src`/`subpath` から無条件に上書き再コピー**する（→ ADR-0020）。copy は世代外で hash 追跡しないため差分判定はせず無条件。上書きした target をレポート表示し、フラグ自体が opt-in なので確認は出さない。**ローカルの copy 編集は破棄され src 内容に戻る**（= upstream 追従の意図）。symlink 部の世代コミット挙動は不変（copy は世代を増やさない）。
-- `reset <name> [target...]` は配置物を**無い状態へ戻す** teardown（→ ADR-0020）。symlink は stale 除去と同じ**保守的不変条件**（nput 管理・記録通りのみ・foreign は warning で残す）で除去し、**copy target も削除**する（copy を消す唯一の明示手段）。データ損失リスクのため**確認プロンプト**を出すか `--yes` で同意を要求し、削除 target をレポート表示する。**profile / 世代は触らない FS-only teardown** で、config が entry を残す限り次の apply で再配置される（transient・project mode は ADR-0017 の lstat 検査で復帰）。恒久除去は config から entry を消して apply、profile 完全除去は `nix-env --profile <profileDir>/profile --delete-generations`。home / project 両モード可。
+- `reset <name> [target...]` は配置物を**無い状態へ戻す** teardown（→ ADR-0020）。symlink は stale 除去と同じ**保守的不変条件**（nput 管理・記録通りのみ・foreign は warning で残す）で除去し、**copy target も削除**する（copy を消す唯一の明示手段）。symlink・copy いずれの除去後も空親ディレクトリ剪定を適用する（→「空親ディレクトリ剪定」節）。データ損失リスクのため**確認プロンプト**を出すか `--yes` で同意を要求し、削除 target をレポート表示する。**profile / 世代は触らない FS-only teardown** で、config が entry を残す限り次の apply で再配置される（transient・project mode は ADR-0017 の lstat 検査で復帰）。恒久除去は config から entry を消して apply、profile 完全除去は `nix-env --profile <profileDir>/profile --delete-generations`。home / project 両モード可。
 - `reset` は **名指し必須（`--all` 非対応）**（一斉撤去は破壊的 footgun・`rollback --all` 却下と一貫・→ ADR-0018, ADR-0021）。複数撤去は名指しを複数回。**解決後 `profileDir` 単位の blocking flock を取得**して並行 apply / reset と直列化する（→ ADR-0013, ADR-0021）。profileDir 確定のため **rootKind 先取り eval → root 解決**を build しないコマンドでも先行する（apply と共通の前段・`--root` 時は同じ roothash キー・→ ADR-0024）。
 - `reset <name> --dryrun` は**副作用ゼロ**で削除対象（symlink / copy target）を表示して exit する（FS 削除・confirm・flock いずれも行わない・`apply --dryrun` と対称・→ ADR-0021）。終了コードは削除対象の有無に依らず 0。
 - `apply --all --recopy` は**合成可**。`--all`（必要なら `--project-root` 等フィルタ）が選んだ各 config に `--recopy` を適用する（`--recopy` は apply 修飾で `--all` と直交・→ ADR-0021）。
@@ -698,6 +698,27 @@ host（`home-manager --rollback` 等）に一本化する。`nput rollback <name
 |---|---|
 | symlink（store / out-of-store）| **除去する**（ただし上記の保守的不変条件を満たすもののみ）|
 | copy | **除去しない**（ユーザー所有データ）。ただし orphan を警告で通知する |
+
+#### 空親ディレクトリ剪定（→ Issue #174, epic #172 D4）
+
+target を除去した後、その親ディレクトリチェーンを root 方向へ保守的に剪定する
+（HM の `rmdir -p --ignore-fail-on-non-empty` 対称）。nput は配置時に親 dir を
+`mkdir -p` 相当で自動作成するが manifest には記録しないため、剪定しないと
+entry 階層を変更するたびに空 dir が積もり、後続配置を塞ぐ conflict の温床になる。
+
+- **空のときだけ** rmdir する。rmdir は空ディレクトリでしか成功しないため、
+  非空（`ENOTEMPTY`。一部 rmdir(2) 実装では `EEXIST`）は**成功扱いとして黙って残す**
+  （追加ロック不要・TOCTOU 安全。並行書き込みで非空になれば rmdir がそこで失敗し自然に停止する）。
+- **root 自体は絶対に消さない**。親チェーンの走査は root 境界で必ず停止する。
+- **祖先チェーンに symlink が現れたら、それに触れず停止する**（symlink 自体を rmdir すると
+  リンクそのものを消してしまい実体には触れないため、安全側に倒して何もしない）。
+- **適用範囲は全除去経路**: removeStale（apply / rollback から共用）・PreRemove・
+  `reset` の symlink 除去・copy target 削除。除去した target ごとに独立して walk するため、
+  別 entry が同じ dir を共有していれば非空として自然に残る。
+- **出力規律**: 剪定は意図された掃除であり warning にはしない。既定 silent、`-v` で
+  配置レポートに `pruned <path>` として可視化する（→ ADR-0031）。剪定ヘルパ自体の失敗
+  （権限エラー等の異常系。ENOTEMPTY は上記の通り対象外）は、呼び出し元の既存ポリシーに従う:
+  removeStale / `reset` は warning で残置、PreRemove は D3 の一律 error 停止に従う。
 
 ### GC とストレージ解放
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -715,10 +715,18 @@ entry 階層を変更するたびに空 dir が積もり、後続配置を塞ぐ
 - **適用範囲は全除去経路**: removeStale（apply / rollback から共用）・PreRemove・
   `reset` の symlink 除去・copy target 削除。除去した target ごとに独立して walk するため、
   別 entry が同じ dir を共有していれば非空として自然に残る。
+- **PreRemove 経由は Place より前に走る**ため、祖先 symlink の除去で外側の dir が
+  一時的に空になった場合、その場で剪定されたうえで直後の Place（`ensureParentDir` の
+  `mkdir -p`）が同じ dir を作り直すことがある（→ ADR-0046）。最終的な FS 状態は不変
+  （実体として消えたままにはならない）だが、`-v` レポートの `pruned <path>` には
+  「この apply の途中で一度空になった」事実として現れる。
 - **出力規律**: 剪定は意図された掃除であり warning にはしない。既定 silent、`-v` で
   配置レポートに `pruned <path>` として可視化する（→ ADR-0031）。剪定ヘルパ自体の失敗
-  （権限エラー等の異常系。ENOTEMPTY は上記の通り対象外）は、呼び出し元の既存ポリシーに従う:
-  removeStale / `reset` は warning で残置、PreRemove は D3 の一律 error 停止に従う。
+  （権限エラー等の異常系。ENOTEMPTY は上記の通り対象外）は、PreRemove を含む全経路で
+  warning にとどめ、除去自体（target の unlink）は成功として扱う。剪定対象は target 除去
+  で既に空になった祖先であり、後続の子配置が使う dir とは別物のため、剪定失敗は子配置の
+  安全性を損なわない（drift 時に一律 error 停止する D3 の対象＝ancestor symlink 自体の
+  再検証とは別軸・→ ADR-0046）。空 dir の残置は cosmetic な取りこぼしに過ぎない。
 
 ### GC とストレージ解放
 

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -87,6 +87,7 @@ type Result struct {
 	Copied     []string // copy targets newly copied via place-once
 	Recopied   []string // existing copy targets overwritten/re-copied by --recopy (→ ADR-0020)
 	Removed    []string // stale-removed targets
+	Pruned     []string // empty ancestor directories rmdir-ed after a removal (→ Issue #174, #172 (D4))
 	Skipped    bool     // skipped on try-lock contention (NoWait path)
 	DryRun     bool     // read-only preview (Placed etc. are "to be placed" plans · → ADR-0023)
 	Conflicts  []string // conflicts detected in dryrun ("target: reason" · used by the CLI to decide exit 2 · → ADR-0006)

--- a/internal/engine/reset.go
+++ b/internal/engine/reset.go
@@ -178,7 +178,6 @@ func Reset(opts ResetOptions) (*ResetResult, error) {
 		return nil, err
 	}
 	res.RemovedSymlinks = a.result.Removed // actually removed (excludes those kept due to drift)
-	res.Pruned = a.result.Pruned
 
 	removedCopies := make([]string, 0, len(copyTargets))
 	for i, targetAbs := range copyTargets {
@@ -187,11 +186,11 @@ func Reset(opts ResetOptions) (*ResetResult, error) {
 		}
 		removedCopies = append(removedCopies, res.RemovedCopies[i])
 		if err := a.pruneEmptyAncestors(targetAbs); err != nil {
-			warnf("nput: could not prune an empty ancestor directory: %v", err)
+			a.opts.Warnf("nput: could not prune an empty ancestor directory: %v", err)
 		}
 	}
 	res.RemovedCopies = removedCopies
-	res.Pruned = a.result.Pruned
+	res.Pruned = a.result.Pruned // covers both the symlink half (removeStale) and the copy half above
 
 	return res, nil
 }

--- a/internal/engine/reset.go
+++ b/internal/engine/reset.go
@@ -57,6 +57,7 @@ type ResetResult struct {
 	RemovedSymlinks []string // removed (in dryrun, to-be-removed) symlink targets
 	RemovedCopies   []string // removed (in dryrun, to-be-removed) copy targets
 	KeptForeign     []string // symlink targets kept for not satisfying the conservative invariant (foreign / record mismatch)
+	Pruned          []string // empty ancestor directories rmdir-ed after a removal (→ Issue #174, #172 (D4); not computed in dryrun)
 	DryRun          bool     // was a read-only preview
 	Aborted         bool     // aborted at the confirmation prompt
 }
@@ -177,6 +178,7 @@ func Reset(opts ResetOptions) (*ResetResult, error) {
 		return nil, err
 	}
 	res.RemovedSymlinks = a.result.Removed // actually removed (excludes those kept due to drift)
+	res.Pruned = a.result.Pruned
 
 	removedCopies := make([]string, 0, len(copyTargets))
 	for i, targetAbs := range copyTargets {
@@ -184,8 +186,12 @@ func Reset(opts ResetOptions) (*ResetResult, error) {
 			return nil, fmt.Errorf("nput: cannot remove copy target (%s): %w", targetAbs, err)
 		}
 		removedCopies = append(removedCopies, res.RemovedCopies[i])
+		if err := a.pruneEmptyAncestors(targetAbs); err != nil {
+			warnf("nput: could not prune an empty ancestor directory: %v", err)
+		}
 	}
 	res.RemovedCopies = removedCopies
+	res.Pruned = a.result.Pruned
 
 	return res, nil
 }

--- a/internal/engine/staleremove.go
+++ b/internal/engine/staleremove.go
@@ -1,8 +1,12 @@
 package engine
 
 import (
+	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
 
 	"github.com/yasunori0418/nput/internal/planner"
 )
@@ -14,6 +18,10 @@ import (
 // between planning and removal, so the stale-remover re-checks lstat/readlink and
 // unlinks only when the invariant still holds; drifted targets are kept with a
 // warning (→ ADR-0002, ADR-0006, docs/spec.md "stale removal targets and safety invariant").
+// After each unlink it walks the parent chain toward root, pruning ancestors left
+// empty by the removal (→ Issue #174, #172 (D4)); a prune failure is folded
+// into the same keep+warn policy as a drifted target, since the target itself is
+// already gone and nothing is lost by leaving a leftover empty dir.
 func (a *applier) removeStale(actions []planner.RemoveAction) error {
 	for _, act := range actions {
 		if !reverifyStale(act) {
@@ -24,6 +32,9 @@ func (a *applier) removeStale(actions []planner.RemoveAction) error {
 			return fmt.Errorf("nput: cannot remove stale symlink (%s): %w", act.TargetAbs, err)
 		}
 		a.result.Removed = append(a.result.Removed, act.Entry.Target)
+		if err := a.pruneEmptyAncestors(act.TargetAbs); err != nil {
+			a.opts.Warnf("nput: could not prune an empty ancestor directory: %v", err)
+		}
 	}
 	return nil
 }
@@ -41,6 +52,11 @@ func (a *applier) removeStale(actions []planner.RemoveAction) error {
 // symlink (e.g. one swapped to a foreign, writable dir) and re-open the ADR-0015 §4 pollution that
 // place/ensureParentDir do not re-guard. So on drift it aborts loudly instead of skipping; an
 // idempotent re-run re-plans against the current FS and converges (→ ADR-0017, ADR-0046).
+//
+// It also prunes ancestors left empty by the unlink (→ Issue #174); unlike the drift check
+// above, a prune failure does not abort — the migration itself already succeeded, so a
+// leftover empty dir is a cosmetic miss, not a correctness hazard for the child placements
+// that follow.
 func (a *applier) preRemove(actions []planner.RemoveAction) error {
 	for _, act := range actions {
 		if !reverifyStale(act) {
@@ -50,8 +66,66 @@ func (a *applier) preRemove(actions []planner.RemoveAction) error {
 			return fmt.Errorf("nput: cannot remove ancestor symlink for migration (%s): %w", act.TargetAbs, err)
 		}
 		a.result.Removed = append(a.result.Removed, act.Entry.Target)
+		if err := a.pruneEmptyAncestors(act.TargetAbs); err != nil {
+			a.opts.Warnf("nput: could not prune an empty ancestor directory: %v", err)
+		}
 	}
 	return nil
+}
+
+// pruneEmptyAncestors walks removedAbs's parent chain toward a.root, rmdir-ing each
+// ancestor left empty by a removal (→ Issue #174, #172 (D4) · HM `rmdir -p
+// --ignore-fail-on-non-empty` counterpart). rmdir only ever succeeds on an empty
+// directory, so this is TOCTOU-safe without extra locking: a concurrent writer simply
+// makes the dir non-empty again and the walk stops there.
+//
+// Stop conditions: root itself is never removed; a non-empty ancestor (ENOTEMPTY) is
+// left in place and the walk stops there (conservative — never touches directories the
+// removal did not empty); a symlink ancestor stops the walk without touching it (rmdir
+// on a symlink targets the link itself, not what it points at, and a symlink ancestor
+// means the walk has left the tree this removal actually emptied). Pruned dirs are
+// folded into result.Pruned, surfaced only under -v like the rest of the placement
+// report (→ ADR-0031).
+func (a *applier) pruneEmptyAncestors(removedAbs string) error {
+	root := filepath.Clean(a.root)
+	dir := filepath.Dir(removedAbs)
+	for {
+		dir = filepath.Clean(dir)
+		if dir == root || !isWithinRoot(root, dir) {
+			return nil
+		}
+		info, err := os.Lstat(dir)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil
+			}
+			return fmt.Errorf("nput: cannot lstat ancestor directory (%s): %w", dir, err)
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return nil
+		}
+		if err := os.Remove(dir); err != nil {
+			// non-empty dir → ENOTEMPTY on Linux, EEXIST on some BSD/Darwin rmdir(2) implementations;
+			// both mean "left something behind, stop here" rather than a real failure.
+			if errors.Is(err, syscall.ENOTEMPTY) || errors.Is(err, syscall.EEXIST) {
+				return nil
+			}
+			return fmt.Errorf("nput: cannot remove empty ancestor directory (%s): %w", dir, err)
+		}
+		a.result.Pruned = append(a.result.Pruned, dir)
+		dir = filepath.Dir(dir)
+	}
+}
+
+// isWithinRoot reports whether dir is root or a descendant of root, guarding the
+// upward walk from ever stepping outside root's subtree (defense in depth alongside
+// the dir == root stop condition above).
+func isWithinRoot(root, dir string) bool {
+	rel, err := filepath.Rel(root, dir)
+	if err != nil {
+		return false
+	}
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
 }
 
 // reverifyStale re-checks the conservative invariant on the real FS right before

--- a/internal/engine/staleremove.go
+++ b/internal/engine/staleremove.go
@@ -56,7 +56,11 @@ func (a *applier) removeStale(actions []planner.RemoveAction) error {
 // It also prunes ancestors left empty by the unlink (→ Issue #174); unlike the drift check
 // above, a prune failure does not abort — the migration itself already succeeded, so a
 // leftover empty dir is a cosmetic miss, not a correctness hazard for the child placements
-// that follow.
+// that follow. Because this runs before Place, an outer ancestor that the removed ancestor
+// symlink happened to be the sole occupant of can be momentarily pruned here and then
+// recreated fresh by Place's ensureParentDir moments later; that transient prune+recreate
+// is invisible on disk (the end state is unchanged) but shows up in result.Pruned, which
+// callers should read as "emptied at some point during this apply," not "stayed removed."
 func (a *applier) preRemove(actions []planner.RemoveAction) error {
 	for _, act := range actions {
 		if !reverifyStale(act) {
@@ -81,11 +85,14 @@ func (a *applier) preRemove(actions []planner.RemoveAction) error {
 //
 // Stop conditions: root itself is never removed; a non-empty ancestor (ENOTEMPTY) is
 // left in place and the walk stops there (conservative — never touches directories the
-// removal did not empty); a symlink ancestor stops the walk without touching it (rmdir
-// on a symlink targets the link itself, not what it points at, and a symlink ancestor
-// means the walk has left the tree this removal actually emptied). Pruned dirs are
-// folded into result.Pruned, surfaced only under -v like the rest of the placement
-// report (→ ADR-0031).
+// removal did not empty); a symlink *anywhere in dir's path from root* stops the walk
+// without touching it. This must be a full re-check from root on every iteration, not
+// just an Lstat of dir itself: Lstat resolves intermediate path components, so once any
+// ancestor component is a symlink, "dir" as a path silently resolves through it into a
+// foreign subtree — Remove(dir) would then rmdir *through* the symlink and delete real
+// directories outside root's tree that this removal never emptied (the ADR-0015 style
+// pollution this walk must not reopen). Pruned dirs are folded into result.Pruned,
+// surfaced only under -v like the rest of the placement report (→ ADR-0031).
 func (a *applier) pruneEmptyAncestors(removedAbs string) error {
 	root := filepath.Clean(a.root)
 	dir := filepath.Dir(removedAbs)
@@ -94,17 +101,17 @@ func (a *applier) pruneEmptyAncestors(removedAbs string) error {
 		if dir == root || !isWithinRoot(root, dir) {
 			return nil
 		}
-		info, err := os.Lstat(dir)
+		hasSymlink, err := pathHasSymlinkComponent(root, dir)
 		if err != nil {
-			if os.IsNotExist(err) {
-				return nil
-			}
-			return fmt.Errorf("nput: cannot lstat ancestor directory (%s): %w", dir, err)
+			return err
 		}
-		if info.Mode()&os.ModeSymlink != 0 {
+		if hasSymlink {
 			return nil
 		}
 		if err := os.Remove(dir); err != nil {
+			if os.IsNotExist(err) {
+				return nil
+			}
 			// non-empty dir → ENOTEMPTY on Linux, EEXIST on some BSD/Darwin rmdir(2) implementations;
 			// both mean "left something behind, stop here" rather than a real failure.
 			if errors.Is(err, syscall.ENOTEMPTY) || errors.Is(err, syscall.EEXIST) {
@@ -115,6 +122,35 @@ func (a *applier) pruneEmptyAncestors(removedAbs string) error {
 		a.result.Pruned = append(a.result.Pruned, dir)
 		dir = filepath.Dir(dir)
 	}
+}
+
+// pathHasSymlinkComponent reports whether any path component strictly between root and
+// dir (dir itself included) is a symlink, lstat-ing each component from root downward
+// rather than the resolved dir path so an ancestor symlink is caught before Remove(dir)
+// would silently resolve through it (→ pruneEmptyAncestors).
+func pathHasSymlinkComponent(root, dir string) (bool, error) {
+	rel, err := filepath.Rel(root, dir)
+	if err != nil {
+		return false, fmt.Errorf("nput: cannot resolve %q relative to root (%s): %w", dir, root, err)
+	}
+	cur := root
+	for _, comp := range strings.Split(rel, string(filepath.Separator)) {
+		if comp == "" || comp == "." {
+			continue
+		}
+		cur = filepath.Join(cur, comp)
+		info, err := os.Lstat(cur)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return false, nil
+			}
+			return false, fmt.Errorf("nput: cannot lstat ancestor directory (%s): %w", cur, err)
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 // isWithinRoot reports whether dir is root or a descendant of root, guarding the

--- a/internal/engine/staleremove_test.go
+++ b/internal/engine/staleremove_test.go
@@ -369,11 +369,13 @@ func TestRemoveStaleStopsAtSymlinkAncestor(t *testing.T) {
 		t.Fatalf("second Apply: %v", err)
 	}
 
-	// a/b was pruned (real dir, now empty), but "a" itself (a symlink) must survive untouched.
-	for _, p := range res.Pruned {
-		if p == filepath.Join(root, "a") {
-			t.Errorf("Pruned must not include the symlink ancestor %q", p)
-		}
+	// The walk must not touch anything: "a" (the symlink) survives untouched, and critically
+	// elsewhere/b (the real directory "a" resolves to) must also survive. Lstat("root/a/b")
+	// resolves through the symlink "a" to elsewhere/b, so a walk that naively rmdir'd the
+	// resolved path would delete a real directory outside root's tree without ever "touching
+	// a" by name — the bug this test guards against (→ Issue #174).
+	if len(res.Pruned) != 0 {
+		t.Errorf("Pruned = %v, want none (walk must stop before crossing the symlink)", res.Pruned)
 	}
 	info, err := os.Lstat(filepath.Join(root, "a"))
 	if err != nil {
@@ -382,14 +384,113 @@ func TestRemoveStaleStopsAtSymlinkAncestor(t *testing.T) {
 	if info.Mode()&os.ModeSymlink == 0 {
 		t.Errorf("a must remain a symlink, got mode %v", info.Mode())
 	}
+	if _, err := os.Lstat(filepath.Join(elsewhere, "b")); err != nil {
+		t.Errorf("elsewhere/b (what the symlink resolves to) must survive untouched: %v", err)
+	}
+}
+
+// TestRemoveStalePruneFailureIsWarnedNotFatal verifies that a prune failure (the rmdir call
+// itself erroring for a reason other than non-empty — here EACCES from a read-only
+// grandparent) does not roll back or fail the already-successful target removal: the target
+// stays removed, the failure is folded into a warning, and removeStale returns nil (→ Issue
+// #174). Permission-denied is induced by an unwritable grandparent dir; skipped as root since
+// root bypasses the permission bit (false negative).
+func TestRemoveStalePruneFailureIsWarnedNotFatal(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("permission-denied rmdir cannot be induced as root")
+	}
+	grandparent := realTempDir(t)
+	parent := filepath.Join(grandparent, "a")
+	if err := os.Mkdir(parent, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	recordedDest := realTempDir(t)
+	targetAbs := filepath.Join(parent, "foo")
+	if err := os.Symlink(recordedDest, targetAbs); err != nil {
+		t.Fatal(err)
+	}
+	// Removing "parent" (once emptied by the target unlink) requires write on grandparent;
+	// drop it so the prune's rmdir fails with EACCES while the target unlink itself (which
+	// only needs write on "parent") still succeeds.
+	if err := os.Chmod(grandparent, 0o555); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(grandparent, 0o755) })
+
+	var warns []string
+	a := staleErr_applier(&warns)
+	a.root = grandparent
+	act := staleErr_action(recordedDest, "a/foo", targetAbs)
+
+	if err := a.removeStale([]planner.RemoveAction{act}); err != nil {
+		t.Fatalf("removeStale must not error on a prune failure: %v", err)
+	}
+	if len(a.result.Removed) != 1 || a.result.Removed[0] != "a/foo" {
+		t.Errorf("Removed = %v, want [a/foo] (target removal succeeds despite the prune failure)", a.result.Removed)
+	}
+	if len(a.result.Pruned) != 0 {
+		t.Errorf("Pruned = %v, want none (prune failed)", a.result.Pruned)
+	}
+	if len(warns) != 1 {
+		t.Errorf("warnings = %d, want 1 (prune failure folded into a warning)", len(warns))
+	}
+	if _, err := os.Lstat(targetAbs); !os.IsNotExist(err) {
+		t.Errorf("target should still be removed: lstat err = %v", err)
+	}
+	if _, err := os.Lstat(parent); err != nil {
+		t.Errorf("parent should survive (rmdir failed): %v", err)
+	}
+}
+
+// TestRemoveStaleLeavesForeignFileNonEmptyAncestorInPlace covers the same conservative
+// residency as TestRemoveStaleLeavesNonEmptyAncestorInPlace, but for a directory made
+// non-empty by a file nput never placed (a user's own file), not by another entry's
+// placement — the boundary case for "never touch what the removal did not empty" (→ Issue
+// #174).
+func TestRemoveStaleLeavesForeignFileNonEmptyAncestorInPlace(t *testing.T) {
+	root := realTempDir(t)
+	state := realTempDir(t)
+	src := makeSrc(t, "x")
+
+	lf1 := writeLinkFarm(t, projectManifest(storeEntry(src, "x", "a/file")))
+	if _, err := Apply(Options{
+		LinkFarm: lf1, Name: "c", RootOverride: root, StateDir: state, Commit: fakeCommit(nil),
+	}); err != nil {
+		t.Fatalf("first Apply: %v", err)
+	}
+
+	// A file nput never recorded, dropped into "a/" out-of-band (e.g. by the user).
+	foreign := filepath.Join(root, "a", "user-notes.txt")
+	if err := os.WriteFile(foreign, []byte("keep me"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	lf2 := writeLinkFarm(t, projectManifest())
+	res, err := Apply(Options{
+		LinkFarm: lf2, Name: "c", RootOverride: root, StateDir: state, Commit: fakeCommit(nil),
+	})
+	if err != nil {
+		t.Fatalf("second Apply: %v", err)
+	}
+
+	if len(res.Pruned) != 0 {
+		t.Errorf("Pruned = %v, want none (a/ still holds the foreign file)", res.Pruned)
+	}
+	if _, err := os.Lstat(filepath.Join(root, "a")); err != nil {
+		t.Errorf("a/ should survive (still holds the foreign file): %v", err)
+	}
+	if _, err := os.Lstat(foreign); err != nil {
+		t.Errorf("the foreign file itself must be untouched: %v", err)
+	}
 }
 
 // TestApplyAncestorSelfRecordedMigrationPrunesOuterAncestor verifies PreRemove's ancestor
-// unlink also runs the pruning walk (Issue #174): after the pre-removed ancestor symlink is
-// gone but before the child is placed, the pruning walk can find an outer ancestor briefly
-// empty. Here it is refilled immediately by the child placement, so the net effect is simply
-// that nothing outside the migrated subtree is disturbed and the outer directory survives as
-// a real (non-symlink) directory.
+// unlink also runs the pruning walk (Issue #174): PreRemove runs before Place, so when
+// unlinking the ancestor symlink leaves "outer/" momentarily empty, the walk prunes it right
+// there — res.Pruned reports it — and the following Place step (ensureParentDir's MkdirAll)
+// recreates it fresh to hold the migrated child. The net effect is a real (non-symlink)
+// "outer/" directory at the end, exactly as before, so the transient prune+recreate is
+// invisible on disk; only res.Pruned reveals it happened.
 func TestApplyAncestorSelfRecordedMigrationPrunesOuterAncestor(t *testing.T) {
 	root := realTempDir(t)
 	state := realTempDir(t)
@@ -417,8 +518,15 @@ func TestApplyAncestorSelfRecordedMigrationPrunesOuterAncestor(t *testing.T) {
 		t.Fatalf("second Apply (migration): %v", err)
 	}
 
-	// outer/skills is now a real directory holding the migrated child; outer/ survives as a
-	// real directory (never pruned, since it is immediately refilled by the child placement).
+	if len(res.Removed) != 1 || res.Removed[0] != "outer/skills" {
+		t.Errorf("Removed = %v, want [outer/skills] (the pre-removed ancestor)", res.Removed)
+	}
+	if len(res.Pruned) != 1 || res.Pruned[0] != filepath.Join(root, "outer") {
+		t.Errorf("Pruned = %v, want [%s] (outer/ momentarily emptied by the ancestor unlink, then recreated by Place)", res.Pruned, filepath.Join(root, "outer"))
+	}
+
+	// outer/skills is now a real directory holding the migrated child; outer/ survives on
+	// disk as a real directory (recreated by Place after the transient prune above).
 	info, err := os.Lstat(filepath.Join(root, "outer"))
 	if err != nil {
 		t.Fatalf("outer/ must survive: %v", err)
@@ -430,7 +538,39 @@ func TestApplyAncestorSelfRecordedMigrationPrunesOuterAncestor(t *testing.T) {
 	if err != nil || got != filepath.Join(srcNew, "foo") {
 		t.Fatalf("outer/skills/foo readlink = %q, err %v; want %q", got, err, filepath.Join(srcNew, "foo"))
 	}
-	_ = res
+}
+
+// TestPreRemovePruneCalledDirectly verifies pruneEmptyAncestors is actually invoked from
+// preRemove's unlink loop (Issue #174), independent of the apply-level refill guarantee
+// above. It drives preRemove directly against a two-level ancestor chain where nothing
+// refills the freed space, so a successful prune is observable in isolation.
+func TestPreRemovePruneCalledDirectly(t *testing.T) {
+	root := realTempDir(t)
+	dest := realTempDir(t)
+
+	// outer/inner is the ancestor symlink to be pre-removed; outer/ holds nothing else, so
+	// once inner is unlinked, outer/ itself becomes empty and should be pruned too.
+	if err := os.MkdirAll(filepath.Join(root, "outer"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	ancestorAbs := filepath.Join(root, "outer", "inner")
+	if err := os.Symlink(dest, ancestorAbs); err != nil {
+		t.Fatal(err)
+	}
+
+	a := &applier{opts: Options{Warnf: func(string, ...any) {}}, result: &Result{}, root: root}
+	act := planner.RemoveAction{Entry: storeEntry(dest, ".", "outer/inner"), TargetAbs: ancestorAbs}
+
+	if err := a.preRemove([]planner.RemoveAction{act}); err != nil {
+		t.Fatalf("preRemove: %v", err)
+	}
+
+	if len(a.result.Pruned) != 1 || a.result.Pruned[0] != filepath.Join(root, "outer") {
+		t.Errorf("Pruned = %v, want [%s] (outer/ emptied by the ancestor unlink)", a.result.Pruned, filepath.Join(root, "outer"))
+	}
+	if _, err := os.Lstat(filepath.Join(root, "outer")); !os.IsNotExist(err) {
+		t.Errorf("outer/ should have been pruned away, lstat err = %v", err)
+	}
 }
 
 // TestResetPrunesEmptyAncestors verifies the pruning walk also runs on the reset teardown
@@ -473,5 +613,42 @@ func TestResetPrunesEmptyAncestors(t *testing.T) {
 	}
 	if _, err := os.Lstat(root); err != nil {
 		t.Errorf("root must survive: %v", err)
+	}
+}
+
+// TestResetPrunesEmptyAncestorsCopyOnly isolates the copy-target deletion half of Reset's
+// pruning (reset.go's copy-removal loop calls pruneEmptyAncestors independently of
+// removeStale): with no symlink entries in the mix, a regression that dropped the copy
+// loop's prune call would only be caught here, not by the combined symlink+copy case above.
+func TestResetPrunesEmptyAncestorsCopyOnly(t *testing.T) {
+	root := realTempDir(t)
+	state := realTempDir(t)
+	copySrc := makeSrc(t, "data/x")
+
+	applyForReset(t, root, state, homeManifest(
+		copyEntry(copySrc, "data", "c/d/.copied"),
+	))
+
+	res, err := Reset(resetOpts(root, state, nil, false, nil))
+	if err != nil {
+		t.Fatalf("Reset: %v", err)
+	}
+
+	wantPruned := map[string]bool{
+		filepath.Join(root, "c", "d"): true,
+		filepath.Join(root, "c"):      true,
+	}
+	if len(res.Pruned) != len(wantPruned) {
+		t.Errorf("Pruned = %v, want %d entries covering c/d, c", res.Pruned, len(wantPruned))
+	}
+	for _, p := range res.Pruned {
+		if !wantPruned[p] {
+			t.Errorf("unexpected pruned dir: %s", p)
+		}
+	}
+	for dir := range wantPruned {
+		if _, err := os.Lstat(dir); !os.IsNotExist(err) {
+			t.Errorf("expected %s to be pruned away, lstat err = %v", dir, err)
+		}
 	}
 }

--- a/internal/engine/staleremove_test.go
+++ b/internal/engine/staleremove_test.go
@@ -189,3 +189,289 @@ func TestStaleRemoveUnlinkError(t *testing.T) {
 		t.Errorf("warnings = %v, want none (drift warning only on reverify failure)", warns)
 	}
 }
+
+// --- empty-ancestor pruning (Issue #174, epic #172 D4) ---------------------
+
+// TestRemoveStalePrunesMultiLevelEmptyAncestors verifies that removing the last entry under
+// a multi-level directory chain prunes the whole chain up to (but not including) root, the
+// same as HM's `rmdir -p --ignore-fail-on-non-empty`.
+func TestRemoveStalePrunesMultiLevelEmptyAncestors(t *testing.T) {
+	root := realTempDir(t)
+	state := realTempDir(t)
+	src := makeSrc(t, "x")
+
+	lf1 := writeLinkFarm(t, projectManifest(storeEntry(src, "x", "a/b/c/file")))
+	if _, err := Apply(Options{
+		LinkFarm: lf1, Name: "c", RootOverride: root, StateDir: state, Commit: fakeCommit(nil),
+	}); err != nil {
+		t.Fatalf("first Apply: %v", err)
+	}
+
+	// New generation drops the entry entirely → a/b/c/file is stale-removed and the now-empty
+	// a/b/c, a/b, a chain should be pruned back to root.
+	lf2 := writeLinkFarm(t, projectManifest())
+	res, err := Apply(Options{
+		LinkFarm: lf2, Name: "c", RootOverride: root, StateDir: state, Commit: fakeCommit(nil),
+	})
+	if err != nil {
+		t.Fatalf("second Apply: %v", err)
+	}
+
+	if len(res.Removed) != 1 || res.Removed[0] != "a/b/c/file" {
+		t.Errorf("Removed = %v, want [a/b/c/file]", res.Removed)
+	}
+	wantPruned := map[string]bool{
+		filepath.Join(root, "a", "b", "c"): true,
+		filepath.Join(root, "a", "b"):      true,
+		filepath.Join(root, "a"):           true,
+	}
+	if len(res.Pruned) != len(wantPruned) {
+		t.Errorf("Pruned = %v, want %d entries covering a/b/c, a/b, a", res.Pruned, len(wantPruned))
+	}
+	for _, p := range res.Pruned {
+		if !wantPruned[p] {
+			t.Errorf("unexpected pruned dir: %s", p)
+		}
+	}
+	for dir := range wantPruned {
+		if _, err := os.Lstat(dir); !os.IsNotExist(err) {
+			t.Errorf("expected %s to be pruned away, lstat err = %v", dir, err)
+		}
+	}
+	// root itself must survive.
+	if _, err := os.Lstat(root); err != nil {
+		t.Errorf("root must not be pruned: %v", err)
+	}
+}
+
+// TestRemoveStaleLeavesNonEmptyAncestorInPlace verifies the conservative half of D4: a
+// directory that still holds an unrelated entry's placement is left in place (ENOTEMPTY
+// treated as success, not an error), and pruning stops there without touching its own parent.
+func TestRemoveStaleLeavesNonEmptyAncestorInPlace(t *testing.T) {
+	root := realTempDir(t)
+	state := realTempDir(t)
+	src := makeSrc(t, "x")
+
+	lf1 := writeLinkFarm(t, projectManifest(
+		storeEntry(src, "x", "a/b/c/file1"),
+		storeEntry(src, "x", "a/other/file2"),
+	))
+	if _, err := Apply(Options{
+		LinkFarm: lf1, Name: "c", RootOverride: root, StateDir: state, Commit: fakeCommit(nil),
+	}); err != nil {
+		t.Fatalf("first Apply: %v", err)
+	}
+
+	// Drop only a/b/c/file1; a/other/file2 (and thus a/) must survive.
+	lf2 := writeLinkFarm(t, projectManifest(storeEntry(src, "x", "a/other/file2")))
+	res, err := Apply(Options{
+		LinkFarm: lf2, Name: "c", RootOverride: root, StateDir: state, Commit: fakeCommit(nil),
+	})
+	if err != nil {
+		t.Fatalf("second Apply: %v", err)
+	}
+
+	wantPruned := map[string]bool{
+		filepath.Join(root, "a", "b", "c"): true,
+		filepath.Join(root, "a", "b"):      true,
+	}
+	if len(res.Pruned) != len(wantPruned) {
+		t.Errorf("Pruned = %v, want 2 entries covering a/b/c, a/b (a/ kept non-empty)", res.Pruned)
+	}
+	for _, p := range res.Pruned {
+		if !wantPruned[p] {
+			t.Errorf("unexpected pruned dir: %s", p)
+		}
+	}
+	// a/ survives because a/other/file2 still lives under it.
+	if _, err := os.Lstat(filepath.Join(root, "a")); err != nil {
+		t.Errorf("a/ should survive (still holds a/other): %v", err)
+	}
+	if _, err := os.Lstat(filepath.Join(root, "a", "other", "file2")); err != nil {
+		t.Errorf("a/other/file2 should be untouched: %v", err)
+	}
+}
+
+// TestRemoveStaleStopsAtRootBoundary verifies that when the removed target is a direct
+// child of root, pruning has no ancestor to walk and root itself is never touched.
+func TestRemoveStaleStopsAtRootBoundary(t *testing.T) {
+	root := realTempDir(t)
+	state := realTempDir(t)
+	src := makeSrc(t, "x")
+
+	lf1 := writeLinkFarm(t, projectManifest(storeEntry(src, "x", "file")))
+	if _, err := Apply(Options{
+		LinkFarm: lf1, Name: "c", RootOverride: root, StateDir: state, Commit: fakeCommit(nil),
+	}); err != nil {
+		t.Fatalf("first Apply: %v", err)
+	}
+
+	lf2 := writeLinkFarm(t, projectManifest())
+	res, err := Apply(Options{
+		LinkFarm: lf2, Name: "c", RootOverride: root, StateDir: state, Commit: fakeCommit(nil),
+	})
+	if err != nil {
+		t.Fatalf("second Apply: %v", err)
+	}
+
+	if len(res.Pruned) != 0 {
+		t.Errorf("Pruned = %v, want none (removed target's parent is root)", res.Pruned)
+	}
+	if _, err := os.Lstat(root); err != nil {
+		t.Errorf("root must survive: %v", err)
+	}
+}
+
+// TestRemoveStaleStopsAtSymlinkAncestor verifies that pruning stops (without touching it)
+// when the walk reaches a directory component that is itself a symlink, rather than
+// following/removing it. This guards the walk against ever unlinking something other than
+// a plain empty directory it created.
+func TestRemoveStaleStopsAtSymlinkAncestor(t *testing.T) {
+	root := realTempDir(t)
+	state := realTempDir(t)
+	src := makeSrc(t, "x")
+
+	lf1 := writeLinkFarm(t, projectManifest(storeEntry(src, "x", "a/b/file")))
+	if _, err := Apply(Options{
+		LinkFarm: lf1, Name: "c", RootOverride: root, StateDir: state, Commit: fakeCommit(nil),
+	}); err != nil {
+		t.Fatalf("first Apply: %v", err)
+	}
+
+	// Replace a/b (about to become empty) so the *parent* the walk reaches after removing it
+	// is a symlink: swap a itself for a symlink pointing elsewhere, simulating a foreign
+	// ancestor introduced out-of-band. The walk must stop at "a" without touching it.
+	if err := os.RemoveAll(filepath.Join(root, "a", "b")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(filepath.Join(root, "a")); err != nil {
+		t.Fatal(err)
+	}
+	elsewhere := realTempDir(t)
+	if err := os.Symlink(elsewhere, filepath.Join(root, "a")); err != nil {
+		t.Fatal(err)
+	}
+	// Re-create a/b/file directly (bypassing the engine) so removeStale's target lstat/readlink
+	// reverify still finds the recorded symlink, and pruning walks up into the now-symlinked "a".
+	if err := os.MkdirAll(filepath.Join(elsewhere, "b"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	dest := filepath.Join(src, "x")
+	if err := os.Symlink(dest, filepath.Join(elsewhere, "b", "file")); err != nil {
+		t.Fatal(err)
+	}
+
+	lf2 := writeLinkFarm(t, projectManifest())
+	res, err := Apply(Options{
+		LinkFarm: lf2, Name: "c", RootOverride: root, StateDir: state, Commit: fakeCommit(nil),
+	})
+	if err != nil {
+		t.Fatalf("second Apply: %v", err)
+	}
+
+	// a/b was pruned (real dir, now empty), but "a" itself (a symlink) must survive untouched.
+	for _, p := range res.Pruned {
+		if p == filepath.Join(root, "a") {
+			t.Errorf("Pruned must not include the symlink ancestor %q", p)
+		}
+	}
+	info, err := os.Lstat(filepath.Join(root, "a"))
+	if err != nil {
+		t.Fatalf("symlink ancestor a must survive: %v", err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Errorf("a must remain a symlink, got mode %v", info.Mode())
+	}
+}
+
+// TestApplyAncestorSelfRecordedMigrationPrunesOuterAncestor verifies PreRemove's ancestor
+// unlink also runs the pruning walk (Issue #174): after the pre-removed ancestor symlink is
+// gone but before the child is placed, the pruning walk can find an outer ancestor briefly
+// empty. Here it is refilled immediately by the child placement, so the net effect is simply
+// that nothing outside the migrated subtree is disturbed and the outer directory survives as
+// a real (non-symlink) directory.
+func TestApplyAncestorSelfRecordedMigrationPrunesOuterAncestor(t *testing.T) {
+	root := realTempDir(t)
+	state := realTempDir(t)
+	srcOld := realTempDir(t)
+	if err := os.WriteFile(filepath.Join(srcOld, "foo"), []byte("old"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	lf1 := writeLinkFarm(t, projectManifest(storeEntry(srcOld, ".", "outer/skills")))
+	if _, err := Apply(Options{
+		LinkFarm: lf1, Name: "c", RootOverride: root, StateDir: state, Commit: fakeCommit(nil),
+	}); err != nil {
+		t.Fatalf("first Apply: %v", err)
+	}
+
+	srcNew := realTempDir(t)
+	if err := os.WriteFile(filepath.Join(srcNew, "foo"), []byte("new"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	lf2 := writeLinkFarm(t, projectManifest(storeEntry(srcNew, "foo", "outer/skills/foo")))
+	res, err := Apply(Options{
+		LinkFarm: lf2, Name: "c", RootOverride: root, StateDir: state, Commit: fakeCommit(nil),
+	})
+	if err != nil {
+		t.Fatalf("second Apply (migration): %v", err)
+	}
+
+	// outer/skills is now a real directory holding the migrated child; outer/ survives as a
+	// real directory (never pruned, since it is immediately refilled by the child placement).
+	info, err := os.Lstat(filepath.Join(root, "outer"))
+	if err != nil {
+		t.Fatalf("outer/ must survive: %v", err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		t.Errorf("outer/ must be a real directory, not a symlink")
+	}
+	got, err := os.Readlink(filepath.Join(root, "outer", "skills", "foo"))
+	if err != nil || got != filepath.Join(srcNew, "foo") {
+		t.Fatalf("outer/skills/foo readlink = %q, err %v; want %q", got, err, filepath.Join(srcNew, "foo"))
+	}
+	_ = res
+}
+
+// TestResetPrunesEmptyAncestors verifies the pruning walk also runs on the reset teardown
+// path (Reset reuses removeStale for the symlink half, and this covers the copy-target
+// deletion half too), matching apply's behavior (Issue #174).
+func TestResetPrunesEmptyAncestors(t *testing.T) {
+	root := realTempDir(t)
+	state := realTempDir(t)
+	symSrc := makeSrc(t, "sub/file")
+	copySrc := makeSrc(t, "data/x")
+
+	applyForReset(t, root, state, homeManifest(
+		storeEntry(symSrc, "sub", "a/b/.link"),
+		copyEntry(copySrc, "data", "c/d/.copied"),
+	))
+
+	res, err := Reset(resetOpts(root, state, nil, false, nil))
+	if err != nil {
+		t.Fatalf("Reset: %v", err)
+	}
+
+	wantPruned := map[string]bool{
+		filepath.Join(root, "a", "b"): true,
+		filepath.Join(root, "a"):      true,
+		filepath.Join(root, "c", "d"): true,
+		filepath.Join(root, "c"):      true,
+	}
+	if len(res.Pruned) != len(wantPruned) {
+		t.Errorf("Pruned = %v, want %d entries covering a/b, a, c/d, c", res.Pruned, len(wantPruned))
+	}
+	for _, p := range res.Pruned {
+		if !wantPruned[p] {
+			t.Errorf("unexpected pruned dir: %s", p)
+		}
+	}
+	for dir := range wantPruned {
+		if _, err := os.Lstat(dir); !os.IsNotExist(err) {
+			t.Errorf("expected %s to be pruned away, lstat err = %v", dir, err)
+		}
+	}
+	if _, err := os.Lstat(root); err != nil {
+		t.Errorf("root must survive: %v", err)
+	}
+}


### PR DESCRIPTION
## 概要

除去した target の親ディレクトリチェーンを root 方向へ保守的に剪定する（HM の `rmdir -p --ignore-fail-on-non-empty` 対称）。nput は配置時に親 dir を `mkdir -p` 相当で自動作成するが manifest に記録せず除去もしていなかったため、entry 階層を変更するたびに空 dir が積もり、後続配置を塞ぐ conflict（2026-07-12 の `.claude/hooks` 実障害）の温床になっていた。

剪定ヘルパ `pruneEmptyAncestors` を新設し、空のときだけ rmdir する（非空は ENOTEMPTY/EEXIST を成功扱いとして黙って残す・追加ロック不要で TOCTOU 安全）。root 自体は消さず、祖先チェーンに symlink が現れたら触れずに停止する。適用範囲は全除去経路（`removeStale`＝apply/rollback 共用・`preRemove`・`reset` の symlink/copy 除去）。出力は既定 silent、`-v` で `pruned <path>` として可視化する（ADR-0031 の出力規律に準拠）。

diff-review（test レンズ）で、`os.Lstat(dir)` が dir 自体の判定にとどまり途中コンポーネントの symlink 解決を素通りしてしまう実装バグ（symlink 祖先を跨いでその指す先の実ディレクトリを誤って rmdir しうる）を検出し、`pathHasSymlinkComponent` を新設して root から 1 段ずつ Lstat する方式に修正した。あわせて design レンズの指摘で、初回実装時に書いた「PreRemove の剪定失敗は D3 の一律 error 停止に従う」という spec.md の記述が実装（warn して継続）と矛盾していたため、実装に合わせて改訂した。

## 関連 issue

Closes #174
Refs #172

## docs / ADR 影響

- `docs/spec.md` の「stale 除去の対象と安全不変条件」節に「空親ディレクトリ剪定」小節を追加し、`reset` 節から相互参照するよう更新した。PreRemove の剪定失敗時の扱い（warn 継続に統一）と、PreRemove が Place より前に走ることによる一時 prune+recreate（`-v` レポートには現れるが最終 FS 状態は不変）についても明記した。
- ADR は起票しない。epic #172 の合意により、本機能は PreRemove 一般化（#175）の ADR-0047 に包含される。
