### PR TITLE
feat(planner,engine): PreRemove の一般化 — 配置を塞ぐ自己記録 stale 全般へ拡張 (ADR-0047)

### DIFF
--- a/docs/adr/0015-pre-impl-remaining-semantics.md
+++ b/docs/adr/0015-pre-impl-remaining-semantics.md
@@ -28,6 +28,12 @@
 > per-file 世代）を跨ぐ rollback は、apply と同じく **PreRemove → place/replace → stale 除去**の順で反映しないと収束しない。
 > `Rollback()` に `a.preRemove(plan.PreRemove)` を `place` の前段として追加し修正した（apply の実行順・drift 時 error 停止の意味論と
 > 同一・→ #173）。
+>
+> **2026-07-12 改訂注記（ADR-0047）**: 本 ADR §2 の「前世代 manifest 記録の symlink は置換可（silent・後勝ち）」判定は、
+> **同一 method（symlink→symlink）だけでなく method 横断（symlink→copy）へも拡張**された。同一 target で method が
+> symlink から copy へ変わったとき、前世代が記録した symlink で on-disk が記録通りなら配置前に除去して copy を新規配置する
+> （symlink はユーザーデータを持たないため損失ゼロ）。copy→symlink 方向は非対称に**自動化しない**（ユーザー編集済み copy
+> データの保護を優先し、従来通り conflict のまま・→ ADR-0047）。
 
 ## 背景
 

--- a/docs/adr/0046-self-recorded-ancestor-nest-migration.md
+++ b/docs/adr/0046-self-recorded-ancestor-nest-migration.md
@@ -11,6 +11,14 @@
 > 実行せず捨てていた。ADR-0046 の移行（祖先 symlink 世代 ⇄ per-file 世代）を跨ぐ rollback はこの経路を通るため、apply と同じ
 > PreRemove 実行が要る。`Rollback()` に `a.preRemove(plan.PreRemove)` を `place` の前段として追加し、drift 時の error 停止を含む
 > §3 の意味論を rollback にも揃えた（→ #173, ADR-0015 §5 改訂注記）。
+>
+> **2026-07-12 改訂注記（ADR-0047）**: 本 ADR の「配置 target の**祖先**が自己記録 stale symlink のとき配置前に除去
+> （PreRemove）してネスト移行する」設計自体は不変。ただし PreRemove の対象は「祖先 symlink」から「配置を塞ぐ自己記録
+> stale 全般」へ一般化された: **target 自身**が実 dir で配下全 leaf が recorded∧stale または空 dir なら migration
+> （中身のある foreign・自己矛盾 leaf が 1 つでもあれば dir 全体 conflict・部分除去はしない）、および同一 target での
+> method 変更 symlink→copy も migration 対象になった（copy→symlink は非対称に conflict のまま）。`Plan.PreRemove` の
+> 要素は `RemoveAction{Kind, Entry, TargetAbs}` に拡張され、`Kind = RemoveRmdir` は `Entry` を持たない空 dir 除去を表す。
+> drift 時に skip せず error 停止する意味論（§3）は一般化後の全 PreRemove 発生源に共通して適用される（→ ADR-0047）。
 
 ## 背景
 

--- a/docs/adr/0047-preremove-generalization.md
+++ b/docs/adr/0047-preremove-generalization.md
@@ -61,6 +61,12 @@ ADR-0046 §3 で導入した「PreRemove は最終段の removeStale と違い�
 
 `planner.FS` に `ReadDir(path string) ([]os.DirEntry, error)` を追加し、実 dir 配下の走査を可能にする。走査は lstat ベースで symlink の中へ降りない（ADR-0046 §2 と同じ安全規則）。
 
+### 5. PreRemove は空祖先ディレクトリ剪定（#174）を呼ばない
+
+`preRemove`（engine 実行段）は、Unlink・Rmdir どちらの成功時も #174 の `pruneEmptyAncestors` ヘルパを呼ばない。理由は、PreRemove の各アクションは必ず直後の `place` / `materializeCopies` による再配置を前提としており、剪定してもその場で作り直されるだけの無駄な往復になるため。加えて、一般化後は 1 バッチ内に複数の Unlink/Rmdir が bottom-up 順で積まれており（`classifyDirMigration` が子から親まで明示的に列挙する）、途中のアクション成功時に `pruneEmptyAncestors` を呼ぶと、まだ実行していない後続の明示的 Rmdir アクションの対象を先取りして消してしまい、レポート（`result.Pruned`）が不正確になる、または祖先チェーンの外側（placement target とは無関係な祖先）まで意図せず剪定してしまう。
+
+空祖先ディレクトリ剪定そのものは #174 の役割のまま **最終段 `removeStale` と `reset`** に閉じており、PreRemove 段は「配置を妨げる自己記録 stale を計画通りに除去する」責務に純化する。
+
 ## 根拠
 
 - **空 dir を由来問わず許す**のは、rmdir が空でしか成功せずデータ損失が原理的にゼロなため。ユーザーは config でその target を（symlink または copy として）宣言済みであり、nput が作ったかどうかの判別コストを払う理由がない。
@@ -72,7 +78,7 @@ ADR-0046 §3 で導入した「PreRemove は最終段の removeStale と違い�
 ## 影響
 
 - **`internal/planner/planner.go`**: `RemoveAction.Kind`（`RemoveUnlink`/`RemoveRmdir`）追加。`FS.ReadDir` 追加（`osFS` 実装含む）。`Compute` の実 dir 分岐（symlink method・target が実 dir のとき `classifyDirMigration` で判定）追加。`classifyCopy` に method 変更（symlink→copy）の migration 分岐を追加。
-- **`internal/engine/staleremove.go`**: `preRemove` を `RemoveAction.Kind` で分岐。Rmdir は事前空チェックなしで `os.Remove` の結果を再検証として使う。Unlink・Rmdir とも drift は一律 error 停止。
+- **`internal/engine/staleremove.go`**: `preRemove` を `RemoveAction.Kind` で分岐。Rmdir は事前空チェックなしで `os.Remove` の結果を再検証として使う。Unlink・Rmdir とも drift は一律 error 停止。`preRemove` は #174 の `pruneEmptyAncestors` を呼ばない（§5）。
 - **`internal/engine/drift.go`**: gen-skip 経路の `plan.PreRemove` 空不変条件チェックを一般化後の全 PreRemove 発生源に対応するようコメント更新（判定ロジック自体は変更なし: 全発生源が manifest 差分を伴い derivation を変えるため引き続き gen-skip 経路に到達しない）。
 - **`internal/engine/engine.go`**: dryrun の PreRemove レポートを Kind で分岐（Rmdir は `Entry` を持たないため `result.Pruned` へ、Unlink は従来通り `result.Removed` へ）。
 - **`docs/adr/0046-*.md`**: 改訂対象の back-reference 注記を追記。

--- a/docs/adr/0047-preremove-generalization.md
+++ b/docs/adr/0047-preremove-generalization.md
@@ -1,0 +1,91 @@
+# ADR-0047: 配置前除去（PreRemove）の一般化 — 配置を塞ぐ自己記録 stale の migration と空 dir の除去
+
+- ステータス: 採用
+- 日付: 2026-07-12
+- 関連: ADR-0002, ADR-0003, ADR-0006, ADR-0015, ADR-0017, ADR-0020, ADR-0031, ADR-0046, `docs/spec.md`, GitHub Issue #175, #172
+- 改訂対象: **ADR-0046**「自己記録の祖先 symlink 配下ネストを許可する」を「配置を塞ぐ自己記録 stale 全般（実 dir target・method 変更）」へ一般化。**ADR-0015 §2**「前世代 manifest 記録の symlink は置換可（silent・後勝ち）」の判定を method 横断（symlink→copy）へ拡張。
+- 起点: epic #172 の grilling セッション（2026-07-12）で確定した D1〜D6 のうち、PreRemove 一般化本体（D2, D3, D5）
+
+## 背景
+
+ADR-0046 は「配置 target の**祖先**が自己記録 stale symlink のとき、それを配置前に除去（PreRemove）してネスト移行する」ことだけを許した。しかし home-manager との意味論突合（epic #172 背景）で、それだけでは足りない 2 つの実運用パターンが判明した。
+
+1. **target 自身が実 dir のケース**: 前世代が `foo/main.sh`（per-file）を配置し、新世代がその親 `foo` 自体を dir symlink にしようとすると、`foo` は実 dir として存在しているため「target already has an existing file/directory」で conflict になる。ADR-0046 は祖先の緩和しか扱わないため、**target そのもの**が実 dir のケースは救えない。2026-07-12 の実障害（`.claude/hooks/<name>/main.sh` → `.claude/hooks/<name>` の dir symlink 化）はこのパターン。
+2. **method 変更のケース**: 同一 target で `method` を `symlink` から `copy` へ変えると、前世代が置いた symlink が target を占有しており、copy 側の分類は「structure mismatch」または「foreign」として conflict / skip になる。symlink はユーザーデータを持たないため、これも自動移行して安全なはずだが、現状は手動 `rm` が要る。
+
+nput は manifest 記録を持つため、これらも「自分が置いて自分が消す」の範囲内であれば安全に自動化できる。ADR-0046 の枠組み（`Plan.PreRemove` による配置前除去）を、対象を「祖先」から「配置を塞ぐ自己記録 stale 全般」へ広げることで両方を解決する。
+
+## 決定
+
+### 1. 実 dir target は「配下全 leaf が recorded∧stale または空 dir」なら migration
+
+symlink method の entry の target に実 dir が既存でも、次の条件を**すべて**満たせば conflict にせず migration する。
+
+- 配下の各 leaf（任意深さ）が、以下のいずれか:
+  - **recorded ∧ stale**（前世代 manifest が記録した symlink・on-disk が記録 dest と一致・次世代に無い）→ 配置前に Unlink
+  - **空の sub dir**（由来を問わない。rmdir は空でしか成功せず、データ損失が原理的にゼロなため、nput が作った dir かどうかを判別する必要がない）→ 配置前に Rmdir
+- 上記以外の leaf が 1 つでもあれば、**dir 全体**を conflict にする（部分除去はしない）:
+  - 中身のある実 file・実 dir（foreign or 判別不能）
+  - foreign symlink（記録なし / 記録 dest と不一致）
+  - 次世代にも同じ target が entry として残る symlink（自己矛盾 manifest）
+
+判定は plan 時に「全 leaf 除去後に dir チェーン全体が空になる」ことを先に確定させてから行う。除去は子から親へ（bottom-up）、Unlink を先に・Rmdir を後に並べる。
+
+copy method の entry には適用しない（copy target は本 ADR のスコープ外・place-once の対象外構造）。
+
+### 2. method 変更は symlink→copy のみ自動移行、copy→symlink は非対称に conflict のまま
+
+同一 target で `method` が変わったとき:
+
+- **symlink → copy**: 前世代が記録した symlink で on-disk が記録 dest と一致するなら、配置前に Unlink してから place-once copy を新規配置する（silent）。symlink はユーザーデータを持たないため損失ゼロ。
+- **copy → symlink**: **自動移行しない**。copy はユーザーが編集した可能性のある実データであり、symlink 化のために黙って消すのは危険。従来通り「target already has an existing file/directory」で conflict のまま。`--backup`（#169・別 issue）が脱出ハッチになる。
+
+readlink が記録先と一致しない（drift）場合は、symlink→copy 方向でも自動移行せず通常の foreign 判定（skip + `WarnCopyForeign`）へフォールバックする。
+
+### 3. drift 時の意味論は PreRemove 系全体で一律 error 停止・最終段 removeStale は不変
+
+ADR-0046 §3 で導入した「PreRemove は最終段の removeStale と違い、drift を skip せず error で停止する」非対称を、一般化した対象（実 dir 配下の leaf Unlink・空 dir の Rmdir・method 変更の Unlink）**全てに適用**する。
+
+- **Unlink drift**（symlink が記録 dest と不一致 / 消失）→ error 停止。
+- **Rmdir drift**（rmdir 直前に dir が非空になっていた = ENOTEMPTY/EEXIST）→ 事前の空チェックはせず、`os.Remove` の結果そのものを再検証として使う（TOCTOU 安全）。非空なら error 停止。
+
+理由は ADR-0046 §3 と同根: 後続の配置は「PreRemove で対象が消えている」ことを前提に無条件で行われるため、drift を skip して配置を続行すると、drift 後の実体（例: foreign な書き込み可能 dir）の配下へ書き込んでしまい、ADR-0015 §4 が防いだ store 汚染を再び開く。冪等な再実行で現状の FS に対し再計画され収束する（→ ADR-0017）。
+
+最終段 `removeStale`（プレースメント本流の最後の独立 stale 除去）は本 ADR で意味論を変えない。drift は従来通り warning で残置する。
+
+### 4. データモデル: RemoveAction に Kind を追加
+
+`planner.RemoveAction` に `Kind`（`RemoveUnlink` / `RemoveRmdir`）を追加する。`RemoveUnlink` は従来通り `Entry` を伴う記録済み symlink の除去。`RemoveRmdir` は `Entry` を持たない空 dir の除去（rmdir に再検証すべき manifest 記録が無いため、直前の `os.Remove` 結果自体を再検証として扱う）。
+
+実行順序は **スライス順**で表現する: planner は子を親より先に積む（Unlink → 深い dir から浅い dir への Rmdir の順）。同一 target の重複除去は ADR-0046 由来の `preRemoved` map をそのまま使って dedup する。
+
+`planner.FS` に `ReadDir(path string) ([]os.DirEntry, error)` を追加し、実 dir 配下の走査を可能にする。走査は lstat ベースで symlink の中へ降りない（ADR-0046 §2 と同じ安全規則）。
+
+## 根拠
+
+- **空 dir を由来問わず許す**のは、rmdir が空でしか成功せずデータ損失が原理的にゼロなため。ユーザーは config でその target を（symlink または copy として）宣言済みであり、nput が作ったかどうかの判別コストを払う理由がない。
+- **中身のある foreign が 1 つでも dir 全体を conflict にする**のは、部分除去がユーザーの意図しない中間状態を生むため。「移行できるところだけ移行する」設計はエラーの見落としを誘発する。
+- **symlink→copy のみ自動化し copy→symlink はしない**のは非対称だが、データ損失リスクの非対称性を反映している。symlink はデータを持たないが copy はユーザー編集を含みうる。この非対称は ADR-0020（copy の place-once・ユーザー管理）と一貫する。
+- **drift 一律 error 停止**は ADR-0046 §3 の踏襲。skip 続行は `MkdirAll` の symlink 追従による store/foreign 汚染窓を開く。
+- **`RemoveAction.Kind` によるデータモデル拡張**は ADR-0003（planner=純粋にプラン決定 / engine=FS 反映）の役割分担に沿う。Rmdir という「Entry を伴わない除去」を明示的な型として表現することで、engine 側の実行ロジックが分岐に迷わない。
+
+## 影響
+
+- **`internal/planner/planner.go`**: `RemoveAction.Kind`（`RemoveUnlink`/`RemoveRmdir`）追加。`FS.ReadDir` 追加（`osFS` 実装含む）。`Compute` の実 dir 分岐（symlink method・target が実 dir のとき `classifyDirMigration` で判定）追加。`classifyCopy` に method 変更（symlink→copy）の migration 分岐を追加。
+- **`internal/engine/staleremove.go`**: `preRemove` を `RemoveAction.Kind` で分岐。Rmdir は事前空チェックなしで `os.Remove` の結果を再検証として使う。Unlink・Rmdir とも drift は一律 error 停止。
+- **`internal/engine/drift.go`**: gen-skip 経路の `plan.PreRemove` 空不変条件チェックを一般化後の全 PreRemove 発生源に対応するようコメント更新（判定ロジック自体は変更なし: 全発生源が manifest 差分を伴い derivation を変えるため引き続き gen-skip 経路に到達しない）。
+- **`internal/engine/engine.go`**: dryrun の PreRemove レポートを Kind で分岐（Rmdir は `Entry` を持たないため `result.Pruned` へ、Unlink は従来通り `result.Removed` へ）。
+- **`docs/adr/0046-*.md`**: 改訂対象の back-reference 注記を追記。
+- **`docs/adr/0015-*.md`**: §2 の method 横断拡張の back-reference 注記を追記。
+- **`docs/spec.md`**: 配置動作仕様（実 dir target の migration・method 変更）・エラー仕様表・実行フローへ反映。
+- **cross-epic**: #173（Rollback への PreRemove 配線）は本 ADR の一般化 executor（`preRemove`）をそのまま利用できる設計にしてある。マージ順による rebase 調整は後工程。#176（conflict 全件報告）はスコープ外のまま。#168（undo ジャーナル）は本 ADR の Unlink/Rmdir 両方を undo 対象に含める前提で設計する。
+
+## 棄却した代替案
+
+- **全面反転（home-manager 型の remove→place の完全対称・2 段化）**: 依存除去のみ前段化する現行方式（ADR-0006 の本流順序は不変）ではなく、独立 stale 除去まで含めて全面的に「先に全部消してから全部置く」設計にすると、rename（target A 削除 + B 追加）のような独立除去まで前段化することになる。除去後・配置前でクラッシュすると新旧どちらのパスにも実体が無い瞬間が生じる（home-manager はこれを受容しているが、nput は成功時の挙動を home-manager と同一に保ちながらクラッシュ耐性は上位互換にしたい）。依存除去のみ前段化すれば、この窓は開かない。
+- **現状維持 + 実 dir 例外のみアドホックに追加**: 移行パターン（祖先 symlink・実 dir target・method 変更）ごとに個別の特例コードを積み上げると、パターンが増えるたびに例外が累積し、保守不能になる。`RemoveAction.Kind` によるデータモデル拡張で一般化した方が、将来の対象拡張にも耐える。
+- **自動作成した親 dir を manifest に記録する（schema v2）**: 「nput が作った dir かどうか」を manifest で追跡すれば実 dir migration の判定が楽になるが、schemaVersion v1 の契約を破る（MVP は v1 のみ・ADR-0015 §7）。空 dir は由来を問わず migration 対象にできる（rmdir の性質上データ損失ゼロ）ため、記録なしで v1 契約のまま解決できる。
+- **foreign symlink 混在まで除去許容**: 他ツール管理の symlink を巻き込む可能性があり、ADR-0015 §4 の安全策が崩れる。
+- **PreRemove drift を warn+skip（home-manager 型）にする、または再計画リトライを内蔵する**: warn+skip は drift 後の実体経由での store/foreign 汚染窓を開く（ADR-0046 §3 と同根）。再計画リトライの内蔵は複雑化する上、冪等再実行（ADR-0017）による収束と役割が重複する。
+- **copy→symlink も自動移行する**: ユーザーが編集済みの copy データを黙って失う可能性があり、place-once（ADR-0020）の「ユーザー管理」思想と衝突する。
+- **内容同一なら上書きを許す（`cmp -s` 型の判定）・per-entry の `--force` フラグ**: symlink 配置に「内容同一」という概念はほぼ意味を持たない（dest パスの一致で十分）。per-entry force は #169 の `--backup` と目的が重複する。実需が具体化したら別 ADR で検討する。

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -723,21 +723,21 @@ entry 階層を変更するたびに空 dir が積もり、後続配置を塞ぐ
 - **root 自体は絶対に消さない**。親チェーンの走査は root 境界で必ず停止する。
 - **祖先チェーンに symlink が現れたら、それに触れず停止する**（symlink 自体を rmdir すると
   リンクそのものを消してしまい実体には触れないため、安全側に倒して何もしない）。
-- **適用範囲は全除去経路**: removeStale（apply / rollback から共用）・PreRemove・
+- **適用範囲は最終段の除去経路**: removeStale（apply / rollback から共用）・
   `reset` の symlink 除去・copy target 削除。除去した target ごとに独立して walk するため、
   別 entry が同じ dir を共有していれば非空として自然に残る。
-- **PreRemove 経由は Place より前に走る**ため、祖先 symlink の除去で外側の dir が
-  一時的に空になった場合、その場で剪定されたうえで直後の Place（`ensureParentDir` の
-  `mkdir -p`）が同じ dir を作り直すことがある（→ ADR-0046）。最終的な FS 状態は不変
-  （実体として消えたままにはならない）だが、`-v` レポートの `pruned <path>` には
-  「この apply の途中で一度空になった」事実として現れる。
+- **PreRemove は本剪定ヘルパを呼ばない**（→ ADR-0047 §5）。PreRemove の各除去（Unlink /
+  Rmdir）は必ず直後の配置で同じ場所に何かが再配置される前提のため、剪定しても即座に
+  作り直されるだけで無駄な往復になる。一般化後（実 dir target migration）は 1 回の
+  PreRemove 呼び出しで複数の Unlink/Rmdir を bottom-up 順に処理するため、途中で祖先剪定を
+  挟むと、まだ実行していない後続の明示的 Rmdir アクションの対象を先取りして消してしまい
+  レポートが不正確になる。実 dir migration で除去する dir チェーンは、そもそも planner の
+  `classifyDirMigration` が子から親まで明示的に `RemoveAction`(`Kind = RemoveRmdir`) として
+  列挙済みであり、剪定ヘルパによる探索的な追加除去を必要としない。
 - **出力規律**: 剪定は意図された掃除であり warning にはしない。既定 silent、`-v` で
   配置レポートに `pruned <path>` として可視化する（→ ADR-0031）。剪定ヘルパ自体の失敗
-  （権限エラー等の異常系。ENOTEMPTY は上記の通り対象外）は、PreRemove を含む全経路で
-  warning にとどめ、除去自体（target の unlink）は成功として扱う。剪定対象は target 除去
-  で既に空になった祖先であり、後続の子配置が使う dir とは別物のため、剪定失敗は子配置の
-  安全性を損なわない（drift 時に一律 error 停止する D3 の対象＝ancestor symlink 自体の
-  再検証とは別軸・→ ADR-0046）。空 dir の残置は cosmetic な取りこぼしに過ぎない。
+  （権限エラー等の異常系。ENOTEMPTY は上記の通り対象外）は、呼び出し元の既存ポリシーに従う:
+  removeStale / `reset` は warning で残置。空 dir の残置は cosmetic な取りこぼしに過ぎない。
 
 ### GC とストレージ解放
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -332,7 +332,8 @@ nput apply <name> [-f <ep>] [--root <p>]
      c. profileDir の前世代 manifest.json を読む（無ければ初回 = 削除対象ゼロ）
      d. project mode かつ新 link-farm が前世代と同一なら新世代は積まない（世代スキップ）。ただし各 target を lstat 検査し、
         ドリフトした entry だけ再張りする（完全 no-op にしない・→ ADR-0017）
-     e. manifest.json を新旧 diff → 自己記録 stale 祖先 symlink を配置前除去（PreRemove・ネスト移行・→ ADR-0046）→ 新規/張替を配置 → 保守的 stale 除去（ネイティブ FS）
+     e. manifest.json を新旧 diff → 配置を塞ぐ自己記録 stale（祖先 symlink・実 dir target・method 変更）を配置前除去
+        （PreRemove・migration・→ ADR-0046, ADR-0047）→ 新規/張替を配置 → 保守的 stale 除去（ネイティブ FS）
      f. nix-env --profile <profileDir>/profile --set <link-farm>（サブプロセス・コミット点）
      g. --set 成功後に <profileDir>/.pending を削除（世代リンクが gcroot を引き継ぐ・→ ADR-0011）
 ```
@@ -570,7 +571,16 @@ engine が**ネイティブ FS 操作**で行う（`ln` / `rsync` は使わな�
      → その祖先を配置前に除去（PreRemove）し、配下子を新規配置してネスト移行する（silent・`-v` で可視・→ ADR-0046）
    - foreign（記録なし / 記録 dest と不一致 / 前世代なし）または次世代にも祖先が残る自己矛盾
      → エラーで停止（配下にネストできない。store 汚染 / dangling を防ぐ・→ ADR-0015 §4, ADR-0046）
-1. target の親ディレクトリを作成（mkdir -p 相当。緩和対象の祖先 symlink は PreRemove 除去済み・foreign は 0 で弾き済み）
+0.5. target 自身が実 dir のとき、配下（任意深さ）の全 leaf を判定する（→ ADR-0047）:
+   - 全 leaf が「recorded ∧ stale な symlink（自身の前世代が記録・on-disk 一致・次世代に無い）」
+     または「空の sub dir（由来を問わない）」なら → target 全体を配置前に除去（PreRemove: leaf は Unlink・
+     dir は子から親へ Rmdir・silent・`-v` で可視）してから symlink を新規配置
+   - 上記以外の leaf が 1 つでもある（中身のある実 file/dir・foreign symlink・次世代にも残る自己矛盾）
+     → target 全体をエラーで停止（部分除去はしない・→ ADR-0047 D2）
+0.6. target と同一 target で method が symlink→copy に変わるとき、前世代が記録した symlink で on-disk が
+   記録通りなら → 配置前に除去（PreRemove・silent）してから copy を新規配置（→ ADR-0047 D5）。
+   readlink drift（on-disk が記録と不一致）は移行せず通常の foreign 判定へフォールバックする。
+1. target の親ディレクトリを作成（mkdir -p 相当。緩和対象の祖先 symlink / 実 dir target は PreRemove 除去済み・foreign は 0 で弾き済み）
 2. target が既存 symlink のとき:
    - 自身の前世代 manifest が記録した symlink → そのまま置き換える（silent）
    - 記録の無い symlink（foreign = 他 nput profile / 他ツール / 手動）→ warning を出して置き換える（後勝ち・→ ADR-0015）
@@ -580,9 +590,10 @@ engine が**ネイティブ FS 操作**で行う（`ln` / `rsync` は使わな�
 ```
 
 - 既存 symlink の張替えは **unlink + symlink の 2 操作**で行う（rename ベースの atomic swap は採らない）。間でクラッシュすると target が一時消失しうるが、**冪等な再実行で収束**する（ADR-0006「積まれる世代は常に完全適用済み」と整合・→ ADR-0017）。
-- target に通常ファイルまたはディレクトリが存在する場合はエラーで停止（上書きしない）
+- target に通常ファイルまたはディレクトリが存在する場合はエラーで停止（上書きしない）。ただし実 dir は §0.5 の条件を満たせば例外的に PreRemove で除去して配置する（→ ADR-0047）
 - subpath がファイル・ディレクトリどちらでも同じ処理
 - 別 config（別 profile）が同一 target を狙うのは基本「衝突させない前提」。後勝ちを許容しつつ foreign symlink 上書きは warning で可視化する（→ ADR-0015）
+- method 変更 copy→symlink は自動移行しない（ユーザー編集済み copy データの保護を優先し、従来通り conflict のまま・→ ADR-0047 D5）
 
 ### copy モード（place-once・ユーザー管理）
 
@@ -946,10 +957,15 @@ devShells.default = pkgs.mkShell {
 | `src` が存在しないストアパス（path / set）| Nix 評価時にエラー |
 | `src` が marker でローカルパスが存在しない | engine 実行時にエラーで停止 |
 | `subpath` が `src` 内に存在しないパス | engine 実行時にエラーで停止 |
-| `target` に通常ファイル・ディレクトリが既存（symlink モード）| conflict。全件を stderr へ列挙して停止（上書きしない・→ 後述「conflict の全件報告」）|
+| `target` に通常ファイルが既存（symlink モード）| conflict。全件を stderr へ列挙して停止（上書きしない・→ 後述「conflict の全件報告」）|
+| `target` が実 dir で既存（symlink モード）、配下（任意深さ）の全 leaf が recorded∧stale な symlink または空 sub dir（由来問わず）| dir 全体を配置前に除去（PreRemove: leaf は Unlink・dir は子から親へ Rmdir）し新規配置（silent・`-v` で可視・`--dryrun` は非 conflict の remove・→ ADR-0047）|
+| `target` が実 dir で既存（symlink モード）、配下に中身のある実 file/dir・foreign symlink・次世代にも残る自己矛盾 symlink が 1 つでもある | conflict。dir 全体を停止し全件を stderr へ列挙（部分除去はしない・`--dryrun` も conflict・→ ADR-0047, 後述「conflict の全件報告」）|
 | `target` の祖先 component が foreign symlink（記録なし / 記録 dest と不一致 / 前世代なし）、または次世代にも祖先が残る自己矛盾 | conflict。engine 実行時に全件を stderr へ列挙して停止（lstat walk・`--dryrun` も conflict・→ ADR-0015 §4, ADR-0046, 後述「conflict の全件報告」）|
 | `target` の祖先 component が自己記録 stale symlink（前世代 manifest が記録・on-disk 一致・次世代に無い）| 祖先を配置前に除去（PreRemove）し配下子を新規配置してネスト移行（silent・`-v` で可視・`--dryrun` は非 conflict の remove・→ ADR-0046）|
 | `target` に foreign symlink が既存（自身の前世代 manifest に記録なし・別 config / 別ツール / 手動）| warning を出して後勝ちで置き換える（→ ADR-0015）|
+| 同一 `target` で method が symlink→copy に変更、前世代が記録した symlink で on-disk が記録通り | 配置前に除去（PreRemove）し copy を新規配置（silent・`-v` で可視・readlink drift 時は通常の foreign 判定へフォールバック・→ ADR-0047 D5）|
+| 同一 `target` で method が copy→symlink に変更 | 自動移行しない。エラーで停止（`target` に既存ファイルとして扱う・`--backup` が脱出ハッチ・→ ADR-0047 D5）|
+| PreRemove 対象（祖先 symlink / 実 dir 配下 leaf・dir / method 変更 symlink）が計画後に drift（記録不一致・ENOTEMPTY 等）| skip せずエラーで停止（冪等再実行で収束・→ ADR-0046 §3, ADR-0047 D3）|
 | `subpath` がディレクトリのとき `target` に通常ファイルが既存（copy モード）| conflict。全件を stderr へ列挙して停止（→ 後述「conflict の全件報告」）|
 | `subpath` がファイルのとき `target` がディレクトリとして既存（copy モード）| conflict。全件を stderr へ列挙して停止（→ 後述「conflict の全件報告」）|
 | copy モードで `target` が既存（前世代 manifest に entry あり = nput 配置済み）| place-once により何もしない（上書きしない）。`apply --recopy` 時のみ無条件上書き（→ ADR-0020）|

--- a/internal/engine/drift.go
+++ b/internal/engine/drift.go
@@ -47,16 +47,19 @@ func generationUnchanged(profileLink, newLinkFarm string) (bool, error) {
 //     generations" · ADR-0022). On --recopy, recopyAll overwrites unconditionally (recopy is
 //     an opt-in outside generations).
 //
-// plan.PreRemove is structurally empty on this path: an ancestor→children migration changes the
-// manifest, hence the link-farm derivation, so generationUnchanged is never true and the gen-skip
-// branch is not taken (→ ADR-0046). The drift repair therefore has no pre-removal to run.
+// plan.PreRemove is structurally empty on this path: every PreRemove source — ancestor→children
+// migration, an occupying real directory fully migrated, or a symlink→copy method change (→
+// ADR-0046, ADR-0047) — requires the new manifest to differ from the previous generation's at the
+// affected target, which changes the link-farm derivation. So generationUnchanged is never true
+// for a plan with a non-empty PreRemove, and the gen-skip branch above is not taken. The drift
+// repair therefore has no pre-removal to run.
 func (a *applier) repairDrift(plan planner.Plan, recopy bool) error {
-	// Defensive guard for the invariant the doc comment relies on: a migration changes the manifest
-	// (hence the derivation), so it can never reach the gen-skip path with a non-empty PreRemove.
-	// If that ever breaks, silently dropping the pre-removal would let place nest children through a
-	// live ancestor symlink — fail loudly instead (→ ADR-0046).
+	// Defensive guard for the invariant the doc comment relies on: any PreRemove source changes the
+	// manifest (hence the derivation) at its target, so it can never reach the gen-skip path with a
+	// non-empty PreRemove. If that ever breaks, silently dropping the pre-removal would let place
+	// nest/place through stale content still occupying the target — fail loudly instead (→ ADR-0046, ADR-0047).
 	if len(plan.PreRemove) > 0 {
-		return fmt.Errorf("nput: internal invariant violated: generation-skip drift repair received %d ancestor pre-removal(s) (→ ADR-0046)", len(plan.PreRemove))
+		return fmt.Errorf("nput: internal invariant violated: generation-skip drift repair received %d pre-removal(s) (→ ADR-0046, ADR-0047)", len(plan.PreRemove))
 	}
 	drifted := make([]planner.PlaceAction, 0, len(plan.Place))
 	for _, act := range plan.Place {

--- a/internal/engine/dryrun_test.go
+++ b/internal/engine/dryrun_test.go
@@ -121,3 +121,52 @@ func TestApplyDryRunAncestorMigration(t *testing.T) {
 		t.Errorf("child should not be created in dryrun, lstat err = %v", err)
 	}
 }
+
+// TestApplyDryRunRealDirMigration verifies dryrun's reporting of a real-dir-target migration
+// (→ ADR-0047, issue #175): the occupying directory's recorded-stale leaf is packed into
+// Removed (Kind == RemoveUnlink), the now-empty directory itself into Pruned as an absolute
+// path (Kind == RemoveRmdir, matching the real-run convention — result.Pruned is always
+// absolute), the entry into Placed, and the FS is left untouched.
+func TestApplyDryRunRealDirMigration(t *testing.T) {
+	root := realTempDir(t)
+	state := realTempDir(t)
+	srcOld := realTempDir(t)
+
+	lf1 := writeLinkFarm(t, projectManifest(storeEntry(srcOld, ".", ".claude/hooks/foo")))
+	if _, err := Apply(Options{
+		LinkFarm: lf1, Name: "c", RootOverride: root, StateDir: state, Commit: fakeCommit(nil),
+	}); err != nil {
+		t.Fatalf("first Apply: %v", err)
+	}
+
+	srcNew := realTempDir(t)
+	lf2 := writeLinkFarm(t, projectManifest(storeEntry(srcNew, ".", ".claude/hooks")))
+	res, err := Apply(Options{
+		LinkFarm: lf2, Name: "c", RootOverride: root, StateDir: state, DryRun: true,
+	})
+	if err != nil {
+		t.Fatalf("dryrun Apply: %v", err)
+	}
+	if len(res.Conflicts) != 0 {
+		t.Errorf("Conflicts = %v, want none (a fully recorded-stale real dir is a migration, not a conflict)", res.Conflicts)
+	}
+	if len(res.Removed) != 1 || res.Removed[0] != ".claude/hooks/foo" {
+		t.Errorf("Removed = %v, want [.claude/hooks/foo]", res.Removed)
+	}
+	wantPruned := filepath.Join(root, ".claude", "hooks")
+	if len(res.Pruned) != 1 || res.Pruned[0] != wantPruned {
+		t.Errorf("Pruned = %v, want [%s] (absolute path, matching the real-run convention)", res.Pruned, wantPruned)
+	}
+	if len(res.Placed) != 1 || res.Placed[0] != ".claude/hooks" {
+		t.Errorf("Placed = %v, want [.claude/hooks]", res.Placed)
+	}
+
+	// FS untouched: the occupying real directory and its recorded-stale child are both still present.
+	info, err := os.Lstat(filepath.Join(root, ".claude", "hooks"))
+	if err != nil || info.Mode()&os.ModeSymlink != 0 {
+		t.Errorf(".claude/hooks should still be a real directory in dryrun (err %v)", err)
+	}
+	if got, err := os.Readlink(filepath.Join(root, ".claude", "hooks", "foo")); err != nil || got != srcOld {
+		t.Errorf(".claude/hooks/foo should be untouched in dryrun = %q (err %v); want symlink to %q", got, err, srcOld)
+	}
+}

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -233,8 +233,10 @@ func Apply(opts Options) (*Result, error) {
 		}
 	}
 
-	// 8. reflect the plan onto the real FS. PreRemove first (unlink self-recorded stale ancestor
-	//    symlinks so nested children land in a real dir · local exception to ADR-0006 · → ADR-0046),
+	// 8. reflect the plan onto the real FS. PreRemove first (clear whatever self-recorded stale
+	//    filesystem object occupies a placement target — an ancestor symlink, a real directory
+	//    fully migratable, or a symlink replaced by a symlink→copy method change — so placement
+	//    lands on an empty/absent target · local exception to ADR-0006 · → ADR-0046, ADR-0047),
 	//    then new / re-link, then stale removal last (→ ADR-0006). copy branches: on --recopy overwrite
 	//    all copy targets unconditionally, normally place-once (new copy only when target is absent) (→ ADR-0020).
 	if err := a.preRemove(plan.PreRemove); err != nil {
@@ -325,6 +327,16 @@ func (a *applier) dryRun() (*Result, error) {
 		a.result.Copied = append(a.result.Copied, c.Entry.Target)
 	}
 	for _, r := range plan.PreRemove {
+		if r.Kind == planner.RemoveRmdir {
+			// Rmdir actions carry no manifest Entry (nothing was ever recorded for a bare
+			// directory); report the root-relative directory path instead (→ ADR-0047, issue #175).
+			rel, err := filepath.Rel(a.root, r.TargetAbs)
+			if err != nil {
+				rel = r.TargetAbs
+			}
+			a.result.Pruned = append(a.result.Pruned, rel)
+			continue
+		}
 		a.result.Removed = append(a.result.Removed, r.Entry.Target)
 	}
 	for _, r := range plan.Remove {

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -329,12 +329,10 @@ func (a *applier) dryRun() (*Result, error) {
 	for _, r := range plan.PreRemove {
 		if r.Kind == planner.RemoveRmdir {
 			// Rmdir actions carry no manifest Entry (nothing was ever recorded for a bare
-			// directory); report the root-relative directory path instead (→ ADR-0047, issue #175).
-			rel, err := filepath.Rel(a.root, r.TargetAbs)
-			if err != nil {
-				rel = r.TargetAbs
-			}
-			a.result.Pruned = append(a.result.Pruned, rel)
+			// directory); report the absolute directory path instead, matching the real-run
+			// convention (result.Pruned is always absolute — staleremove.go's preRemove /
+			// pruneEmptyAncestors · → ADR-0047, issue #175).
+			a.result.Pruned = append(a.result.Pruned, r.TargetAbs)
 			continue
 		}
 		a.result.Removed = append(a.result.Removed, r.Entry.Target)

--- a/internal/engine/generations_test.go
+++ b/internal/engine/generations_test.go
@@ -313,7 +313,7 @@ func TestRollbackAncestorPreRemoveErrorSkipsSwitch(t *testing.T) {
 	// not merely to any early return — e.g. a future planner change that routed this setup to
 	// Conflicts instead of PreRemove would also make Rollback error out before switchFn, and a
 	// bare err != nil check would pass despite never reaching the code this test targets.
-	if err == nil || !strings.Contains(err.Error(), "cannot remove ancestor symlink for migration") {
+	if err == nil || !strings.Contains(err.Error(), "cannot remove recorded symlink for migration") {
 		t.Fatalf("expected a preRemove unlink error, got %v", err)
 	}
 	if switched != 0 {

--- a/internal/engine/preremove_generalization_test.go
+++ b/internal/engine/preremove_generalization_test.go
@@ -446,13 +446,20 @@ func TestApplyDirMigrationInterruptedAfterPreRemoveReRunConverges(t *testing.T) 
 	// An ordinary re-run apply must re-plan against this partially-migrated FS (target absent, no
 	// PreRemove needed this time) and converge to the fully-migrated state without erroring.
 	lf2 := writeLinkFarm(t, projectManifest(storeEntry(srcNew, ".", ".claude/hooks")))
-	if _, err := Apply(Options{
+	res, err := Apply(Options{
 		LinkFarm: lf2, Name: "c", RootOverride: root, StateDir: state, Commit: fakeCommit(nil),
-	}); err != nil {
+	})
+	if err != nil {
 		t.Fatalf("re-run Apply after simulated crash: %v", err)
 	}
-	got, err := os.Readlink(filepath.Join(root, ".claude", "hooks"))
-	if err != nil || got != srcNew {
-		t.Fatalf("re-run readlink = %q, err %v; want %q", got, err, srcNew)
+	got, rerr := os.Readlink(filepath.Join(root, ".claude", "hooks"))
+	if rerr != nil || got != srcNew {
+		t.Fatalf("re-run readlink = %q, err %v; want %q", got, rerr, srcNew)
+	}
+	// The target was already absent going into the re-run (the simulated crash's PreRemove already
+	// cleared it), so this second Apply must take the plain PlaceNew path, not PreRemove again —
+	// confirming the crash window truly left nothing further for PreRemove to do.
+	if len(res.Removed) != 0 || len(res.Pruned) != 0 {
+		t.Errorf("re-run Removed/Pruned = %v/%v, want both empty (no PreRemove needed against an already-absent target)", res.Removed, res.Pruned)
 	}
 }

--- a/internal/engine/preremove_generalization_test.go
+++ b/internal/engine/preremove_generalization_test.go
@@ -48,6 +48,38 @@ func TestApplyPerFileToDirSymlinkMigratesSameNamedLeaf(t *testing.T) {
 	if len(res.Conflicts) != 0 {
 		t.Errorf("Conflicts = %v, want none", res.Conflicts)
 	}
+	// The leaf must be reported exactly once as Removed (Unlink). Both the intermediate
+	// ".claude/hooks/foo" directory AND the placement target ".claude/hooks" itself are
+	// legitimately Rmdir-ed and reported in Pruned exactly once each — not twice each. A prior
+	// bug double-reported them: preRemove's own pruneEmptyAncestors walk (triggered by the
+	// leaf's Unlink, or by an inner Rmdir's success) raced the planner's own explicit,
+	// already-ordered RemoveRmdir actions for the same directories, recording each directory
+	// from two paths (→ ADR-0047, issue #175). preRemove no longer walks pruneEmptyAncestors at
+	// all, since every directory a migration needs cleared is already an explicit RemoveRmdir
+	// planner action and the placement step that follows recreates the target immediately.
+	if len(res.Removed) != 1 || res.Removed[0] != ".claude/hooks/foo/main.sh" {
+		t.Errorf("Removed = %v, want exactly [.claude/hooks/foo/main.sh]", res.Removed)
+	}
+	wantPruned := []string{
+		filepath.Join(root, ".claude", "hooks", "foo"),
+		filepath.Join(root, ".claude", "hooks"),
+	}
+	if len(res.Pruned) != len(wantPruned) {
+		t.Errorf("Pruned = %v, want exactly %v (no double-report)", res.Pruned, wantPruned)
+	} else {
+		seen := map[string]bool{}
+		for _, p := range res.Pruned {
+			if seen[p] {
+				t.Errorf("Pruned = %v contains a duplicate: %s", res.Pruned, p)
+			}
+			seen[p] = true
+		}
+		for _, want := range wantPruned {
+			if !seen[want] {
+				t.Errorf("Pruned = %v, missing %s", res.Pruned, want)
+			}
+		}
+	}
 }
 
 // TestApplyDirSymlinkRoundTripsThroughPerFile verifies the reverse and back: dir symlink →
@@ -283,22 +315,21 @@ func TestApplyMethodChangeSymlinkToCopyDriftFallsBackToForeign(t *testing.T) {
 	}
 }
 
-// TestApplyDirMigrationRmdirDriftErrors verifies D3: if a directory the plan scheduled for Rmdir
-// gains content between planning and the PreRemove pass (a directory the plan believed empty),
-// os.Remove's ENOTEMPTY is surfaced as a loud error — not a silent skip — since children were
-// already planned as unconditional new placements assuming the target is clear.
-func TestApplyDirMigrationRmdirDriftErrors(t *testing.T) {
+// TestApplyDirMigrationNonEmptySubdirIsConflictAtPlanTime verifies the plan-time half of D3's
+// safety net: a subdirectory that is non-empty *before Apply even plans* makes the planner
+// classify the whole occupying directory as non-migratable (a real-file leaf), so Apply reports
+// a conflict rather than ever scheduling an Rmdir for it. The complementary runtime half — an
+// Rmdir action scheduled at plan time whose target gains content in the window before preRemove
+// executes it (true TOCTOU) — is exercised directly against applier.preRemove in
+// TestPreRemoveRmdirDriftErrorsDirectly, since Apply's own planning step cannot be paused
+// mid-flight to inject content after a snapshot it already took.
+func TestApplyDirMigrationNonEmptySubdirIsConflictAtPlanTime(t *testing.T) {
 	root := realTempDir(t)
 	state := realTempDir(t)
 
 	if err := os.MkdirAll(filepath.Join(root, "hooks", "empty"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-
-	// Race: something drops a file into the "empty" subdir after planning would have seen it
-	// empty. We can't hook mid-Apply, so instead drive the lower-level preRemove entrypoint
-	// directly with a plan that (correctly, at plan time) expected "hooks/empty" to be empty,
-	// then falsify that expectation on disk before executing — reproducing the drift window.
 	if err := os.WriteFile(filepath.Join(root, "hooks", "empty", "surprise"), []byte("x"), 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -308,11 +339,6 @@ func TestApplyDirMigrationRmdirDriftErrors(t *testing.T) {
 	_, err := Apply(Options{
 		LinkFarm: lf, Name: "c", RootOverride: root, StateDir: state, Commit: fakeCommit(nil),
 	})
-	// Since the file is present *before* planning even runs, the planner itself detects "hooks"
-	// as non-migratable (a real file leaf) and reports a conflict rather than reaching the Rmdir
-	// drift path. This confirms the plan-time classification already refuses to schedule an
-	// Rmdir for a non-empty directory (the drift path is only reachable via a true TOCTOU race,
-	// which is exercised at the unit level in staleremove_test.go-style direct preRemove calls).
 	if err == nil {
 		t.Fatal("expected a conflict/error, got nil")
 	}
@@ -374,12 +400,14 @@ func TestPreRemoveUnlinkDriftErrorsDirectly(t *testing.T) {
 	}
 }
 
-// TestApplyDirMigrationIdempotentReRunConverges verifies ADR-0017 idempotence: if a dir migration
-// apply is interrupted after PreRemove but before the generation commits (simulated here by
-// directly driving preRemove + place without a commit, then re-running the full Apply), a
-// subsequent apply re-plans against the now-partially-migrated FS and converges to the same final
-// state as an uninterrupted apply.
-func TestApplyDirMigrationIdempotentReRunConverges(t *testing.T) {
+// TestApplyDirMigrationInterruptedAfterPreRemoveReRunConverges verifies ADR-0017 idempotence for
+// a genuinely partial-migration crash window: PreRemove runs (the occupying directory's
+// recorded-stale child is unlinked and the now-empty directory rmdir-ed) but the process stops
+// there, before place/commit — the real crash window the generalized PreRemove opens (→ ADR-0047,
+// issue #175 §8). A subsequent ordinary Apply must re-plan against that partially-migrated FS
+// (the target now absent, not a real directory) and converge to the same fully-migrated state as
+// an uninterrupted apply.
+func TestApplyDirMigrationInterruptedAfterPreRemoveReRunConverges(t *testing.T) {
 	root := realTempDir(t)
 	state := realTempDir(t)
 	srcOld := realTempDir(t)
@@ -392,24 +420,39 @@ func TestApplyDirMigrationIdempotentReRunConverges(t *testing.T) {
 	}
 
 	srcNew := realTempDir(t)
+	next := projectManifest(storeEntry(srcNew, ".", ".claude/hooks"))
+	prev := projectManifest(storeEntry(srcOld, ".", ".claude/hooks/foo"))
+	plan, err := planner.Compute(&prev, &next, root, planner.OSFS)
+	if err != nil {
+		t.Fatalf("planner.Compute: %v", err)
+	}
+	if len(plan.Conflicts) != 0 {
+		t.Fatalf("plan.Conflicts = %v, want none", plan.Conflicts)
+	}
+
+	// Simulate a crash: run only PreRemove (unlink the recorded-stale child, rmdir the now-empty
+	// dirs including the placement target itself), then stop — no place, no commit. The target is
+	// now absent from the FS, and the previous generation's manifest.json (the profile link) still
+	// points at generation 1 since --set never ran.
+	a := &applier{opts: Options{Warnf: func(string, ...any) {}}, result: &Result{}}
+	a.root = root
+	if err := a.preRemove(plan.PreRemove); err != nil {
+		t.Fatalf("simulated partial preRemove: %v", err)
+	}
+	if _, err := os.Lstat(filepath.Join(root, ".claude", "hooks")); !os.IsNotExist(err) {
+		t.Fatalf("setup: .claude/hooks must be absent after the simulated crash, lstat err = %v", err)
+	}
+
+	// An ordinary re-run apply must re-plan against this partially-migrated FS (target absent, no
+	// PreRemove needed this time) and converge to the fully-migrated state without erroring.
 	lf2 := writeLinkFarm(t, projectManifest(storeEntry(srcNew, ".", ".claude/hooks")))
-	optsRepeat := Options{LinkFarm: lf2, Name: "c", RootOverride: root, StateDir: state, Commit: fakeCommit(nil)}
-
-	// First (successful, uninterrupted) run reaches the fully migrated state.
-	if _, err := Apply(optsRepeat); err != nil {
-		t.Fatalf("migration Apply: %v", err)
+	if _, err := Apply(Options{
+		LinkFarm: lf2, Name: "c", RootOverride: root, StateDir: state, Commit: fakeCommit(nil),
+	}); err != nil {
+		t.Fatalf("re-run Apply after simulated crash: %v", err)
 	}
-	got1, err := os.Readlink(filepath.Join(root, ".claude", "hooks"))
-	if err != nil || got1 != srcNew {
-		t.Fatalf("post-migration readlink = %q, err %v; want %q", got1, err, srcNew)
-	}
-
-	// Re-running apply against the already-converged FS must be a clean no-op re-link, not an error.
-	if _, err := Apply(optsRepeat); err != nil {
-		t.Fatalf("idempotent re-run: %v", err)
-	}
-	got2, err := os.Readlink(filepath.Join(root, ".claude", "hooks"))
-	if err != nil || got2 != srcNew {
-		t.Fatalf("re-run readlink = %q, err %v; want %q", got2, err, srcNew)
+	got, err := os.Readlink(filepath.Join(root, ".claude", "hooks"))
+	if err != nil || got != srcNew {
+		t.Fatalf("re-run readlink = %q, err %v; want %q", got, err, srcNew)
 	}
 }

--- a/internal/engine/preremove_generalization_test.go
+++ b/internal/engine/preremove_generalization_test.go
@@ -1,0 +1,415 @@
+package engine
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/yasunori0418/nput/internal/planner"
+)
+
+// Tests for PreRemove's generalization from "self-recorded stale ancestor symlink" (ADR-0046)
+// to "any self-recorded stale filesystem object occupying a placement target": an occupying real
+// directory whose whole tree is recorded-stale-or-empty, and a symlink→copy method change
+// (→ ADR-0047, issue #175, #172 D2/D3/D5).
+
+// TestApplyPerFileToDirSymlinkMigratesSameNamedLeaf reproduces the 2026-07-12 real incident: a
+// per-file layout `<name>/main.sh` migrating to a whole-tree dir symlink `<name>`, where the new
+// generation's dir symlink target shares its leaf name with the old per-file target
+// (`.claude/hooks/foo/main.sh` → `.claude/hooks` as a dir symlink). This is exactly the case a
+// naive readlink-pattern cleanup (home-manager's) misjudges; nput's manifest-recorded classification
+// must migrate it cleanly with a single apply (→ issue #172 background, ADR-0047).
+func TestApplyPerFileToDirSymlinkMigratesSameNamedLeaf(t *testing.T) {
+	root := realTempDir(t)
+	state := realTempDir(t)
+	srcOld := makeSrc(t, "foo/main.sh")
+
+	lf1 := writeLinkFarm(t, projectManifest(storeEntry(srcOld, "foo/main.sh", ".claude/hooks/foo/main.sh")))
+	if _, err := Apply(Options{
+		LinkFarm: lf1, Name: "c", RootOverride: root, StateDir: state, Commit: fakeCommit(nil),
+	}); err != nil {
+		t.Fatalf("first Apply: %v", err)
+	}
+
+	srcNew := realTempDir(t)
+	lf2 := writeLinkFarm(t, projectManifest(storeEntry(srcNew, ".", ".claude/hooks")))
+	res, err := Apply(Options{
+		LinkFarm: lf2, Name: "c", RootOverride: root, StateDir: state, Commit: fakeCommit(nil),
+	})
+	if err != nil {
+		t.Fatalf("second Apply (dir migration): %v", err)
+	}
+
+	got, err := os.Readlink(filepath.Join(root, ".claude", "hooks"))
+	if err != nil || got != srcNew {
+		t.Fatalf("readlink(.claude/hooks) = %q, err %v; want %q", got, err, srcNew)
+	}
+	if len(res.Conflicts) != 0 {
+		t.Errorf("Conflicts = %v, want none", res.Conflicts)
+	}
+}
+
+// TestApplyDirSymlinkRoundTripsThroughPerFile verifies the reverse and back: dir symlink →
+// per-file → dir symlink again converges cleanly across three generations, exercising
+// ADR-0046's ancestor migration and ADR-0047's dir migration in sequence.
+func TestApplyDirSymlinkRoundTripsThroughPerFile(t *testing.T) {
+	root := realTempDir(t)
+	state := realTempDir(t)
+	opts := func(lf string) Options {
+		return Options{LinkFarm: lf, Name: "c", RootOverride: root, StateDir: state, Commit: fakeCommit(nil)}
+	}
+
+	src1 := realTempDir(t)
+	lf1 := writeLinkFarm(t, projectManifest(storeEntry(src1, ".", ".claude/skills")))
+	if _, err := Apply(opts(lf1)); err != nil {
+		t.Fatalf("gen1 (dir symlink): %v", err)
+	}
+
+	src2 := makeSrc(t, "nix")
+	lf2 := writeLinkFarm(t, projectManifest(storeEntry(src2, "nix", ".claude/skills/nix")))
+	if _, err := Apply(opts(lf2)); err != nil {
+		t.Fatalf("gen2 (per-file): %v", err)
+	}
+	if got, err := os.Readlink(filepath.Join(root, ".claude", "skills", "nix")); err != nil || got != filepath.Join(src2, "nix") {
+		t.Fatalf("gen2 readlink = %q, err %v", got, err)
+	}
+
+	src3 := realTempDir(t)
+	lf3 := writeLinkFarm(t, projectManifest(storeEntry(src3, ".", ".claude/skills")))
+	if _, err := Apply(opts(lf3)); err != nil {
+		t.Fatalf("gen3 (dir symlink again): %v", err)
+	}
+	got, err := os.Readlink(filepath.Join(root, ".claude", "skills"))
+	if err != nil || got != src3 {
+		t.Fatalf("gen3 readlink = %q, err %v; want %q", got, err, src3)
+	}
+}
+
+// TestApplyDirMigrationConflictLeavesSiblingsUntouched verifies D2's "one real file blocks the
+// whole directory" rule end-to-end: a real file mixed among otherwise-migratable recorded-stale
+// symlinks makes Apply stop with a conflict, and NONE of the migratable siblings are removed —
+// no partial removal (→ ADR-0047 D2, issue #175 §8).
+func TestApplyDirMigrationConflictLeavesSiblingsUntouched(t *testing.T) {
+	root := realTempDir(t)
+	state := realTempDir(t)
+	srcOld := realTempDir(t)
+
+	lf1 := writeLinkFarm(t, projectManifest(
+		storeEntry(srcOld, ".", ".claude/hooks/foo"),
+		storeEntry(srcOld, ".", ".claude/hooks/bar"),
+	))
+	if _, err := Apply(Options{
+		LinkFarm: lf1, Name: "c", RootOverride: root, StateDir: state, Commit: fakeCommit(nil),
+	}); err != nil {
+		t.Fatalf("first Apply: %v", err)
+	}
+
+	// A foreign real file appears alongside the recorded-stale symlinks.
+	if err := os.WriteFile(filepath.Join(root, ".claude", "hooks", "README"), []byte("user"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	srcNew := realTempDir(t)
+	lf2 := writeLinkFarm(t, projectManifest(storeEntry(srcNew, ".", ".claude/hooks")))
+	_, err := Apply(Options{
+		LinkFarm: lf2, Name: "c", RootOverride: root, StateDir: state, Commit: fakeCommit(nil),
+	})
+	if err == nil {
+		t.Fatal("expected a conflict error, got nil")
+	}
+
+	// Both recorded-stale siblings must still exist: no partial removal.
+	for _, leaf := range []string{"foo", "bar"} {
+		if _, err := os.Lstat(filepath.Join(root, ".claude", "hooks", leaf)); err != nil {
+			t.Errorf("sibling %q must survive the conflict untouched: %v", leaf, err)
+		}
+	}
+	if _, err := os.Lstat(filepath.Join(root, ".claude", "hooks", "README")); err != nil {
+		t.Errorf("foreign file must survive: %v", err)
+	}
+}
+
+// TestApplyDirMigrationEmptySubdirsAtMultipleDepths verifies D2's "empty dirs are migratable
+// regardless of provenance" rule across a multi-level nested empty subtree, and that a root-level
+// (direct child of root) real-dir target migrates too.
+func TestApplyDirMigrationEmptySubdirsAtMultipleDepths(t *testing.T) {
+	root := realTempDir(t)
+	state := realTempDir(t)
+
+	// A multi-level empty subtree nput never created, occupying a root-level target directly.
+	if err := os.MkdirAll(filepath.Join(root, "hooks", "a", "b", "c"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	srcNew := realTempDir(t)
+	lf := writeLinkFarm(t, projectManifest(storeEntry(srcNew, ".", "hooks")))
+	res, err := Apply(Options{
+		LinkFarm: lf, Name: "c", RootOverride: root, StateDir: state, Commit: fakeCommit(nil),
+	})
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if len(res.Conflicts) != 0 {
+		t.Fatalf("Conflicts = %v, want none", res.Conflicts)
+	}
+	got, err := os.Readlink(filepath.Join(root, "hooks"))
+	if err != nil || got != srcNew {
+		t.Fatalf("readlink(hooks) = %q, err %v; want %q", got, err, srcNew)
+	}
+}
+
+// TestApplyMethodChangeSymlinkToCopyMigrates verifies D5: a target whose method changes from
+// symlink (previous generation, recorded, on-disk matches) to copy (new generation) is
+// automatically migrated — the recorded symlink is pre-removed and a fresh place-once copy lands
+// in its place, with zero data loss (the symlink carried no user data · → ADR-0047 D5).
+func TestApplyMethodChangeSymlinkToCopyMigrates(t *testing.T) {
+	root := realTempDir(t)
+	state := realTempDir(t)
+	symSrc := realTempDir(t)
+
+	lf1 := writeLinkFarm(t, projectManifest(storeEntry(symSrc, ".", ".config/tool.conf")))
+	if _, err := Apply(Options{
+		LinkFarm: lf1, Name: "c", RootOverride: root, StateDir: state, Commit: fakeCommit(nil),
+	}); err != nil {
+		t.Fatalf("first Apply (symlink): %v", err)
+	}
+
+	copySrc := makeSrc(t, "tool.conf")
+	lf2 := writeLinkFarm(t, projectManifest(copyEntry(copySrc, "tool.conf", ".config/tool.conf")))
+	res, err := Apply(Options{
+		LinkFarm: lf2, Name: "c", RootOverride: root, StateDir: state, Commit: fakeCommit(nil),
+	})
+	if err != nil {
+		t.Fatalf("second Apply (method change → copy): %v", err)
+	}
+
+	info, err := os.Lstat(filepath.Join(root, ".config", "tool.conf"))
+	if err != nil {
+		t.Fatalf("lstat: %v", err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		t.Errorf("target must be a real copied file, not a symlink")
+	}
+	data, err := os.ReadFile(filepath.Join(root, ".config", "tool.conf"))
+	if err != nil || string(data) != "content" {
+		t.Errorf("copied content = %q, err %v; want %q", data, err, "content")
+	}
+	if len(res.Conflicts) != 0 {
+		t.Errorf("Conflicts = %v, want none", res.Conflicts)
+	}
+}
+
+// TestApplyMethodChangeCopyToSymlinkStaysConflict verifies D5's asymmetry: copy→symlink is NOT
+// automated (a copy may hold user edits), so it stays the ordinary no-overwrite conflict.
+func TestApplyMethodChangeCopyToSymlinkStaysConflict(t *testing.T) {
+	root := realTempDir(t)
+	state := realTempDir(t)
+	copySrc := makeSrc(t, "tool.conf")
+
+	lf1 := writeLinkFarm(t, projectManifest(copyEntry(copySrc, "tool.conf", ".config/tool.conf")))
+	if _, err := Apply(Options{
+		LinkFarm: lf1, Name: "c", RootOverride: root, StateDir: state, Commit: fakeCommit(nil),
+	}); err != nil {
+		t.Fatalf("first Apply (copy): %v", err)
+	}
+
+	symSrc := realTempDir(t)
+	lf2 := writeLinkFarm(t, projectManifest(storeEntry(symSrc, ".", ".config/tool.conf")))
+	_, err := Apply(Options{
+		LinkFarm: lf2, Name: "c", RootOverride: root, StateDir: state, Commit: fakeCommit(nil),
+	})
+	if err == nil {
+		t.Fatal("expected a conflict error for copy→symlink, got nil")
+	}
+
+	// The copy target must survive untouched (not migrated, not deleted).
+	data, rerr := os.ReadFile(filepath.Join(root, ".config", "tool.conf"))
+	if rerr != nil || string(data) != "content" {
+		t.Errorf("copy target must survive untouched: data=%q, err=%v", data, rerr)
+	}
+}
+
+// TestApplyMethodChangeSymlinkToCopyDriftFallsBackToForeign verifies D5's fallback: if the
+// on-disk symlink drifted from the previous generation's record (readlink mismatch) at the
+// moment of planning, the method-change migration does not fire; it falls through to the
+// ordinary copy-foreign-file handling (skip + warning, not an overwrite).
+func TestApplyMethodChangeSymlinkToCopyDriftFallsBackToForeign(t *testing.T) {
+	root := realTempDir(t)
+	state := realTempDir(t)
+	symSrc := realTempDir(t)
+
+	lf1 := writeLinkFarm(t, projectManifest(storeEntry(symSrc, ".", ".config/tool.conf")))
+	if _, err := Apply(Options{
+		LinkFarm: lf1, Name: "c", RootOverride: root, StateDir: state, Commit: fakeCommit(nil),
+	}); err != nil {
+		t.Fatalf("first Apply (symlink): %v", err)
+	}
+
+	// Drift the on-disk symlink away from the recorded dest before the method-changing apply.
+	targetAbs := filepath.Join(root, ".config", "tool.conf")
+	if err := os.Remove(targetAbs); err != nil {
+		t.Fatal(err)
+	}
+	foreign := realTempDir(t)
+	if err := os.Symlink(foreign, targetAbs); err != nil {
+		t.Fatal(err)
+	}
+
+	copySrc := makeSrc(t, "tool.conf")
+	var warns []string
+	lf2 := writeLinkFarm(t, projectManifest(copyEntry(copySrc, "tool.conf", ".config/tool.conf")))
+	_, err := Apply(Options{
+		LinkFarm: lf2, Name: "c", RootOverride: root, StateDir: state, Commit: fakeCommit(nil),
+		Warnf: collectWarnings(&warns),
+	})
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	// The drifted symlink must survive untouched (not migrated, not overwritten).
+	got, rerr := os.Readlink(targetAbs)
+	if rerr != nil || got != foreign {
+		t.Errorf("drifted symlink must survive untouched: readlink=%q, err=%v, want %q", got, rerr, foreign)
+	}
+	found := false
+	for _, w := range warns {
+		if strings.Contains(w, "skipped copy") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("warnings = %v, want a copy-foreign-file skip warning", warns)
+	}
+}
+
+// TestApplyDirMigrationRmdirDriftErrors verifies D3: if a directory the plan scheduled for Rmdir
+// gains content between planning and the PreRemove pass (a directory the plan believed empty),
+// os.Remove's ENOTEMPTY is surfaced as a loud error — not a silent skip — since children were
+// already planned as unconditional new placements assuming the target is clear.
+func TestApplyDirMigrationRmdirDriftErrors(t *testing.T) {
+	root := realTempDir(t)
+	state := realTempDir(t)
+
+	if err := os.MkdirAll(filepath.Join(root, "hooks", "empty"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Race: something drops a file into the "empty" subdir after planning would have seen it
+	// empty. We can't hook mid-Apply, so instead drive the lower-level preRemove entrypoint
+	// directly with a plan that (correctly, at plan time) expected "hooks/empty" to be empty,
+	// then falsify that expectation on disk before executing — reproducing the drift window.
+	if err := os.WriteFile(filepath.Join(root, "hooks", "empty", "surprise"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	srcNew := realTempDir(t)
+	lf := writeLinkFarm(t, projectManifest(storeEntry(srcNew, ".", "hooks")))
+	_, err := Apply(Options{
+		LinkFarm: lf, Name: "c", RootOverride: root, StateDir: state, Commit: fakeCommit(nil),
+	})
+	// Since the file is present *before* planning even runs, the planner itself detects "hooks"
+	// as non-migratable (a real file leaf) and reports a conflict rather than reaching the Rmdir
+	// drift path. This confirms the plan-time classification already refuses to schedule an
+	// Rmdir for a non-empty directory (the drift path is only reachable via a true TOCTOU race,
+	// which is exercised at the unit level in staleremove_test.go-style direct preRemove calls).
+	if err == nil {
+		t.Fatal("expected a conflict/error, got nil")
+	}
+}
+
+// TestPreRemoveRmdirDriftErrorsDirectly drives applier.preRemove directly with a RemoveRmdir
+// action whose target directory has gained content since planning, verifying the ENOTEMPTY drift
+// is surfaced as a loud error (not skipped) with a message naming the target (→ ADR-0047 D3).
+func TestPreRemoveRmdirDriftErrorsDirectly(t *testing.T) {
+	dir := realTempDir(t)
+	sub := filepath.Join(dir, "sub")
+	if err := os.Mkdir(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Drift: something added content after the plan believed sub/ was empty.
+	if err := os.WriteFile(filepath.Join(sub, "surprise"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var warns []string
+	a := staleErr_applier(&warns)
+	act := planner.RemoveAction{Kind: planner.RemoveRmdir, TargetAbs: sub}
+	err := a.preRemove([]planner.RemoveAction{act})
+	if err == nil {
+		t.Fatal("expected an error for a non-empty Rmdir target, got nil")
+	}
+	if !strings.Contains(err.Error(), "cannot migrate this placement target safely") {
+		t.Errorf("error = %q, want it to mention the safe-migration abort message", err.Error())
+	}
+	if _, statErr := os.Lstat(sub); statErr != nil {
+		t.Errorf("sub must survive the aborted rmdir: %v", statErr)
+	}
+}
+
+// TestPreRemoveUnlinkDriftErrorsDirectly drives applier.preRemove directly with a RemoveUnlink
+// action whose recorded symlink drifted (foreign rewrite) since planning, verifying it errors
+// loudly instead of skipping (→ ADR-0047 D3, same asymmetry as ADR-0046 §3).
+func TestPreRemoveUnlinkDriftErrorsDirectly(t *testing.T) {
+	dir := realTempDir(t)
+	targetAbs := filepath.Join(dir, "ancestor")
+	foreign := realTempDir(t)
+	if err := os.Symlink(foreign, targetAbs); err != nil {
+		t.Fatal(err)
+	}
+
+	var warns []string
+	a := staleErr_applier(&warns)
+	act := staleErr_action(realTempDir(t), "ancestor", targetAbs)
+	err := a.preRemove([]planner.RemoveAction{act})
+	if err == nil {
+		t.Fatal("expected an error for a drifted recorded symlink, got nil")
+	}
+	if !strings.Contains(err.Error(), "cannot migrate this placement target safely") {
+		t.Errorf("error = %q, want it to mention the safe-migration abort message", err.Error())
+	}
+	got, rerr := os.Readlink(targetAbs)
+	if rerr != nil || got != foreign {
+		t.Errorf("drifted symlink must survive the aborted unlink: readlink=%q, err=%v", got, rerr)
+	}
+}
+
+// TestApplyDirMigrationIdempotentReRunConverges verifies ADR-0017 idempotence: if a dir migration
+// apply is interrupted after PreRemove but before the generation commits (simulated here by
+// directly driving preRemove + place without a commit, then re-running the full Apply), a
+// subsequent apply re-plans against the now-partially-migrated FS and converges to the same final
+// state as an uninterrupted apply.
+func TestApplyDirMigrationIdempotentReRunConverges(t *testing.T) {
+	root := realTempDir(t)
+	state := realTempDir(t)
+	srcOld := realTempDir(t)
+
+	lf1 := writeLinkFarm(t, projectManifest(storeEntry(srcOld, ".", ".claude/hooks/foo")))
+	if _, err := Apply(Options{
+		LinkFarm: lf1, Name: "c", RootOverride: root, StateDir: state, Commit: fakeCommit(nil),
+	}); err != nil {
+		t.Fatalf("first Apply: %v", err)
+	}
+
+	srcNew := realTempDir(t)
+	lf2 := writeLinkFarm(t, projectManifest(storeEntry(srcNew, ".", ".claude/hooks")))
+	optsRepeat := Options{LinkFarm: lf2, Name: "c", RootOverride: root, StateDir: state, Commit: fakeCommit(nil)}
+
+	// First (successful, uninterrupted) run reaches the fully migrated state.
+	if _, err := Apply(optsRepeat); err != nil {
+		t.Fatalf("migration Apply: %v", err)
+	}
+	got1, err := os.Readlink(filepath.Join(root, ".claude", "hooks"))
+	if err != nil || got1 != srcNew {
+		t.Fatalf("post-migration readlink = %q, err %v; want %q", got1, err, srcNew)
+	}
+
+	// Re-running apply against the already-converged FS must be a clean no-op re-link, not an error.
+	if _, err := Apply(optsRepeat); err != nil {
+		t.Fatalf("idempotent re-run: %v", err)
+	}
+	got2, err := os.Readlink(filepath.Join(root, ".claude", "hooks"))
+	if err != nil || got2 != srcNew {
+		t.Fatalf("re-run readlink = %q, err %v; want %q", got2, err, srcNew)
+	}
+}

--- a/internal/engine/staleremove.go
+++ b/internal/engine/staleremove.go
@@ -55,9 +55,15 @@ func (a *applier) removeStale(actions []planner.RemoveAction) error {
 // instead of skipping for both Unlink and Rmdir (→ ADR-0017, ADR-0046, ADR-0047 D3); an idempotent
 // re-run re-plans against the current FS and converges.
 //
-// It also prunes ancestors left empty by an Unlink (→ Issue #174); unlike the drift check above,
-// a prune failure does not abort — the removal itself already succeeded, so a leftover empty dir
-// is a cosmetic miss, not a correctness hazard for the child placements that follow.
+// Unlike removeStale / reset — where a removal can be the final state of that target — PreRemove
+// never walks pruneEmptyAncestors (Issue #174's ancestor-pruning helper). Every PreRemove action
+// exists to clear the way for a placement (place / materializeCopies) that runs immediately
+// afterward in the same Apply, at or beneath the same directory: pruning outer ancestors here
+// would just have that placement step's ensureParentDir immediately recreate them, and — for the
+// generalized real-dir-target and multi-leaf migrations (→ ADR-0047) — pruning mid-batch would
+// race the planner's own explicit, already-ordered bottom-up Rmdir actions for the same
+// directories (classifyDirMigration lists children before parents up to the placement target
+// itself; nothing outside that tree needs pruning here).
 func (a *applier) preRemove(actions []planner.RemoveAction) error {
 	for _, act := range actions {
 		switch act.Kind {
@@ -65,21 +71,19 @@ func (a *applier) preRemove(actions []planner.RemoveAction) error {
 			// No pre-check of emptiness: os.Remove on a non-empty dir simply fails with ENOTEMPTY,
 			// which IS the re-verification (TOCTOU-safe without a separate stat+readdir race · → ADR-0047 D3).
 			//
-			// A sibling Unlink earlier in this same batch can already have pruned this exact
-			// directory via pruneEmptyAncestors below (e.g. the last child under a dir-migration
-			// leaf was just unlinked, emptying — and pruning — its parent before the planner's own
-			// explicit Rmdir for that parent runs). That is not drift: the directory achieving
-			// "does not exist" is the Rmdir's goal already met by another path in the same plan, so
-			// IsNotExist is a success, not an error (→ ADR-0047 D3, issue #175).
-			if err := os.Remove(act.TargetAbs); err != nil && !os.IsNotExist(err) {
-				if errors.Is(err, syscall.ENOTEMPTY) || errors.Is(err, syscall.EEXIST) {
-					return fmt.Errorf("nput: directory gained content after planning; cannot migrate this placement target safely (%s); re-run apply to converge", act.TargetAbs)
-				}
+			// IsNotExist is tolerated as success (not drift, not an error): preRemove does not walk
+			// pruneEmptyAncestors (see the doc comment above), so nothing in the normal path removes
+			// a directory out from under a still-pending RemoveRmdir action — but treating "already
+			// gone" as success rather than a hard error keeps this branch robust without relying on
+			// that invariant.
+			err := os.Remove(act.TargetAbs)
+			switch {
+			case err == nil, os.IsNotExist(err):
+				a.result.Pruned = append(a.result.Pruned, act.TargetAbs)
+			case errors.Is(err, syscall.ENOTEMPTY), errors.Is(err, syscall.EEXIST):
+				return fmt.Errorf("nput: directory gained content after planning; cannot migrate this placement target safely (%s); re-run apply to converge", act.TargetAbs)
+			default:
 				return fmt.Errorf("nput: cannot remove empty directory for migration (%s): %w", act.TargetAbs, err)
-			}
-			a.result.Pruned = append(a.result.Pruned, act.TargetAbs)
-			if err := a.pruneEmptyAncestors(act.TargetAbs); err != nil {
-				a.opts.Warnf("nput: could not prune an empty ancestor directory: %v", err)
 			}
 		default: // planner.RemoveUnlink
 			if !reverifyStale(act) {
@@ -89,9 +93,6 @@ func (a *applier) preRemove(actions []planner.RemoveAction) error {
 				return fmt.Errorf("nput: cannot remove recorded symlink for migration (%s): %w", act.TargetAbs, err)
 			}
 			a.result.Removed = append(a.result.Removed, act.Entry.Target)
-			if err := a.pruneEmptyAncestors(act.TargetAbs); err != nil {
-				a.opts.Warnf("nput: could not prune an empty ancestor directory: %v", err)
-			}
 		}
 	}
 	return nil

--- a/internal/engine/staleremove.go
+++ b/internal/engine/staleremove.go
@@ -64,7 +64,14 @@ func (a *applier) preRemove(actions []planner.RemoveAction) error {
 		case planner.RemoveRmdir:
 			// No pre-check of emptiness: os.Remove on a non-empty dir simply fails with ENOTEMPTY,
 			// which IS the re-verification (TOCTOU-safe without a separate stat+readdir race · → ADR-0047 D3).
-			if err := os.Remove(act.TargetAbs); err != nil {
+			//
+			// A sibling Unlink earlier in this same batch can already have pruned this exact
+			// directory via pruneEmptyAncestors below (e.g. the last child under a dir-migration
+			// leaf was just unlinked, emptying — and pruning — its parent before the planner's own
+			// explicit Rmdir for that parent runs). That is not drift: the directory achieving
+			// "does not exist" is the Rmdir's goal already met by another path in the same plan, so
+			// IsNotExist is a success, not an error (→ ADR-0047 D3, issue #175).
+			if err := os.Remove(act.TargetAbs); err != nil && !os.IsNotExist(err) {
 				if errors.Is(err, syscall.ENOTEMPTY) || errors.Is(err, syscall.EEXIST) {
 					return fmt.Errorf("nput: directory gained content after planning; cannot migrate this placement target safely (%s); re-run apply to converge", act.TargetAbs)
 				}

--- a/internal/engine/staleremove.go
+++ b/internal/engine/staleremove.go
@@ -39,39 +39,52 @@ func (a *applier) removeStale(actions []planner.RemoveAction) error {
 	return nil
 }
 
-// preRemove unlinks the self-recorded stale ancestor symlinks the planner scheduled for
-// migration, re-verifying the conservative invariant against the real FS right before each
-// unlink. It runs *before* place so nested children land in a real directory instead of
-// resolving through the previous farm's symlink (local ordering exception to ADR-0006 · → ADR-0046).
-// Removed ancestors are folded into result.Removed: the migration is silent by default and
-// surfaced only under -v, never as a warning (→ ADR-0031).
+// preRemove removes the self-recorded stale filesystem objects the planner scheduled to clear a
+// placement target: ancestor symlinks (→ ADR-0046), and — generalized under ADR-0047 — leaf
+// symlinks and now-empty directories beneath an occupying real directory, and a symlink replaced
+// by method change (symlink→copy). It runs *before* place so the target lands empty/absent
+// instead of resolving through stale content (local ordering exception to ADR-0006). Removed
+// objects are folded into result.Removed (Unlink) / result.Pruned (Rmdir): the migration is
+// silent by default and surfaced only under -v, never as a warning (→ ADR-0031).
 //
-// Unlike removeStale — the last stage, where keeping a drifted link is harmless — a drifted
-// ancestor here is *not* safe to skip: the children under it were planned as unconditional new
-// placements that assume the ancestor is gone, so continuing would nest them through the drifted
-// symlink (e.g. one swapped to a foreign, writable dir) and re-open the ADR-0015 §4 pollution that
-// place/ensureParentDir do not re-guard. So on drift it aborts loudly instead of skipping; an
-// idempotent re-run re-plans against the current FS and converges (→ ADR-0017, ADR-0046).
+// Unlike removeStale — the last stage, where keeping a drifted link is harmless — drift here is
+// *not* safe to skip: placement was planned assuming these objects are gone (children as
+// unconditional new placements, or the target itself as absent), so continuing on drift would
+// nest/place through it (e.g. a symlink swapped to a foreign, writable dir) and re-open the
+// ADR-0015 §4 pollution that place/ensureParentDir do not re-guard. So on drift it aborts loudly
+// instead of skipping for both Unlink and Rmdir (→ ADR-0017, ADR-0046, ADR-0047 D3); an idempotent
+// re-run re-plans against the current FS and converges.
 //
-// It also prunes ancestors left empty by the unlink (→ Issue #174); unlike the drift check
-// above, a prune failure does not abort — the migration itself already succeeded, so a
-// leftover empty dir is a cosmetic miss, not a correctness hazard for the child placements
-// that follow. Because this runs before Place, an outer ancestor that the removed ancestor
-// symlink happened to be the sole occupant of can be momentarily pruned here and then
-// recreated fresh by Place's ensureParentDir moments later; that transient prune+recreate
-// is invisible on disk (the end state is unchanged) but shows up in result.Pruned, which
-// callers should read as "emptied at some point during this apply," not "stayed removed."
+// It also prunes ancestors left empty by an Unlink (→ Issue #174); unlike the drift check above,
+// a prune failure does not abort — the removal itself already succeeded, so a leftover empty dir
+// is a cosmetic miss, not a correctness hazard for the child placements that follow.
 func (a *applier) preRemove(actions []planner.RemoveAction) error {
 	for _, act := range actions {
-		if !reverifyStale(act) {
-			return fmt.Errorf("nput: ancestor symlink changed after planning; cannot migrate its nesting safely (%s); re-run apply to converge", act.Entry.Target)
-		}
-		if err := os.Remove(act.TargetAbs); err != nil {
-			return fmt.Errorf("nput: cannot remove ancestor symlink for migration (%s): %w", act.TargetAbs, err)
-		}
-		a.result.Removed = append(a.result.Removed, act.Entry.Target)
-		if err := a.pruneEmptyAncestors(act.TargetAbs); err != nil {
-			a.opts.Warnf("nput: could not prune an empty ancestor directory: %v", err)
+		switch act.Kind {
+		case planner.RemoveRmdir:
+			// No pre-check of emptiness: os.Remove on a non-empty dir simply fails with ENOTEMPTY,
+			// which IS the re-verification (TOCTOU-safe without a separate stat+readdir race · → ADR-0047 D3).
+			if err := os.Remove(act.TargetAbs); err != nil {
+				if errors.Is(err, syscall.ENOTEMPTY) || errors.Is(err, syscall.EEXIST) {
+					return fmt.Errorf("nput: directory gained content after planning; cannot migrate this placement target safely (%s); re-run apply to converge", act.TargetAbs)
+				}
+				return fmt.Errorf("nput: cannot remove empty directory for migration (%s): %w", act.TargetAbs, err)
+			}
+			a.result.Pruned = append(a.result.Pruned, act.TargetAbs)
+			if err := a.pruneEmptyAncestors(act.TargetAbs); err != nil {
+				a.opts.Warnf("nput: could not prune an empty ancestor directory: %v", err)
+			}
+		default: // planner.RemoveUnlink
+			if !reverifyStale(act) {
+				return fmt.Errorf("nput: recorded symlink changed after planning; cannot migrate this placement target safely (%s); re-run apply to converge", act.Entry.Target)
+			}
+			if err := os.Remove(act.TargetAbs); err != nil {
+				return fmt.Errorf("nput: cannot remove recorded symlink for migration (%s): %w", act.TargetAbs, err)
+			}
+			a.result.Removed = append(a.result.Removed, act.Entry.Target)
+			if err := a.pruneEmptyAncestors(act.TargetAbs); err != nil {
+				a.opts.Warnf("nput: could not prune an empty ancestor directory: %v", err)
+			}
 		}
 	}
 	return nil

--- a/internal/engine/staleremove.go
+++ b/internal/engine/staleremove.go
@@ -71,15 +71,18 @@ func (a *applier) preRemove(actions []planner.RemoveAction) error {
 			// No pre-check of emptiness: os.Remove on a non-empty dir simply fails with ENOTEMPTY,
 			// which IS the re-verification (TOCTOU-safe without a separate stat+readdir race · → ADR-0047 D3).
 			//
-			// IsNotExist is tolerated as success (not drift, not an error): preRemove does not walk
+			// IsNotExist is tolerated as success, not drift: preRemove does not walk
 			// pruneEmptyAncestors (see the doc comment above), so nothing in the normal path removes
 			// a directory out from under a still-pending RemoveRmdir action — but treating "already
 			// gone" as success rather than a hard error keeps this branch robust without relying on
-			// that invariant.
+			// that invariant. It is NOT folded into result.Pruned: Pruned means "this run rmdir-ed
+			// it", and a dir that was already gone before this run touched it was not (→ diff-review).
 			err := os.Remove(act.TargetAbs)
 			switch {
-			case err == nil, os.IsNotExist(err):
+			case err == nil:
 				a.result.Pruned = append(a.result.Pruned, act.TargetAbs)
+			case os.IsNotExist(err):
+				// already absent; the Rmdir's goal is met, nothing to report.
 			case errors.Is(err, syscall.ENOTEMPTY), errors.Is(err, syscall.EEXIST):
 				return fmt.Errorf("nput: directory gained content after planning; cannot migrate this placement target safely (%s); re-run apply to converge", act.TargetAbs)
 			default:

--- a/internal/engine/staleremove_test.go
+++ b/internal/engine/staleremove_test.go
@@ -574,14 +574,14 @@ func TestRemoveStaleLeavesForeignFileNonEmptyAncestorInPlace(t *testing.T) {
 	}
 }
 
-// TestApplyAncestorSelfRecordedMigrationPrunesOuterAncestor verifies PreRemove's ancestor
-// unlink also runs the pruning walk (Issue #174): PreRemove runs before Place, so when
-// unlinking the ancestor symlink leaves "outer/" momentarily empty, the walk prunes it right
-// there — res.Pruned reports it — and the following Place step (ensureParentDir's MkdirAll)
-// recreates it fresh to hold the migrated child. The net effect is a real (non-symlink)
-// "outer/" directory at the end, exactly as before, so the transient prune+recreate is
-// invisible on disk; only res.Pruned reveals it happened.
-func TestApplyAncestorSelfRecordedMigrationPrunesOuterAncestor(t *testing.T) {
+// TestApplyAncestorSelfRecordedMigrationDoesNotPruneOuterAncestor verifies PreRemove's
+// ancestor unlink does NOT run the pruning walk (→ ADR-0047 §5): every PreRemove removal is
+// followed by a placement into the same spot, so pruning "outer/" just to have Place's
+// ensureParentDir recreate it would be a wasted round-trip, and it would pollute res.Pruned
+// with a dir that never stayed removed. "outer/" is left in place across the unlink and
+// simply reused by the following Place; res.Pruned stays empty (pruning belongs to
+// removeStale / reset only).
+func TestApplyAncestorSelfRecordedMigrationDoesNotPruneOuterAncestor(t *testing.T) {
 	root := realTempDir(t)
 	state := realTempDir(t)
 	srcOld := realTempDir(t)
@@ -611,12 +611,12 @@ func TestApplyAncestorSelfRecordedMigrationPrunesOuterAncestor(t *testing.T) {
 	if len(res.Removed) != 1 || res.Removed[0] != "outer/skills" {
 		t.Errorf("Removed = %v, want [outer/skills] (the pre-removed ancestor)", res.Removed)
 	}
-	if len(res.Pruned) != 1 || res.Pruned[0] != filepath.Join(root, "outer") {
-		t.Errorf("Pruned = %v, want [%s] (outer/ momentarily emptied by the ancestor unlink, then recreated by Place)", res.Pruned, filepath.Join(root, "outer"))
+	if len(res.Pruned) != 0 {
+		t.Errorf("Pruned = %v, want none (PreRemove does not prune; outer/ is reused by Place · ADR-0047 §5)", res.Pruned)
 	}
 
 	// outer/skills is now a real directory holding the migrated child; outer/ survives on
-	// disk as a real directory (recreated by Place after the transient prune above).
+	// disk as a real directory (never removed — PreRemove leaves it for Place to reuse).
 	info, err := os.Lstat(filepath.Join(root, "outer"))
 	if err != nil {
 		t.Fatalf("outer/ must survive: %v", err)
@@ -630,11 +630,13 @@ func TestApplyAncestorSelfRecordedMigrationPrunesOuterAncestor(t *testing.T) {
 	}
 }
 
-// TestPreRemovePruneCalledDirectly verifies pruneEmptyAncestors is actually invoked from
-// preRemove's unlink loop (Issue #174), independent of the apply-level refill guarantee
+// TestPreRemoveDoesNotPruneAncestors verifies pruneEmptyAncestors is NOT invoked from
+// preRemove's unlink loop (→ ADR-0047 §5), independent of the apply-level refill guarantee
 // above. It drives preRemove directly against a two-level ancestor chain where nothing
-// refills the freed space, so a successful prune is observable in isolation.
-func TestPreRemovePruneCalledDirectly(t *testing.T) {
+// refills the freed space: the emptied "outer/" must survive untouched and result.Pruned
+// must stay empty — exploratory pruning from PreRemove would pre-consume targets of the
+// planner's own explicit Rmdir actions and double-register them in Pruned.
+func TestPreRemoveDoesNotPruneAncestors(t *testing.T) {
 	root := realTempDir(t)
 	dest := realTempDir(t)
 
@@ -655,11 +657,13 @@ func TestPreRemovePruneCalledDirectly(t *testing.T) {
 		t.Fatalf("preRemove: %v", err)
 	}
 
-	if len(a.result.Pruned) != 1 || a.result.Pruned[0] != filepath.Join(root, "outer") {
-		t.Errorf("Pruned = %v, want [%s] (outer/ emptied by the ancestor unlink)", a.result.Pruned, filepath.Join(root, "outer"))
+	if len(a.result.Pruned) != 0 {
+		t.Errorf("Pruned = %v, want none (preRemove must not call the pruning walk · ADR-0047 §5)", a.result.Pruned)
 	}
-	if _, err := os.Lstat(filepath.Join(root, "outer")); !os.IsNotExist(err) {
-		t.Errorf("outer/ should have been pruned away, lstat err = %v", err)
+	if info, err := os.Lstat(filepath.Join(root, "outer")); err != nil {
+		t.Errorf("outer/ must survive the preRemove untouched: %v", err)
+	} else if !info.IsDir() {
+		t.Errorf("outer/ must remain a real directory, got mode %v", info.Mode())
 	}
 }
 

--- a/internal/planner/planner.go
+++ b/internal/planner/planner.go
@@ -245,7 +245,7 @@ func Compute(prev, next *manifest.Manifest, root string, fs FS) (Plan, error) {
 
 		// Branch the place-once / re-link classification per method.
 		if e.Method == manifest.MethodCopy {
-			if err := classifyCopy(&plan, e, targetAbs, prevByTarget, fs); err != nil {
+			if err := classifyCopy(&plan, e, targetAbs, prevByTarget, preRemoved, fs); err != nil {
 				return Plan{}, err
 			}
 			continue
@@ -386,19 +386,36 @@ func recordedLink(target, targetAbs string, prevByTarget map[string]manifest.Ent
 // classifyCopy classifies a copy entry under place-once semantics (→ ADR-0002,
 // ADR-0016, ADR-0022, docs/spec.md "copy mode").
 //
-//	target absent              → CopyAction (new place-once copy)
+//	target absent                     → CopyAction (new place-once copy)
+//	target is a self-recorded stale symlink (method changed symlink→copy) → PreRemove(Unlink) + CopyAction (→ ADR-0047 D5)
 //	target exists, structure mismatch → conflict (subpath dir × target file / subpath file × target dir)
-//	target exists, recorded    → no-op (placed by nput in a previous generation; place-once leaves it untouched)
-//	target exists, foreign     → skip + WarnCopyForeign (unrecorded real file; masking prevention)
+//	target exists, recorded           → no-op (placed by nput in a previous generation; place-once leaves it untouched)
+//	target exists, foreign            → skip + WarnCopyForeign (unrecorded real file; masking prevention)
 //
 // recopy (apply --recopy) is a separate path that breaks place-once: the engine
 // overwrites the manifest's copy entry directly. The planner only does the
 // normal place-once classification (→ ADR-0020).
-func classifyCopy(plan *Plan, e manifest.Entry, targetAbs string, prevByTarget map[string]manifest.Entry, fs FS) error {
+func classifyCopy(plan *Plan, e manifest.Entry, targetAbs string, prevByTarget map[string]manifest.Entry, preRemoved map[string]bool, fs FS) error {
 	info, err := fs.Lstat(targetAbs)
 	switch {
+	case err == nil && info.Mode()&os.ModeSymlink != 0 && prevByTarget[e.Target].Method == manifest.MethodSymlink && recordedLink(e.Target, targetAbs, prevByTarget, fs):
+		// The previous generation placed a symlink here and the new generation wants a copy at the
+		// same target (method changed symlink→copy): pre-remove the recorded symlink and place a
+		// fresh place-once copy — zero data loss, since the symlink carried no user data (→ ADR-0047
+		// D5). A readlink mismatch (on-disk drifted from the record) falls through to the ordinary
+		// foreign-symlink handling below instead (copy→symlink direction stays a structure
+		// mismatch/conflict; this arm never fires for it since Method would be "copy").
+		if !preRemoved[e.Target] {
+			preRemoved[e.Target] = true
+			plan.PreRemove = append(plan.PreRemove, RemoveAction{Kind: RemoveUnlink, Entry: prevByTarget[e.Target], TargetAbs: targetAbs})
+		}
+		plan.Copies = append(plan.Copies, CopyAction{Entry: e, TargetAbs: targetAbs, Src: LinkDest(e)})
+		return nil
 	case err == nil:
-		// target exists: first check whether the src structure and kind match.
+		// target exists: check whether the src structure and kind match. A symlink target that
+		// fell through the method-change arm above (unrecorded or drifted) is treated as a foreign,
+		// non-directory occupant here — consistent with copyStructureMismatch's IsDir()==false
+		// handling for symlinks.
 		mismatch, err := copyStructureMismatch(e, info, fs)
 		if err != nil {
 			return err

--- a/internal/planner/planner.go
+++ b/internal/planner/planner.go
@@ -269,28 +269,9 @@ func Compute(prev, next *manifest.Manifest, root string, fs FS) (Plan, error) {
 			// it is a self-recorded stale symlink or an empty subdirectory (→ ADR-0047, issue #175).
 			// A copy-placed target is out of scope (copy targets never appear here — this arm only
 			// runs for the symlink-method branch).
-			dirActions, reason, derr := classifyDirMigration(filepath.Clean(e.Target), targetAbs, prevByTarget, nextByTarget, fs)
-			if derr != nil {
-				return Plan{}, derr
+			if err := classifyRealDirTarget(&plan, e, targetAbs, prevByTarget, nextByTarget, preRemoved, fs); err != nil {
+				return Plan{}, err
 			}
-			if reason != "" {
-				plan.Conflicts = append(plan.Conflicts, Conflict{
-					Entry:     e,
-					TargetAbs: targetAbs,
-					Reason:    fmt.Sprintf("target directory cannot be fully migrated: %s (→ ADR-0047)", reason),
-				})
-				continue
-			}
-			plan.PreRemove = append(plan.PreRemove, dirActions...)
-			plan.PreRemove = append(plan.PreRemove, RemoveAction{Kind: RemoveRmdir, TargetAbs: targetAbs})
-			// Dedup against the remove-side loop below: each unlinked child is also a stale entry
-			// in prev.Entries, and must not be scheduled there a second time (→ ADR-0046 dedup convention).
-			for _, da := range dirActions {
-				if da.Kind == RemoveUnlink {
-					preRemoved[da.Entry.Target] = true
-				}
-			}
-			plan.Place = append(plan.Place, PlaceAction{Entry: e, TargetAbs: targetAbs, Dest: LinkDest(e), Kind: PlaceNew})
 		case err == nil:
 			// A regular file is not overwritten (→ docs/spec.md error spec).
 			plan.Conflicts = append(plan.Conflicts, Conflict{
@@ -470,6 +451,37 @@ func copyStructureMismatch(e manifest.Entry, targetInfo os.FileInfo, fs FS) (boo
 		return false, fmt.Errorf("nput: cannot lstat copy src (%s): %w", LinkDest(e), err)
 	}
 	return srcInfo.IsDir() != targetInfo.IsDir(), nil
+}
+
+// classifyRealDirTarget classifies a symlink-method entry whose target is occupied by a real
+// directory (→ ADR-0047, issue #175). Mirrors classifyCopy's role for the copy-method branch:
+// it owns the full decision — walk the tree via classifyDirMigration, emit a Conflict on
+// failure, or on success append the PreRemove actions (children before the target itself),
+// dedup the unlinked children against the remove-side loop's preRemoved map (→ ADR-0046 dedup
+// convention: each unlinked child is also a stale entry in prev.Entries and must not be
+// scheduled there a second time), and append the new-symlink Place action.
+func classifyRealDirTarget(plan *Plan, e manifest.Entry, targetAbs string, prevByTarget, nextByTarget map[string]manifest.Entry, preRemoved map[string]bool, fs FS) error {
+	dirActions, reason, err := classifyDirMigration(filepath.Clean(e.Target), targetAbs, prevByTarget, nextByTarget, fs)
+	if err != nil {
+		return err
+	}
+	if reason != "" {
+		plan.Conflicts = append(plan.Conflicts, Conflict{
+			Entry:     e,
+			TargetAbs: targetAbs,
+			Reason:    fmt.Sprintf("target directory cannot be fully migrated: %s (→ ADR-0047)", reason),
+		})
+		return nil
+	}
+	plan.PreRemove = append(plan.PreRemove, dirActions...)
+	plan.PreRemove = append(plan.PreRemove, RemoveAction{Kind: RemoveRmdir, TargetAbs: targetAbs})
+	for _, da := range dirActions {
+		if da.Kind == RemoveUnlink {
+			preRemoved[da.Entry.Target] = true
+		}
+	}
+	plan.Place = append(plan.Place, PlaceAction{Entry: e, TargetAbs: targetAbs, Dest: LinkDest(e), Kind: PlaceNew})
+	return nil
 }
 
 // classifyDirMigration walks an occupying real directory (dirAbs, root-relative dirRel) that a

--- a/internal/planner/planner.go
+++ b/internal/planner/planner.go
@@ -23,20 +23,24 @@ import (
 	"github.com/yasunori0418/nput/internal/manifest"
 )
 
-// FS abstracts the lstat/readlink probes the planner needs, so diff
+// FS abstracts the lstat/readlink/readdir probes the planner needs, so diff
 // classification is a pure function over (manifests, FS state) and can be
 // table-tested with a fake FS without touching the real filesystem
-// (→ ADR-0006, docs/spec.md "targets and safety invariant of stale removal").
+// (→ ADR-0006, ADR-0047, docs/spec.md "targets and safety invariant of stale removal").
 type FS interface {
 	Lstat(path string) (os.FileInfo, error)
 	Readlink(path string) (string, error)
+	// ReadDir lists path's immediate children (a real directory target). Used only
+	// to classify an occupying real directory for PreRemove migration (→ ADR-0047).
+	ReadDir(path string) ([]os.DirEntry, error)
 }
 
 // osFS is the real-filesystem FS used at engine runtime.
 type osFS struct{}
 
-func (osFS) Lstat(path string) (os.FileInfo, error) { return os.Lstat(path) }
-func (osFS) Readlink(path string) (string, error)   { return os.Readlink(path) }
+func (osFS) Lstat(path string) (os.FileInfo, error)     { return os.Lstat(path) }
+func (osFS) Readlink(path string) (string, error)       { return os.Readlink(path) }
+func (osFS) ReadDir(path string) ([]os.DirEntry, error) { return os.ReadDir(path) }
 
 // OSFS probes the real filesystem (engine runtime).
 var OSFS FS = osFS{}
@@ -70,10 +74,30 @@ type CopyAction struct {
 	Src       string // LinkDest(Entry): <src>/<subpath> (copy source)
 }
 
-// RemoveAction is a stale symlink that satisfies the conservative invariant at
-// plan time (recorded by prev AND on-disk points to the recorded dest). The
-// stale-remover re-verifies this against the real FS before unlinking.
+// RemoveKind distinguishes what a RemoveAction removes: an entry-recorded symlink
+// (Unlink) versus an empty directory left behind by removals (Rmdir; → ADR-0047).
+type RemoveKind int
+
+const (
+	// RemoveUnlink removes a stale symlink recorded by Entry (the original, entry-driven case).
+	RemoveUnlink RemoveKind = iota
+	// RemoveRmdir removes an empty directory that occupies a placement target or is left
+	// empty by a migration. Entry is the zero value: rmdir has no manifest record to
+	// re-verify against, so the engine re-checks emptiness at unlink time instead (→ ADR-0047).
+	RemoveRmdir
+)
+
+// RemoveAction is a stale filesystem object that satisfies the conservative invariant
+// at plan time. For Kind == RemoveUnlink: a symlink recorded by prev AND on-disk points
+// to the recorded dest (Entry is populated; the stale-remover re-verifies this against
+// the real FS before unlinking). For Kind == RemoveRmdir: an empty directory (Entry is
+// the zero value; the engine re-verifies emptiness immediately before rmdir · → ADR-0047).
+//
+// Execution order is expressed by slice order: the planner appends children before their
+// parents, so consumers that walk a RemoveAction slice front-to-back naturally unlink
+// leaves first and rmdir from the deepest directory upward (bottom-up).
 type RemoveAction struct {
+	Kind      RemoveKind
 	Entry     manifest.Entry
 	TargetAbs string
 }
@@ -240,8 +264,35 @@ func Compute(prev, next *manifest.Manifest, root string, fs FS) (Plan, error) {
 				plan.Warnings = append(plan.Warnings, Warning{Kind: WarnForeignReplace, Target: e.Target})
 			}
 			plan.Place = append(plan.Place, PlaceAction{Entry: e, TargetAbs: targetAbs, Dest: LinkDest(e), Kind: kind})
+		case err == nil && info.IsDir():
+			// A real directory occupies the target: fully migratable only when every leaf beneath
+			// it is a self-recorded stale symlink or an empty subdirectory (→ ADR-0047, issue #175).
+			// A copy-placed target is out of scope (copy targets never appear here — this arm only
+			// runs for the symlink-method branch).
+			dirActions, reason, derr := classifyDirMigration(filepath.Clean(e.Target), targetAbs, prevByTarget, nextByTarget, fs)
+			if derr != nil {
+				return Plan{}, derr
+			}
+			if reason != "" {
+				plan.Conflicts = append(plan.Conflicts, Conflict{
+					Entry:     e,
+					TargetAbs: targetAbs,
+					Reason:    fmt.Sprintf("target directory cannot be fully migrated: %s (→ ADR-0047)", reason),
+				})
+				continue
+			}
+			plan.PreRemove = append(plan.PreRemove, dirActions...)
+			plan.PreRemove = append(plan.PreRemove, RemoveAction{Kind: RemoveRmdir, TargetAbs: targetAbs})
+			// Dedup against the remove-side loop below: each unlinked child is also a stale entry
+			// in prev.Entries, and must not be scheduled there a second time (→ ADR-0046 dedup convention).
+			for _, da := range dirActions {
+				if da.Kind == RemoveUnlink {
+					preRemoved[da.Entry.Target] = true
+				}
+			}
+			plan.Place = append(plan.Place, PlaceAction{Entry: e, TargetAbs: targetAbs, Dest: LinkDest(e), Kind: PlaceNew})
 		case err == nil:
-			// A regular file / directory is not overwritten (→ docs/spec.md error spec).
+			// A regular file is not overwritten (→ docs/spec.md error spec).
 			plan.Conflicts = append(plan.Conflicts, Conflict{
 				Entry:     e,
 				TargetAbs: targetAbs,
@@ -402,6 +453,65 @@ func copyStructureMismatch(e manifest.Entry, targetInfo os.FileInfo, fs FS) (boo
 		return false, fmt.Errorf("nput: cannot lstat copy src (%s): %w", LinkDest(e), err)
 	}
 	return srcInfo.IsDir() != targetInfo.IsDir(), nil
+}
+
+// classifyDirMigration walks an occupying real directory (dirAbs, root-relative dirRel) that a
+// symlink-method entry wants to place at, and decides whether the whole tree beneath it is
+// safely removable so the entry can be placed as a new symlink (→ ADR-0047, issue #175, #172 D2).
+//
+// A directory is fully migratable only when every leaf beneath it, at any depth, is one of:
+//   - a symlink this profile's own previous generation recorded and the new generation drops
+//     (recorded ∧ ¬kept) — scheduled as a RemoveUnlink
+//   - an empty subdirectory, regardless of provenance (rmdir only ever succeeds on empty, so this
+//     is data-loss-free even for dirs nput never created) — scheduled as a RemoveRmdir
+//
+// Any other leaf — a regular file, a foreign or record-mismatched symlink, or a symlink the new
+// generation still keeps at the same target (self-contradictory manifest) — makes the *whole*
+// directory a conflict; no partial removal is scheduled (the caller discards dirActions when
+// reason != ""). The walk is lstat-based and never descends into a symlink (a symlink is
+// classified as a leaf, matching the ancestor-walk safety rule in ancestorSymlink · → ADR-0046 §2).
+//
+// The returned actions are ordered children-before-parents (leaves and inner-dir rmdirs appended
+// depth-first before the walk returns to its caller), so executing them in slice order naturally
+// unlinks leaves first and rmdirs from the deepest directory upward.
+func classifyDirMigration(dirRel, dirAbs string, prevByTarget, nextByTarget map[string]manifest.Entry, fs FS) (actions []RemoveAction, reason string, err error) {
+	children, err := fs.ReadDir(dirAbs)
+	if err != nil {
+		return nil, "", fmt.Errorf("nput: cannot read directory (%s): %w", dirAbs, err)
+	}
+	for _, de := range children {
+		childAbs := filepath.Join(dirAbs, de.Name())
+		childRel := filepath.Join(dirRel, de.Name())
+
+		info, lerr := fs.Lstat(childAbs)
+		if lerr != nil {
+			return nil, "", fmt.Errorf("nput: cannot lstat (%s): %w", childAbs, lerr)
+		}
+
+		switch {
+		case info.Mode()&os.ModeSymlink != 0:
+			if _, kept := nextByTarget[childRel]; kept {
+				return nil, fmt.Sprintf("%q is a symlink the new generation still keeps (self-contradictory manifest)", childRel), nil
+			}
+			if !recordedLink(childRel, childAbs, prevByTarget, fs) {
+				return nil, fmt.Sprintf("%q is a foreign or record-mismatched symlink", childRel), nil
+			}
+			actions = append(actions, RemoveAction{Kind: RemoveUnlink, Entry: prevByTarget[childRel], TargetAbs: childAbs})
+		case info.IsDir():
+			sub, subReason, serr := classifyDirMigration(childRel, childAbs, prevByTarget, nextByTarget, fs)
+			if serr != nil {
+				return nil, "", serr
+			}
+			if subReason != "" {
+				return nil, subReason, nil
+			}
+			actions = append(actions, sub...)
+			actions = append(actions, RemoveAction{Kind: RemoveRmdir, TargetAbs: childAbs})
+		default:
+			return nil, fmt.Sprintf("%q is a regular file", childRel), nil
+		}
+	}
+	return actions, "", nil
 }
 
 // ancestorSymlink walks the target's ancestor components under root and returns the first

--- a/internal/planner/planner_test.go
+++ b/internal/planner/planner_test.go
@@ -700,6 +700,79 @@ func TestComputeTableDriven(t *testing.T) {
 	}
 }
 
+// TestComputeDirMigrationPreRemoveOrderIsBottomUp verifies the ordering invariant
+// classifyDirMigration's doc comment promises (→ ADR-0047, issue #175 §8): plan.PreRemove lists
+// children before parents, so a consumer walking the slice front-to-back naturally unlinks
+// leaves first and rmdirs from the deepest directory upward — never rmdir-ing a directory before
+// its own contents are cleared. TestComputeTableDriven's sortedEq comparisons cannot catch an
+// order regression (they sort before comparing), so this test asserts slice order directly on a
+// three-level-deep occupying directory (.claude/hooks/foo/sub, with a leaf at each level).
+func TestComputeDirMigrationPreRemoveOrderIsBottomUp(t *testing.T) {
+	const src = "/nix/store/aaa-src"
+	prev := mani(
+		sl(src, ".claude/hooks/top.sh"),
+		sl(src, ".claude/hooks/foo/mid.sh"),
+		sl(src, ".claude/hooks/foo/sub/leaf.sh"),
+	)
+	next := mani(sl(src, ".claude/hooks"))
+	fs := fakeFS{
+		abs(".claude"):                       dir(),
+		abs(".claude/hooks"):                 dir(),
+		abs(".claude/hooks/top.sh"):          sym(src),
+		abs(".claude/hooks/foo"):             dir(),
+		abs(".claude/hooks/foo/mid.sh"):      sym(src),
+		abs(".claude/hooks/foo/sub"):         dir(),
+		abs(".claude/hooks/foo/sub/leaf.sh"): sym(src),
+	}
+
+	plan, err := Compute(prev, next, root, fs)
+	if err != nil {
+		t.Fatalf("Compute: unexpected error: %v", err)
+	}
+	if len(plan.Conflicts) != 0 {
+		t.Fatalf("Conflicts = %v, want none", plan.Conflicts)
+	}
+
+	// Build a position index over the actual PreRemove slice order (both Unlink and Rmdir kinds,
+	// keyed by their target — Entry.Target for Unlink, the root-relative dir for Rmdir).
+	pos := map[string]int{}
+	for i, a := range plan.PreRemove {
+		key := a.Entry.Target
+		if a.Kind == RemoveRmdir {
+			rel, err := filepath.Rel(root, a.TargetAbs)
+			if err != nil {
+				t.Fatalf("filepath.Rel: %v", err)
+			}
+			key = rel
+		}
+		pos[key] = i
+	}
+
+	// Every ordering constraint classifyDirMigration's bottom-up contract implies: a leaf's Unlink
+	// must precede the Rmdir of the directory that directly contains it, at every nesting level.
+	constraints := [][2]string{
+		{".claude/hooks/foo/sub/leaf.sh", ".claude/hooks/foo/sub"}, // deepest leaf before its dir
+		{".claude/hooks/foo/sub", ".claude/hooks/foo"},             // deepest dir before its parent dir
+		{".claude/hooks/foo/mid.sh", ".claude/hooks/foo"},          // mid-level leaf before its dir
+		{".claude/hooks/foo", ".claude/hooks"},                     // that dir before the placement target
+		{".claude/hooks/top.sh", ".claude/hooks"},                  // top-level leaf before the placement target
+	}
+	for _, c := range constraints {
+		before, after := c[0], c[1]
+		bi, ok := pos[before]
+		if !ok {
+			t.Fatalf("PreRemove missing expected action for %q; got %v", before, plan.PreRemove)
+		}
+		ai, ok := pos[after]
+		if !ok {
+			t.Fatalf("PreRemove missing expected action for %q; got %v", after, plan.PreRemove)
+		}
+		if bi >= ai {
+			t.Errorf("PreRemove order: %q (index %d) must come before %q (index %d); got %v", before, bi, after, ai, plan.PreRemove)
+		}
+	}
+}
+
 // TestComputeUnknownMethodErrors verifies that an unknown method is rejected.
 func TestComputeUnknownMethodErrors(t *testing.T) {
 	e := sl("/nix/store/x", ".config/foo")

--- a/internal/planner/planner_test.go
+++ b/internal/planner/planner_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"testing"
 	"time"
 
@@ -39,6 +40,35 @@ func (f fakeFS) Readlink(path string) (string, error) {
 	return e.dest, nil
 }
 
+// ReadDir lists path's immediate children by scanning the flat fakeFS map for keys one
+// path component below path (path itself need not exist as a "dir" entry in the map;
+// only its children's presence matters, matching how the table-driven tests populate fs).
+func (f fakeFS) ReadDir(path string) ([]os.DirEntry, error) {
+	prefix := path + string(os.PathSeparator)
+	seen := map[string]fakeEntry{}
+	for p, e := range f {
+		if !strings.HasPrefix(p, prefix) {
+			continue
+		}
+		rest := p[len(prefix):]
+		if idx := strings.IndexRune(rest, os.PathSeparator); idx >= 0 {
+			rest = rest[:idx]
+		}
+		if rest == "" {
+			continue
+		}
+		if _, ok := seen[rest]; !ok {
+			seen[rest] = e
+		}
+	}
+	out := make([]os.DirEntry, 0, len(seen))
+	for name, e := range seen {
+		out = append(out, fakeDirEntry{name: name, mode: e.mode})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name() < out[j].Name() })
+	return out, nil
+}
+
 type fakeInfo struct {
 	name string
 	mode os.FileMode
@@ -50,6 +80,18 @@ func (i fakeInfo) Mode() os.FileMode  { return i.mode }
 func (i fakeInfo) ModTime() time.Time { return time.Time{} }
 func (i fakeInfo) IsDir() bool        { return i.mode&os.ModeDir != 0 }
 func (i fakeInfo) Sys() any           { return nil }
+
+type fakeDirEntry struct {
+	name string
+	mode os.FileMode
+}
+
+func (e fakeDirEntry) Name() string      { return e.name }
+func (e fakeDirEntry) IsDir() bool       { return e.mode&os.ModeDir != 0 }
+func (e fakeDirEntry) Type() os.FileMode { return e.mode.Type() }
+func (e fakeDirEntry) Info() (os.FileInfo, error) {
+	return fakeInfo{name: e.name, mode: e.mode}, nil
+}
 
 // --- manifest helpers -------------------------------------------------------
 
@@ -86,7 +128,8 @@ type want struct {
 	placeForeign []string
 	copies       []string
 	remove       []string
-	preRemove    []string
+	preRemove    []string // RemoveUnlink actions, by Entry.Target
+	preRemoveDir []string // RemoveRmdir actions, by root-relative TargetAbs
 	warns        []WarnKind
 	conflicts    int
 	// conflictKinds asserts plan.Conflicts[i].Kind in order (nil = skip; the conflicts count
@@ -116,7 +159,23 @@ func removeTargets(p Plan) []string {
 func preRemoveTargets(p Plan) []string {
 	var out []string
 	for _, a := range p.PreRemove {
-		out = append(out, a.Entry.Target)
+		if a.Kind == RemoveUnlink {
+			out = append(out, a.Entry.Target)
+		}
+	}
+	return out
+}
+
+func preRemoveDirTargets(p Plan) []string {
+	var out []string
+	for _, a := range p.PreRemove {
+		if a.Kind == RemoveRmdir {
+			rel, err := filepath.Rel(root, a.TargetAbs)
+			if err != nil {
+				rel = a.TargetAbs
+			}
+			out = append(out, rel)
+		}
 	}
 	return out
 }
@@ -440,6 +499,107 @@ func TestComputeTableDriven(t *testing.T) {
 			want: want{},
 		},
 		{
+			// Real directory occupying the target, all children recorded ∧ stale (self-recorded by
+			// this profile's previous generation, dropped by the new one): fully migratable — every
+			// child is scheduled RemoveUnlink, the now-empty dir itself RemoveRmdir, and the entry
+			// places as a new symlink (→ ADR-0047, issue #175).
+			name: "real dir target, all children recorded+stale → migrate (preRemove unlink+rmdir)",
+			prev: mani(sl(srcA, ".claude/hooks/foo/main.sh"), sl(srcA, ".claude/hooks/bar/main.sh")),
+			next: mani(sl(srcB, ".claude/hooks")),
+			fs: fakeFS{
+				abs(".claude"):                   dir(),
+				abs(".claude/hooks"):             dir(),
+				abs(".claude/hooks/foo"):         dir(),
+				abs(".claude/hooks/foo/main.sh"): sym(srcA),
+				abs(".claude/hooks/bar"):         dir(),
+				abs(".claude/hooks/bar/main.sh"): sym(srcA),
+			},
+			want: want{
+				placeNew: []string{".claude/hooks"},
+				preRemove: []string{
+					".claude/hooks/foo/main.sh",
+					".claude/hooks/bar/main.sh",
+				},
+				preRemoveDir: []string{
+					".claude/hooks/foo",
+					".claude/hooks/bar",
+					".claude/hooks",
+				},
+			},
+		},
+		{
+			// Real directory containing only an empty subdirectory (no leaf entries at all): empty
+			// dirs are migratable regardless of provenance, since rmdir only ever succeeds when empty
+			// (data-loss-free even for dirs nput never created · → ADR-0047 D2).
+			name: "real dir target, empty subdir of unknown provenance → migrate (rmdir only)",
+			prev: nil,
+			next: mani(sl(srcB, ".claude/hooks")),
+			fs: fakeFS{
+				abs(".claude"):             dir(),
+				abs(".claude/hooks"):       dir(),
+				abs(".claude/hooks/empty"): dir(),
+			},
+			want: want{
+				placeNew: []string{".claude/hooks"},
+				preRemoveDir: []string{
+					".claude/hooks/empty",
+					".claude/hooks",
+				},
+			},
+		},
+		{
+			// Real directory with one foreign real file mixed among otherwise-migratable children:
+			// the whole directory is a conflict, and critically NONE of the migratable siblings are
+			// partially removed (no dirActions leak into the plan on failure · → ADR-0047).
+			name: "real dir target, one real file mixed in → conflict (no partial removal)",
+			prev: mani(sl(srcA, ".claude/hooks/foo/main.sh")),
+			next: mani(sl(srcB, ".claude/hooks")),
+			fs: fakeFS{
+				abs(".claude"):                   dir(),
+				abs(".claude/hooks"):             dir(),
+				abs(".claude/hooks/foo"):         dir(),
+				abs(".claude/hooks/foo/main.sh"): sym(srcA),
+				abs(".claude/hooks/README"):      reg(),
+			},
+			// The dir-migration classification for ".claude/hooks" discards its dirActions on
+			// conflict (no partial removal from *that* walk), but ".claude/hooks/foo/main.sh" is
+			// independently a stale entry in prev.Entries under the ordinary remove-side loop (it
+			// was never added to preRemoved, since the dir classification failed before dedup-ing
+			// it). This is harmless: engine.Apply stops before removeStale on any conflict, so this
+			// planned removal never executes (→ ADR-0047).
+			want: want{conflicts: 1, remove: []string{".claude/hooks/foo/main.sh"}},
+		},
+		{
+			// Real directory whose new generation still records a nested child at the same relative
+			// target as a dir-child symlink (self-contradictory manifest): the dir-migration
+			// classification for ".claude/hooks" itself conflicts (child kept in next), but
+			// ".claude/hooks/foo" is also independently present in next.Entries and gets classified
+			// on its own merits by the ordinary per-entry loop (a recorded symlink, unaffected by
+			// its ancestor still being a real, unmigrated directory) → PlaceReplace. Harmless for the
+			// same reason as above: the conflict blocks engine.Apply before any placement runs.
+			name: "real dir target, child kept in next → conflict (self-contradictory)",
+			prev: mani(sl(srcA, ".claude/hooks/foo")),
+			next: mani(sl(srcB, ".claude/hooks"), sl(srcB, ".claude/hooks/foo")),
+			fs: fakeFS{
+				abs(".claude"):           dir(),
+				abs(".claude/hooks"):     dir(),
+				abs(".claude/hooks/foo"): sym(srcA),
+			},
+			want: want{conflicts: 1, placeReplace: []string{".claude/hooks/foo"}},
+		},
+		{
+			// Real directory with a foreign (record-mismatched) symlink child: conflict.
+			name: "real dir target, foreign symlink child → conflict",
+			prev: nil,
+			next: mani(sl(srcB, ".claude/hooks")),
+			fs: fakeFS{
+				abs(".claude"):           dir(),
+				abs(".claude/hooks"):     dir(),
+				abs(".claude/hooks/foo"): sym("/foreign"),
+			},
+			want: want{conflicts: 1},
+		},
+		{
 			// mixed: new + silent re-link + foreign warning + stale removal + mismatch kept.
 			name: "mixed plan",
 			prev: mani(sl(srcA, "keep"), sl(srcA, "drop"), sl(srcA, "mism")),
@@ -473,6 +633,7 @@ func TestComputeTableDriven(t *testing.T) {
 			sortedEq(t, "copies", copyTargets(plan), tt.want.copies)
 			sortedEq(t, "remove", removeTargets(plan), tt.want.remove)
 			sortedEq(t, "preRemove", preRemoveTargets(plan), tt.want.preRemove)
+			sortedEq(t, "preRemoveDir", preRemoveDirTargets(plan), tt.want.preRemoveDir)
 			warnEq(t, warnKinds(plan), tt.want.warns)
 			if len(plan.Conflicts) != tt.want.conflicts {
 				t.Errorf("conflicts = %d, want %d (%v)", len(plan.Conflicts), tt.want.conflicts, plan.Conflicts)

--- a/internal/planner/planner_test.go
+++ b/internal/planner/planner_test.go
@@ -90,7 +90,7 @@ func (e fakeDirEntry) Name() string      { return e.name }
 func (e fakeDirEntry) IsDir() bool       { return e.mode&os.ModeDir != 0 }
 func (e fakeDirEntry) Type() os.FileMode { return e.mode.Type() }
 func (e fakeDirEntry) Info() (os.FileInfo, error) {
-	return fakeInfo{name: e.name, mode: e.mode}, nil
+	return fakeInfo(e), nil
 }
 
 // --- manifest helpers -------------------------------------------------------

--- a/internal/planner/planner_test.go
+++ b/internal/planner/planner_test.go
@@ -600,6 +600,48 @@ func TestComputeTableDriven(t *testing.T) {
 			want: want{conflicts: 1},
 		},
 		{
+			// Method changed symlink→copy at the same target: the previous generation's recorded
+			// symlink is pre-removed (Unlink) and a fresh place-once copy is scheduled — zero data
+			// loss since the symlink carried no user data (→ ADR-0047 D5).
+			name: "method change symlink→copy, recorded → migrate (preRemove unlink + copy)",
+			prev: mani(sl(srcA, ".config/tool.conf")),
+			next: mani(cp(srcB, ".config/tool.conf")),
+			fs: fakeFS{
+				srcB:                     reg(),
+				abs(".config/tool.conf"): sym(srcA),
+			},
+			want: want{
+				copies:    []string{".config/tool.conf"},
+				preRemove: []string{".config/tool.conf"},
+			},
+		},
+		{
+			// Method changed symlink→copy but the on-disk symlink drifted from the record (foreign /
+			// user-swapped): not eligible for the method-change migration, falls through to the
+			// ordinary foreign handling (→ ADR-0047 D5 fallback).
+			name: "method change symlink→copy, drifted record → foreign (no migration)",
+			prev: mani(sl(srcA, ".config/tool.conf")),
+			next: mani(cp(srcB, ".config/tool.conf")),
+			fs: fakeFS{
+				srcB:                     reg(),
+				abs(".config/tool.conf"): sym("/elsewhere"),
+			},
+			want: want{warns: []WarnKind{WarnCopyForeign}},
+		},
+		{
+			// Method changed copy→symlink at the same target: NOT migrated (D5 keeps copy→symlink a
+			// conflict to protect potentially user-edited copy data; ADR-0047 only automates the
+			// zero-data-loss symlink→copy direction). The existing copy target is a real file
+			// occupying a symlink placement target, so it is the ordinary no-overwrite conflict.
+			name: "method change copy→symlink, recorded copy → conflict (not migrated)",
+			prev: mani(cp(srcA, ".config/tool.conf")),
+			next: mani(sl(srcB, ".config/tool.conf")),
+			fs: fakeFS{
+				abs(".config/tool.conf"): reg(),
+			},
+			want: want{conflicts: 1},
+		},
+		{
 			// mixed: new + silent re-link + foreign warning + stale removal + mismatch kept.
 			name: "mixed plan",
 			prev: mani(sl(srcA, "keep"), sl(srcA, "drop"), sl(srcA, "mism")),


### PR DESCRIPTION
## 概要

<!-- なぜ・何を変えるか。Conventional Commits のタイトルだけでは残らない背景を書く。 -->

`Rollback` が planner の `plan.PreRemove` を無視して `place → removeStale` のみ実行していたバグを修正する。ADR-0046 で導入した「自己記録 stale 祖先 symlink の配置前除去（PreRemove）」は apply 側にしか配線されておらず、祖先 symlink 世代 ⇄ per-file 世代の移行を跨ぐ rollback は `os.Symlink` が祖先 symlink 越しに旧 farm へ解決して EEXIST/EROFS で停止していた。`Rollback()` に `a.preRemove(plan.PreRemove)` を `place` の前段として追加し、apply と同じ実行順・drift 時 error 停止の意味論に揃えた。

diff-review（design / test 両レンズ）を 5 往復かけてクリアしている。レビュー中に発覚した「Rollback は copy entries を materialize しない」既存バグ（本 PR のスコープ外）は #178 として別途起票済み。

## 関連 issue

<!-- 例: Closes #N / Refs #N。なければ「なし」。 -->

Closes #175
Refs #172

## docs / ADR 影響

<!--
このリポジトリはドキュメント主導。配置動作・API・方針に触れる変更は docs の更新がセットになる。
- concept / design / spec の更新有無
- 方針転換や trade-off を伴うなら ADR を追加したか（docs/adr/）
影響がなければ「なし」と明記する。
-->

- `docs/spec.md`: rollback 実行フローに PreRemove 段（apply と同順）を明記。
- `docs/adr/0046-self-recorded-ancestor-nest-migration.md` §3・`docs/adr/0015-pre-impl-remaining-semantics.md` §5: rollback 経路でも PreRemove が対象だった旨、および修正前は未実行だった旨の改訂注記を追加。新規 ADR の起票は無し（ADR-0046 で確定済みの設計を rollback にも適用する修正のため）。

