### PR TITLE
fix(engine): conflict の全件一括報告 + 対処ガイダンス

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -915,12 +915,12 @@ devShells.default = pkgs.mkShell {
 | `src` が存在しないストアパス（path / set）| Nix 評価時にエラー |
 | `src` が marker でローカルパスが存在しない | engine 実行時にエラーで停止 |
 | `subpath` が `src` 内に存在しないパス | engine 実行時にエラーで停止 |
-| `target` に通常ファイル・ディレクトリが既存（symlink モード）| エラーで停止（上書きしない）|
-| `target` の祖先 component が foreign symlink（記録なし / 記録 dest と不一致 / 前世代なし）、または次世代にも祖先が残る自己矛盾 | engine 実行時にエラーで停止（lstat walk・`--dryrun` は conflict・→ ADR-0015 §4, ADR-0046）|
+| `target` に通常ファイル・ディレクトリが既存（symlink モード）| conflict。全件を stderr へ列挙して停止（上書きしない・→ 後述「conflict の全件報告」）|
+| `target` の祖先 component が foreign symlink（記録なし / 記録 dest と不一致 / 前世代なし）、または次世代にも祖先が残る自己矛盾 | conflict。engine 実行時に全件を stderr へ列挙して停止（lstat walk・`--dryrun` も conflict・→ ADR-0015 §4, ADR-0046, 後述「conflict の全件報告」）|
 | `target` の祖先 component が自己記録 stale symlink（前世代 manifest が記録・on-disk 一致・次世代に無い）| 祖先を配置前に除去（PreRemove）し配下子を新規配置してネスト移行（silent・`-v` で可視・`--dryrun` は非 conflict の remove・→ ADR-0046）|
 | `target` に foreign symlink が既存（自身の前世代 manifest に記録なし・別 config / 別ツール / 手動）| warning を出して後勝ちで置き換える（→ ADR-0015）|
-| `subpath` がディレクトリのとき `target` に通常ファイルが既存（copy モード）| エラーで停止 |
-| `subpath` がファイルのとき `target` がディレクトリとして既存（copy モード）| エラーで停止 |
+| `subpath` がディレクトリのとき `target` に通常ファイルが既存（copy モード）| conflict。全件を stderr へ列挙して停止（→ 後述「conflict の全件報告」）|
+| `subpath` がファイルのとき `target` がディレクトリとして既存（copy モード）| conflict。全件を stderr へ列挙して停止（→ 後述「conflict の全件報告」）|
 | copy モードで `target` が既存（前世代 manifest に entry あり = nput 配置済み）| place-once により何もしない（上書きしない）。`apply --recopy` 時のみ無条件上書き（→ ADR-0020）|
 | copy モードで `target` に foreign 実ファイルが既存（前世代 manifest に entry なし）| place-once で skip しつつ **warning** で可視化（masking 防止・symlink の foreign 警告と対称・apply は止めない・→ ADR-0022）|
 | 世代スキップ時に copy `target` が不在（project mode）| lstat ドリフト修復で place-once 再マテリアライズ。内容が異なるだけ（編集済み）の場合は不可触（→ ADR-0022）|
@@ -945,6 +945,17 @@ devShells.default = pkgs.mkShell {
 | project mode で git リポジトリ外かつ `--root` 未指定（git toplevel 解決失敗）| engine 実行時にエラーで停止 |
 | project mode で `git` が PATH に無い | engine 実行時にエラーで停止 |
 | `nix-command` / `flakes` experimental-features が未有効 | CLI が前提条件と有効化方法を案内して停止（`--extra-experimental-features` 自動付与はしない・→ ADR-0025）|
+
+### conflict の全件報告（→ grilling 2026-07-12 D6）
+
+`apply` / `rollback` が conflict で停止するとき、`planner.Compute` が収集した **`plan.Conflicts` の全件**を stderr へ列挙してから停止する（`--dryrun` の `Result.Conflicts` と同じ集合。HM の `checkLinkTargets` と対称）。1 件ずつ「修正 → 再実行 → 次の 1 件…」を強いられないよう、1 回の実行で全ての衝突箇所を可視化する。各行には conflict 種別に応じた 1 行の対処ガイダンスが付く：
+
+- foreign 実体（`target` に記録外の通常ファイル・ディレクトリ）→ 手動で退避・削除してから再実行
+- foreign 祖先 symlink（記録なし / 記録 dest と不一致 / 前世代なし）→ そのリンクを作った主体（別 config / 別ツール / 手動操作）を確認
+- 自己矛盾 manifest（次世代にも祖先 symlink が残ったまま配下 target を定義）→ entry 定義を見直す（祖先と配下のどちらかに一本化）
+- copy 構造不一致（`subpath` の dir/file 種別と既存 `target` の種別が食い違う）→ entry 定義を見直す
+
+停止時の `error` は列挙の後に返す**件数付き集約メッセージ 1 本**（例: `nput: N conflict(s) detected; stopped without placing (see above)`）で、個別 conflict の詳細は本文ではなく直前の stderr 列挙が担う。終了コードは不変（`apply` 非 dryrun は `1`・`--dryrun` は `2`）。`--json`（epic #126）の `Conflicts` 配列も同じ全件集合と整合させる。
 
 ---
 

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -203,8 +203,7 @@ func Apply(opts Options) (*Result, error) {
 		return nil, err
 	}
 	if len(plan.Conflicts) > 0 {
-		c := plan.Conflicts[0]
-		return nil, fmt.Errorf("nput: %s (target: %s)", c.Reason, c.Entry.Target)
+		return nil, reportConflicts(a.opts.Warnf, plan.Conflicts)
 	}
 	a.emitWarnings(plan.Warnings, opts.Recopy)
 
@@ -407,6 +406,36 @@ func (a *applier) loadPrevManifest() *manifest.Manifest {
 		return nil
 	}
 	return m
+}
+
+// reportConflicts lists every planner-detected conflict to stderr (warnf), each followed by a
+// one-line guidance for that conflict's kind, then returns a single count-bearing aggregate error
+// (exit code stays 1 · → docs/spec.md エラー仕様, grilling 2026-07-12 D6). Mirrors the dryrun path
+// (a.dryRun packs the same plan.Conflicts into Result.Conflicts in full), so apply / Rollback no
+// longer stop at the first conflict only.
+func reportConflicts(warnf func(format string, args ...any), conflicts []planner.Conflict) error {
+	for _, c := range conflicts {
+		warnf("nput: conflict: %s (target: %s)", c.Reason, c.Entry.Target)
+		warnf("nput:   → %s", conflictGuidance(c.Kind))
+	}
+	return fmt.Errorf("nput: %d conflict(s) detected; stopped without placing (see above)", len(conflicts))
+}
+
+// conflictGuidance returns the one-line remediation hint for a conflict kind (→ docs/spec.md
+// エラー仕様, grilling 2026-07-12 D6; HM checkLinkTargets に倣う).
+func conflictGuidance(kind planner.ConflictKind) string {
+	switch kind {
+	case planner.ConflictForeignEntity:
+		return "move or remove the existing file/directory manually, then re-apply"
+	case planner.ConflictForeignAncestor:
+		return "check what created this symlink (another config / tool / manual placement)"
+	case planner.ConflictSelfContradictoryAncestor:
+		return "the manifest keeps both this ancestor and an entry nested beneath it; fix the entry definitions"
+	case planner.ConflictCopyStructureMismatch:
+		return "the copy entry's structure no longer matches the existing target; fix the entry definition"
+	default:
+		return "review the entry definition and the existing target"
+	}
 }
 
 // emitWarnings emits the non-fatal warnings computed by the planner to stderr (opts.Warnf).

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -245,14 +245,21 @@ func TestApplyAncestorSymlinkError(t *testing.T) {
 		t.Fatalf("expected a 1-conflict aggregate error, got %v", err)
 	}
 	found := false
+	guided := false
 	for _, w := range warns {
-		if strings.Contains(w, "symlink") {
+		if strings.Contains(w, "cannot nest beneath it") {
 			found = true
-			break
+		}
+		// ConflictForeignAncestor guidance (no previous generation recorded this ancestor · → #176).
+		if strings.Contains(w, "check what created this symlink") {
+			guided = true
 		}
 	}
 	if !found {
 		t.Errorf("expected a conflict line mentioning the ancestor symlink, warns = %v", warns)
+	}
+	if !guided {
+		t.Errorf("expected the ConflictForeignAncestor guidance line, warns = %v", warns)
 	}
 }
 
@@ -1196,5 +1203,129 @@ func TestApplyConflictMatchesDryRun(t *testing.T) {
 	})
 	if err == nil || !strings.Contains(err.Error(), "2 conflict") {
 		t.Fatalf("expected a 2-conflict aggregate error, got %v", err)
+	}
+}
+
+// TestApplySelfContradictoryAncestorGuidance verifies that a new generation which keeps a
+// self-recorded ancestor symlink AND defines an entry nested beneath it (self-contradictory
+// manifest) reports the ConflictSelfContradictoryAncestor guidance via Warnf (→ #176, grilling
+// 2026-07-12 D6).
+func TestApplySelfContradictoryAncestorGuidance(t *testing.T) {
+	root := realTempDir(t)
+	state := realTempDir(t)
+
+	// First generation: a whole-tree symlink at .claude/skills.
+	srcOld := makeSrc(t, "x")
+	lf1 := writeLinkFarm(t, projectManifest(storeEntry(srcOld, ".", ".claude/skills")))
+	var commits [][2]string
+	if _, err := Apply(Options{
+		LinkFarm: lf1, Name: "c", RootOverride: root, StateDir: state, Commit: fakeCommit(&commits),
+	}); err != nil {
+		t.Fatalf("first Apply: %v", err)
+	}
+
+	// Second generation: keeps .claude/skills itself AND defines a child beneath it (self-contradictory).
+	srcNew := makeSrc(t, "x")
+	lf2 := writeLinkFarm(t, projectManifest(
+		storeEntry(srcNew, ".", ".claude/skills"),
+		storeEntry(srcNew, ".", ".claude/skills/foo"),
+	))
+	var warns []string
+	_, err := Apply(Options{
+		LinkFarm: lf2, Name: "c", RootOverride: root, StateDir: state,
+		Commit: fakeCommit(&commits), Warnf: collectFormatted(&warns),
+	})
+	if err == nil || !strings.Contains(err.Error(), "1 conflict") {
+		t.Fatalf("expected a 1-conflict aggregate error, got %v", err)
+	}
+	found := false
+	for _, w := range warns {
+		if strings.Contains(w, "the manifest keeps both this ancestor and an entry nested beneath it") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected the ConflictSelfContradictoryAncestor guidance line, warns = %v", warns)
+	}
+}
+
+// TestApplyCopyStructureMismatchGuidance verifies that a copy entry whose src structure (dir)
+// mismatches an existing target (regular file) reports the ConflictCopyStructureMismatch guidance
+// via Warnf (→ #176, grilling 2026-07-12 D6).
+func TestApplyCopyStructureMismatchGuidance(t *testing.T) {
+	root := realTempDir(t)
+	state := realTempDir(t)
+	src := makeSrc(t, "sub/file")
+	lf := writeLinkFarm(t, homeManifest(copyEntry(src, "sub", ".foo")))
+
+	// Occupy the copy target with a regular file while the copy src (sub) is a directory (structure mismatch).
+	if err := os.WriteFile(filepath.Join(root, ".foo"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var warns []string
+	_, err := Apply(Options{
+		LinkFarm: lf, Name: "cfg", RootKind: manifest.RootKindHome,
+		RootOverride: root, StateDir: state, Warnf: collectFormatted(&warns),
+	})
+	if err == nil || !strings.Contains(err.Error(), "1 conflict") {
+		t.Fatalf("expected a 1-conflict aggregate error, got %v", err)
+	}
+	found := false
+	for _, w := range warns {
+		if strings.Contains(w, "the copy entry's structure no longer matches the existing target") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected the ConflictCopyStructureMismatch guidance line, warns = %v", warns)
+	}
+}
+
+// TestApplyConflictMixedKindsPairGuidanceCorrectly verifies that when conflicts of different
+// kinds are reported together, each conflict line is immediately followed by its own kind's
+// guidance (no mis-pairing across kinds · → #176).
+func TestApplyConflictMixedKindsPairGuidanceCorrectly(t *testing.T) {
+	root := realTempDir(t)
+	state := realTempDir(t)
+	src := makeSrc(t, "x")
+
+	// .foreignEntity: a regular file occupies a symlink target (ConflictForeignEntity).
+	// .claude/skills/nix: nests beneath a foreign ancestor symlink (ConflictForeignAncestor).
+	lf := writeLinkFarm(t, projectManifest(
+		storeEntry(src, ".", ".foreignEntity"),
+		storeEntry(src, ".", ".claude/skills/nix"),
+	))
+	if err := os.WriteFile(filepath.Join(root, ".foreignEntity"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(realTempDir(t), filepath.Join(root, ".claude")); err != nil {
+		t.Fatal(err)
+	}
+
+	var warns []string
+	_, err := Apply(Options{
+		LinkFarm: lf, Name: "c", RootOverride: root, StateDir: state, Commit: fakeCommit(nil),
+		Warnf: collectFormatted(&warns),
+	})
+	if err == nil || !strings.Contains(err.Error(), "2 conflict") {
+		t.Fatalf("expected a 2-conflict aggregate error, got %v", err)
+	}
+
+	// Each conflict line (target: X) must be immediately followed by its own kind's guidance,
+	// not the other conflict's.
+	for i, w := range warns {
+		switch {
+		case strings.Contains(w, "target: .foreignEntity"):
+			if i+1 >= len(warns) || !strings.Contains(warns[i+1], "move or remove the existing file/directory manually") {
+				t.Errorf("conflict line %q not immediately followed by ConflictForeignEntity guidance, next = %v", w, warns[i+1:])
+			}
+		case strings.Contains(w, "target: .claude/skills/nix"):
+			if i+1 >= len(warns) || !strings.Contains(warns[i+1], "check what created this symlink") {
+				t.Errorf("conflict line %q not immediately followed by ConflictForeignAncestor guidance, next = %v", w, warns[i+1:])
+			}
+		}
 	}
 }

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -74,6 +75,14 @@ func fakeCommit(captured *[][2]string) CommitFunc {
 func collectWarnings(buf *[]string) func(string, ...any) {
 	return func(format string, args ...any) {
 		*buf = append(*buf, format)
+	}
+}
+
+// collectFormatted is like collectWarnings but stores the formatted message (args applied),
+// used where a test needs to assert on interpolated content such as a target path.
+func collectFormatted(buf *[]string) func(string, ...any) {
+	return func(format string, args ...any) {
+		*buf = append(*buf, fmt.Sprintf(format, args...))
 	}
 }
 
@@ -225,11 +234,25 @@ func TestApplyAncestorSymlinkError(t *testing.T) {
 	}
 	lf := writeLinkFarm(t, projectManifest(storeEntry(src, ".", ".claude/skills/nix")))
 
+	var warns []string
 	_, err := Apply(Options{
 		LinkFarm: lf, Name: "c", RootOverride: root, StateDir: state, Commit: fakeCommit(nil),
+		Warnf: collectFormatted(&warns),
 	})
-	if err == nil || !strings.Contains(err.Error(), "symlink") {
-		t.Fatalf("expected ancestor symlink error, got %v", err)
+	// The aggregate error is a count-bearing summary; the ancestor-symlink detail is reported via
+	// Warnf (→ #176, grilling 2026-07-12 D6).
+	if err == nil || !strings.Contains(err.Error(), "1 conflict") {
+		t.Fatalf("expected a 1-conflict aggregate error, got %v", err)
+	}
+	found := false
+	for _, w := range warns {
+		if strings.Contains(w, "symlink") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected a conflict line mentioning the ancestor symlink, warns = %v", warns)
 	}
 }
 
@@ -1079,5 +1102,99 @@ func TestApplyCleanupPendingRemoveFailureWarns(t *testing.T) {
 	}
 	if !found {
 		t.Errorf("expected a .pending cleanup warning, warns = %v", warns)
+	}
+}
+
+// TestApplyConflictReportsAll verifies that a non-dryrun Apply lists every planner-detected
+// conflict to stderr (with a one-line guidance each) before returning a single count-bearing
+// aggregate error, instead of stopping at the first conflict only (→ #176, grilling 2026-07-12 D6).
+func TestApplyConflictReportsAll(t *testing.T) {
+	root := realTempDir(t)
+	state := realTempDir(t)
+	src := makeSrc(t, "sub/file")
+	lf := writeLinkFarm(t, homeManifest(
+		storeEntry(src, "sub", ".one"),
+		storeEntry(src, "sub", ".two"),
+	))
+
+	// Occupy both targets with regular files (symlink mode cannot overwrite → conflict each).
+	if err := os.WriteFile(filepath.Join(root, ".one"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".two"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var warns []string
+	_, err := Apply(Options{
+		LinkFarm: lf, Name: "cfg", RootKind: manifest.RootKindHome,
+		RootOverride: root, StateDir: state, Warnf: collectFormatted(&warns),
+	})
+	if err == nil {
+		t.Fatal("expected a conflict error, got nil")
+	}
+	if !strings.Contains(err.Error(), "2 conflict") {
+		t.Errorf("aggregate error = %q, want it to mention the conflict count (2)", err.Error())
+	}
+
+	for _, target := range []string{".one", ".two"} {
+		found := false
+		for _, w := range warns {
+			if strings.Contains(w, target) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected a conflict line mentioning %q, warns = %v", target, warns)
+		}
+	}
+	// Each conflict line is followed by a one-line guidance (foreign entity → manual move/remove).
+	guidanceCount := 0
+	for _, w := range warns {
+		if strings.Contains(w, "move or remove the existing file/directory manually") {
+			guidanceCount++
+		}
+	}
+	if guidanceCount != 2 {
+		t.Errorf("guidance line count = %d, want 2 (one per conflict), warns = %v", guidanceCount, warns)
+	}
+}
+
+// TestApplyConflictMatchesDryRun verifies that the non-dryrun conflict set (reported via Warnf)
+// and the --dryrun conflict set (Result.Conflicts) agree on the same plan (→ #176).
+func TestApplyConflictMatchesDryRun(t *testing.T) {
+	root := realTempDir(t)
+	state := realTempDir(t)
+	src := makeSrc(t, "sub/file")
+	lf := writeLinkFarm(t, homeManifest(
+		storeEntry(src, "sub", ".one"),
+		storeEntry(src, "sub", ".two"),
+	))
+	if err := os.WriteFile(filepath.Join(root, ".one"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".two"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	dry, err := Apply(Options{
+		LinkFarm: lf, Name: "cfg", RootKind: manifest.RootKindHome,
+		RootOverride: root, StateDir: state, DryRun: true,
+	})
+	if err != nil {
+		t.Fatalf("Apply dryrun: %v", err)
+	}
+	if len(dry.Conflicts) != 2 {
+		t.Fatalf("dryrun Conflicts = %v, want 2 entries", dry.Conflicts)
+	}
+
+	var warns []string
+	_, err = Apply(Options{
+		LinkFarm: lf, Name: "cfg", RootKind: manifest.RootKindHome,
+		RootOverride: root, StateDir: state, Warnf: collectFormatted(&warns),
+	})
+	if err == nil || !strings.Contains(err.Error(), "2 conflict") {
+		t.Fatalf("expected a 2-conflict aggregate error, got %v", err)
 	}
 }

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -1315,17 +1315,25 @@ func TestApplyConflictMixedKindsPairGuidanceCorrectly(t *testing.T) {
 	}
 
 	// Each conflict line (target: X) must be immediately followed by its own kind's guidance,
-	// not the other conflict's.
+	// not the other conflict's. matched tracks how many of the two expected target lines were
+	// actually found, so a silent no-op (neither switch case firing, e.g. because the target
+	// string changed) fails loudly instead of passing vacuously.
+	matched := 0
 	for i, w := range warns {
 		switch {
 		case strings.Contains(w, "target: .foreignEntity"):
+			matched++
 			if i+1 >= len(warns) || !strings.Contains(warns[i+1], "move or remove the existing file/directory manually") {
 				t.Errorf("conflict line %q not immediately followed by ConflictForeignEntity guidance, next = %v", w, warns[i+1:])
 			}
 		case strings.Contains(w, "target: .claude/skills/nix"):
+			matched++
 			if i+1 >= len(warns) || !strings.Contains(warns[i+1], "check what created this symlink") {
 				t.Errorf("conflict line %q not immediately followed by ConflictForeignAncestor guidance, next = %v", w, warns[i+1:])
 			}
 		}
+	}
+	if matched != 2 {
+		t.Fatalf("expected both conflict target lines to be found, matched = %d, warns = %v", matched, warns)
 	}
 }

--- a/internal/engine/generations.go
+++ b/internal/engine/generations.go
@@ -170,8 +170,7 @@ func Rollback(opts RollbackOptions) (*RollbackResult, error) {
 		return nil, err
 	}
 	if len(plan.Conflicts) > 0 {
-		c := plan.Conflicts[0]
-		return nil, fmt.Errorf("nput: %s (target: %s)", c.Reason, c.Entry.Target)
+		return nil, reportConflicts(warnf, plan.Conflicts)
 	}
 
 	// 6. reflect the plan onto the real FS (new/re-link first, stale removal last · → ADR-0006).

--- a/internal/engine/generations_test.go
+++ b/internal/engine/generations_test.go
@@ -162,6 +162,78 @@ func TestRollbackNoPreviousErrors(t *testing.T) {
 	}
 }
 
+// TestRollbackConflictReportsAll verifies that Rollback, like Apply, lists every planner-detected
+// conflict to stderr (with guidance) before returning a single count-bearing aggregate error
+// (→ #176, grilling 2026-07-12 D6). gen1(target) has {b, c}; gen2(current/baseline) has {a}; both
+// b and c are occupied by regular files on disk, so rolling back to gen1 conflicts on both.
+func TestRollbackConflictReportsAll(t *testing.T) {
+	root := realTempDir(t)
+	state := realTempDir(t)
+	srcA := makeSrc(t, "x")
+	srcB := makeSrc(t, "x")
+	srcC := makeSrc(t, "x")
+
+	prof := paths.Resolve(state, "vim", manifest.RootKindHome, root, true)
+	if err := os.MkdirAll(prof.Dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	lf1 := writeLinkFarm(t, homeManifest(
+		storeEntry(srcB, ".", "b"),
+		storeEntry(srcC, ".", "c"),
+	))
+	lf2 := writeLinkFarm(t, homeManifest(storeEntry(srcA, ".", "a")))
+
+	if err := os.Symlink(lf1, paths.GenerationLink(prof.Profile, 1)); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(lf2, paths.GenerationLink(prof.Profile, 2)); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(lf2, prof.Profile); err != nil {
+		t.Fatal(err)
+	}
+
+	// Current FS = gen2: only a. b/c are occupied by regular files (foreign entity conflicts on rollback).
+	if err := os.Symlink(srcA, filepath.Join(root, "a")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "b"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "c"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var warns []string
+	_, err := Rollback(RollbackOptions{
+		Name: "vim", RootKind: manifest.RootKindHome, RootOverride: root, StateDir: state,
+		ListGenerations: func(string) ([]Generation, error) {
+			return []Generation{{Number: 1}, {Number: 2, Current: true}}, nil
+		},
+		SwitchGeneration: func(string, int) error { return nil },
+		Warnf:            collectFormatted(&warns),
+	})
+	if err == nil {
+		t.Fatal("expected a conflict error, got nil")
+	}
+	if !strings.Contains(err.Error(), "2 conflict") {
+		t.Errorf("aggregate error = %q, want it to mention the conflict count (2)", err.Error())
+	}
+	for _, target := range []string{"b", "c"} {
+		found := false
+		for _, w := range warns {
+			if strings.Contains(w, "target: "+target) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected a conflict line mentioning target %q, warns = %v", target, warns)
+		}
+	}
+}
+
 // TestRollbackNoProfileErrors verifies that rollback stops with an error when profileDir is absent (never applied).
 func TestRollbackNoProfileErrors(t *testing.T) {
 	root := realTempDir(t)

--- a/internal/planner/planner.go
+++ b/internal/planner/planner.go
@@ -93,8 +93,12 @@ type Conflict struct {
 type ConflictKind int
 
 const (
+	// ConflictUnspecified is the zero value: a Kind left unset. It must never be produced by
+	// Compute (every Conflict{} literal below sets Kind explicitly); guarded against by falling
+	// through to a generic guidance rather than silently reading as ConflictForeignEntity.
+	ConflictUnspecified ConflictKind = iota
 	// ConflictForeignEntity is a regular file/directory occupying a symlink target (→ ADR-0006).
-	ConflictForeignEntity ConflictKind = iota
+	ConflictForeignEntity
 	// ConflictForeignAncestor is a symlinked ancestor component not recorded by this profile's
 	// own previous generation (unrecorded / mismatched dest / no previous generation · → ADR-0015 §4).
 	ConflictForeignAncestor

--- a/internal/planner/planner.go
+++ b/internal/planner/planner.go
@@ -84,7 +84,27 @@ type Conflict struct {
 	Entry     manifest.Entry
 	TargetAbs string
 	Reason    string
+	Kind      ConflictKind
 }
+
+// ConflictKind classifies a Conflict for caller-side guidance (→ docs/spec.md エラー仕様 ·
+// grilling 2026-07-12 D6). Kept distinct from the free-form Reason string so guidance
+// selection does not depend on message text.
+type ConflictKind int
+
+const (
+	// ConflictForeignEntity is a regular file/directory occupying a symlink target (→ ADR-0006).
+	ConflictForeignEntity ConflictKind = iota
+	// ConflictForeignAncestor is a symlinked ancestor component not recorded by this profile's
+	// own previous generation (unrecorded / mismatched dest / no previous generation · → ADR-0015 §4).
+	ConflictForeignAncestor
+	// ConflictSelfContradictoryAncestor is a symlinked ancestor still kept by the new generation
+	// while a descendant entry also targets beneath it (→ ADR-0015 §4, ADR-0046).
+	ConflictSelfContradictoryAncestor
+	// ConflictCopyStructureMismatch is a copy entry whose src structure (dir/file) mismatches the
+	// existing target kind (→ ADR-0020).
+	ConflictCopyStructureMismatch
+)
 
 // WarnKind enumerates non-fatal conditions the planner surfaces to the user.
 type WarnKind int
@@ -182,10 +202,15 @@ func Compute(prev, next *manifest.Manifest, root string, fs FS) (Plan, error) {
 			}
 			// foreign ancestor, or the new generation still keeps the ancestor (self-contradictory):
 			// the ancestor symlink cannot be removed, so nesting stays a conflict (→ ADR-0015, ADR-0046).
+			kind := ConflictForeignAncestor
+			if keptInNext {
+				kind = ConflictSelfContradictoryAncestor
+			}
 			plan.Conflicts = append(plan.Conflicts, Conflict{
 				Entry:     e,
 				TargetAbs: targetAbs,
 				Reason:    fmt.Sprintf("ancestor %q is a symlink; cannot nest beneath it (→ ADR-0015)", offenderAbs),
+				Kind:      kind,
 			})
 			continue
 		}
@@ -217,6 +242,7 @@ func Compute(prev, next *manifest.Manifest, root string, fs FS) (Plan, error) {
 				Entry:     e,
 				TargetAbs: targetAbs,
 				Reason:    "target already has an existing file/directory (will not overwrite)",
+				Kind:      ConflictForeignEntity,
 			})
 		case os.IsNotExist(err):
 			plan.Place = append(plan.Place, PlaceAction{Entry: e, TargetAbs: targetAbs, Dest: LinkDest(e), Kind: PlaceNew})
@@ -327,6 +353,7 @@ func classifyCopy(plan *Plan, e manifest.Entry, targetAbs string, prevByTarget m
 				Entry:     e,
 				TargetAbs: targetAbs,
 				Reason:    "copy src structure and target kind mismatch (dir↔file; will not overwrite)",
+				Kind:      ConflictCopyStructureMismatch,
 			})
 			return nil
 		}

--- a/internal/planner/planner_test.go
+++ b/internal/planner/planner_test.go
@@ -483,11 +483,11 @@ func TestComputeTableDriven(t *testing.T) {
 					got[i] = c.Kind
 				}
 				if len(got) != len(tt.want.conflictKinds) {
-					t.Errorf("conflict kinds = %v, want %v", got, tt.want.conflictKinds)
+					t.Errorf("conflict kinds length = %d, want %d (got %v, want %v)", len(got), len(tt.want.conflictKinds), got, tt.want.conflictKinds)
 				} else {
 					for i := range got {
 						if got[i] != tt.want.conflictKinds[i] {
-							t.Errorf("conflict kinds = %v, want %v", got, tt.want.conflictKinds)
+							t.Errorf("conflict kinds[%d] = %v, want %v (full: got %v, want %v)", i, got[i], tt.want.conflictKinds[i], got, tt.want.conflictKinds)
 							break
 						}
 					}

--- a/internal/planner/planner_test.go
+++ b/internal/planner/planner_test.go
@@ -89,6 +89,10 @@ type want struct {
 	preRemove    []string
 	warns        []WarnKind
 	conflicts    int
+	// conflictKinds asserts plan.Conflicts[i].Kind in order (nil = skip; the conflicts count
+	// alone does not catch a Kind mix-up such as ForeignAncestor ↔ SelfContradictoryAncestor,
+	// both assigned from the same keptInNext branch · → #176).
+	conflictKinds []ConflictKind
 }
 
 func placeTargets(p Plan, kind PlaceKind) []string {
@@ -209,7 +213,7 @@ func TestComputeTableDriven(t *testing.T) {
 			prev: nil,
 			next: mani(sl(srcB, ".config/foo")),
 			fs:   fakeFS{abs(".config/foo"): reg()},
-			want: want{conflicts: 1},
+			want: want{conflicts: 1, conflictKinds: []ConflictKind{ConflictForeignEntity}},
 		},
 		{
 			// An ancestor component is a symlink: cannot nest under it, conflict (→ ADR-0015).
@@ -217,7 +221,7 @@ func TestComputeTableDriven(t *testing.T) {
 			prev: nil,
 			next: mani(sl(srcB, ".claude/skills/nix")),
 			fs:   fakeFS{abs(".claude"): sym("/some/store")},
-			want: want{conflicts: 1},
+			want: want{conflicts: 1, conflictKinds: []ConflictKind{ConflictForeignAncestor}},
 		},
 		{
 			// Self-recorded stale ancestor symlink (prev recorded .claude/skills, on-disk matches, next
@@ -302,7 +306,7 @@ func TestComputeTableDriven(t *testing.T) {
 				abs(".claude"):        dir(),
 				abs(".claude/skills"): sym("/foreign"),
 			},
-			want: want{conflicts: 1, warns: []WarnKind{WarnStaleMismatch}},
+			want: want{conflicts: 1, conflictKinds: []ConflictKind{ConflictForeignAncestor}, warns: []WarnKind{WarnStaleMismatch}},
 		},
 		{
 			// The new generation keeps the ancestor whole-tree symlink AND a nested child
@@ -316,8 +320,9 @@ func TestComputeTableDriven(t *testing.T) {
 				abs(".claude/skills"): sym(srcA),
 			},
 			want: want{
-				placeReplace: []string{".claude/skills"},
-				conflicts:    1,
+				placeReplace:  []string{".claude/skills"},
+				conflicts:     1,
+				conflictKinds: []ConflictKind{ConflictSelfContradictoryAncestor},
 			},
 		},
 		{
@@ -416,7 +421,7 @@ func TestComputeTableDriven(t *testing.T) {
 			prev: nil,
 			next: mani(cp(srcA, ".config/foo")),
 			fs:   fakeFS{srcA: dir(), abs(".config/foo"): reg()},
-			want: want{conflicts: 1},
+			want: want{conflicts: 1, conflictKinds: []ConflictKind{ConflictCopyStructureMismatch}},
 		},
 		{
 			// structure mismatch (src file × target dir): conflict.
@@ -424,7 +429,7 @@ func TestComputeTableDriven(t *testing.T) {
 			prev: nil,
 			next: mani(cp(srcA, ".config/foo")),
 			fs:   fakeFS{srcA: reg(), abs(".config/foo"): dir()},
-			want: want{conflicts: 1},
+			want: want{conflicts: 1, conflictKinds: []ConflictKind{ConflictCopyStructureMismatch}},
 		},
 		{
 			// copy exists, recorded, dir/dir match: no-op.
@@ -471,6 +476,22 @@ func TestComputeTableDriven(t *testing.T) {
 			warnEq(t, warnKinds(plan), tt.want.warns)
 			if len(plan.Conflicts) != tt.want.conflicts {
 				t.Errorf("conflicts = %d, want %d (%v)", len(plan.Conflicts), tt.want.conflicts, plan.Conflicts)
+			}
+			if tt.want.conflictKinds != nil {
+				got := make([]ConflictKind, len(plan.Conflicts))
+				for i, c := range plan.Conflicts {
+					got[i] = c.Kind
+				}
+				if len(got) != len(tt.want.conflictKinds) {
+					t.Errorf("conflict kinds = %v, want %v", got, tt.want.conflictKinds)
+				} else {
+					for i := range got {
+						if got[i] != tt.want.conflictKinds[i] {
+							t.Errorf("conflict kinds = %v, want %v", got, tt.want.conflictKinds)
+							break
+						}
+					}
+				}
 			}
 		})
 	}


### PR DESCRIPTION
<!--
PR テンプレート（ソロ運用・最小構成）。
チェックリストは置かない。形骸化を避け、このリポジトリで実際に意味のある 3 点だけ書く。
-->

## 概要

<!-- なぜ・何を変えるか。Conventional Commits のタイトルだけでは残らない背景を書く。 -->

apply / Rollback の conflict 停止時、planner が収集済みの全 Conflicts を先頭 1 件のみで打ち切っていたため、修正 → 再実行 → 次の 1 件…の逐次発見を強いていた（2026-07-12 の実障害では 7 entry 分の conflict のうち 1 件しか見えなかった）。

全件を stderr へ列挙し、conflict 種別（foreign 実体・foreign 祖先 symlink・自己矛盾 manifest・copy 構造不一致）ごとの対処ガイダンスを 1 行添えたうえで、件数付き集約エラー 1 本を返すよう変更する。exit code は不変（apply は 1、`--dryrun` は 2 のまま）。種別判定用に `planner.Conflict` へ `Kind` フィールド（enum）を追加し、表示文言（`Reason`）と分岐ロジックを分離した。

## 関連 issue

<!-- 例: Closes #N / Refs #N。なければ「なし」。 -->

Closes #176
Refs #172

## docs / ADR 影響

<!--
このリポジトリはドキュメント主導。配置動作・API・方針に触れる変更は docs の更新がセットになる。
- concept / design / spec の更新有無
- 方針転換や trade-off を伴うなら ADR を追加したか（docs/adr/）
影響がなければ「なし」と明記する。
-->

`docs/spec.md` のエラー仕様セクションを更新した。conflict 該当行に全件報告である旨を注記し、種別ごとの対処ガイダンス・集約エラーメッセージの形式・終了コード不変を「conflict の全件報告」節として追記した。

既存の設計決定（apply 非 dryrun は conflict も exit 1・`--dryrun` は exit 2）を変更しないため、ADR の新規追加はなし（grilling 2026-07-12 D6 の範囲内）。
