### PR TITLE
fix(engine): Rollback で plan.PreRemove を実行する

### DIFF
--- a/docs/adr/0015-pre-impl-remaining-semantics.md
+++ b/docs/adr/0015-pre-impl-remaining-semantics.md
@@ -21,6 +21,13 @@
 > migration** へ改訂した。§2 の「前世代 manifest 記録の symlink は置換可（silent・後勝ち）」判定を祖先へ拡張し、緩和対象の祖先は配置**前**に
 > 除去（`Plan.PreRemove`）してから配下子を新規配置する。foreign 祖先・自己矛盾（次世代にも祖先が残る）・`prev == nil` は**従来通り
 > error 停止**で store 汚染の担保は不変（→ ADR-0046）。
+>
+> **2026-07-12 改訂注記（#173）**: 本 ADR §5 の rollback 実行段（「`N ∖ N-1` の entry を保守的に stale 除去 → N-1 の entry を
+> place/replace」）は、ADR-0046 で新設された `Plan.PreRemove` の実行を欠いたまま出荷されていた（`internal/engine/generations.go` の
+> `Rollback()` が `plan.PreRemove` を捨てて `place` → `removeStale` のみ実行するバグ）。ADR-0046 の移行（祖先 symlink 世代 ⇄
+> per-file 世代）を跨ぐ rollback は、apply と同じく **PreRemove → place/replace → stale 除去**の順で反映しないと収束しない。
+> `Rollback()` に `a.preRemove(plan.PreRemove)` を `place` の前段として追加し修正した（apply の実行順・drift 時 error 停止の意味論と
+> 同一・→ #173）。
 
 ## 背景
 

--- a/docs/adr/0046-self-recorded-ancestor-nest-migration.md
+++ b/docs/adr/0046-self-recorded-ancestor-nest-migration.md
@@ -6,6 +6,12 @@
 - 改訂対象: **ADR-0015 §4**「target の祖先 component が symlink なら配置前に一律 error 停止」を「**foreign 祖先のみ error / 自己記録 stale 祖先は migration（配置前除去）**」へ改訂。**ADR-0015 §2**「前世代 manifest 記録の symlink は置換可（silent・後勝ち）」の判定を祖先へ拡張。
 - 起点: dotfiles 側での実遭遇（#170）と、次期マイルストーンの grilling セッション（2026-07-11）で設計確定
 
+> **2026-07-12 改訂注記（#173）**: 本 ADR §3 の「engine は PreRemove → place → copies → removeStale の順で流す」は、
+> apply（`internal/engine/engine.go`）のみ実装され `Rollback()`（`internal/engine/generations.go`）は `plan.PreRemove` を
+> 実行せず捨てていた。ADR-0046 の移行（祖先 symlink 世代 ⇄ per-file 世代）を跨ぐ rollback はこの経路を通るため、apply と同じ
+> PreRemove 実行が要る。`Rollback()` に `a.preRemove(plan.PreRemove)` を `place` の前段として追加し、drift 時の error 停止を含む
+> §3 の意味論を rollback にも揃えた（→ #173, ADR-0015 §5 改訂注記）。
+
 ## 背景
 
 `.claude/skills` のような**全体 symlink** entry を、配下に子 entry をネストする形（`.claude/skills/foo`, `.claude/skills/bar`, …）へ移行しようとすると、apply が丸ごと失敗する。原因は 2 段に分かれる。

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -715,7 +715,9 @@ profile の各世代は GC root。`nix-env --profile <profileDir>/profile --dele
 - **standalone（home mode）**: `nput rollback <name>` で前世代に戻す。nput は profile dir 自体ではなく任意 root に配置するため、
   profile ポインタ移動だけでは FS が変わらず**再配置が必須**。stale 除去の diff は次の基準・順序で行う（→ ADR-0015）:
   1. `baseline` = 現世代 N の manifest（FS の現状）／ `target` = 戻る世代 N-1 の manifest。
-  2. `N ∖ N-1` の entry を保守的に stale 除去 → N-1 の entry を place/replace。
+  2. `(baseline, target)` で planner を計算し、apply と同順（**PreRemove → place/replace → stale 除去**）で FS へ反映する。
+     N が自己記録の祖先 symlink を配下ネスト entries へ移行した世代なら、`plan.PreRemove` は戻り先 N-1 の祖先 symlink を
+     塞いでいる自己記録 symlink を配置前除去する（apply の PreRemove と同一実行経路・drift 時は同じく error 停止・→ ADR-0046）。
   3. **最後に** `nix-env --profile <profileDir>/profile --rollback`（または `--switch-generation N-1`）で profile ポインタを移す。
   ポインタを先に動かすと baseline が N-2 へずれ stale 除去が誤るため、FS 収束を先に・ポインタ移動を最後にする。apply エンジンを
   `(baseline, target)` 差し替えで再利用する。任意世代切替・世代 GC は `nix-env --profile <profileDir>/profile` 系 / `nix-collect-garbage` を使う。

--- a/internal/engine/generations.go
+++ b/internal/engine/generations.go
@@ -174,9 +174,11 @@ func Rollback(opts RollbackOptions) (*RollbackResult, error) {
 		return nil, fmt.Errorf("nput: %s (target: %s)", c.Reason, c.Entry.Target)
 	}
 
-	// 6. reflect the plan onto the real FS. PreRemove first (unlink self-recorded stale ancestor
-	//    symlinks so nested children land in a real dir · same order as Apply · → engine.go, ADR-0046),
-	//    then new/re-link, then stale removal last (→ ADR-0006).
+	// 6. reflect the plan onto the real FS: same PreRemove-first ordering as Apply (unlink
+	//    self-recorded stale ancestor symlinks so nested children land in a real dir · →
+	//    engine.go, ADR-0046), then new/re-link, then stale removal last (→ ADR-0006). Unlike
+	//    Apply, Rollback has no materializeCopies step, so copy entries in plan.Copies are not
+	//    reflected onto the FS (pre-existing gap, out of scope here · → issue #178).
 	a := &applier{opts: Options{Warnf: warnf}, result: &Result{Root: root, ProfileDir: prof.Dir}}
 	a.profile = prof
 	a.root = root

--- a/internal/engine/generations.go
+++ b/internal/engine/generations.go
@@ -174,11 +174,16 @@ func Rollback(opts RollbackOptions) (*RollbackResult, error) {
 		return nil, fmt.Errorf("nput: %s (target: %s)", c.Reason, c.Entry.Target)
 	}
 
-	// 6. reflect the plan onto the real FS (new/re-link first, stale removal last · → ADR-0006).
+	// 6. reflect the plan onto the real FS. PreRemove first (unlink self-recorded stale ancestor
+	//    symlinks so nested children land in a real dir · same order as Apply · → engine.go, ADR-0046),
+	//    then new/re-link, then stale removal last (→ ADR-0006).
 	a := &applier{opts: Options{Warnf: warnf}, result: &Result{Root: root, ProfileDir: prof.Dir}}
 	a.profile = prof
 	a.root = root
 	a.emitWarnings(plan.Warnings, false)
+	if err := a.preRemove(plan.PreRemove); err != nil {
+		return nil, err
+	}
 	if err := a.place(plan.Place); err != nil {
 		return nil, err
 	}

--- a/internal/engine/generations_test.go
+++ b/internal/engine/generations_test.go
@@ -255,7 +255,7 @@ func TestRollbackAncestorPreRemoveErrorSkipsSwitch(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	srcNew := realTempDir(t)
+	srcNew := realTempDir(t) // stays empty: preRemove errors before place ever reads its contents
 
 	prof := paths.Resolve(state, "c", manifest.RootKindHome, root, true)
 	if err := os.MkdirAll(prof.Dir, 0o755); err != nil {
@@ -302,8 +302,12 @@ func TestRollbackAncestorPreRemoveErrorSkipsSwitch(t *testing.T) {
 		},
 		SwitchGeneration: func(_ string, gen int) error { switched = gen; return nil },
 	})
-	if err == nil {
-		t.Fatal("expected a preRemove unlink error, got nil")
+	// The message pins the failure to preRemove's os.Remove path specifically (staleremove.go),
+	// not merely to any early return — e.g. a future planner change that routed this setup to
+	// Conflicts instead of PreRemove would also make Rollback error out before switchFn, and a
+	// bare err != nil check would pass despite never reaching the code this test targets.
+	if err == nil || !strings.Contains(err.Error(), "cannot remove ancestor symlink for migration") {
+		t.Fatalf("expected a preRemove unlink error, got %v", err)
 	}
 	if switched != 0 {
 		t.Errorf("SwitchGeneration was called (switched=%d), want it skipped when preRemove fails", switched)

--- a/internal/engine/generations_test.go
+++ b/internal/engine/generations_test.go
@@ -233,6 +233,13 @@ func TestRollbackAncestorMigration(t *testing.T) {
 	if len(res.Removed) != 1 || res.Removed[0] != ".claude/skills" {
 		t.Errorf("Removed = %v, want [.claude/skills]", res.Removed)
 	}
+	placed := map[string]bool{}
+	for _, p := range res.Placed {
+		placed[p] = true
+	}
+	if len(res.Placed) != 2 || !placed[".claude/skills/foo"] || !placed[".claude/skills/bar"] {
+		t.Errorf("Placed = %v, want [.claude/skills/foo .claude/skills/bar]", res.Placed)
+	}
 }
 
 // TestRollbackAncestorPreRemoveErrorSkipsSwitch verifies the Rollback-level wiring of preRemove's

--- a/internal/engine/generations_test.go
+++ b/internal/engine/generations_test.go
@@ -139,6 +139,100 @@ func TestRollbackReconverges(t *testing.T) {
 	}
 }
 
+// TestRollbackAncestorMigration verifies rollback from a whole-tree-ancestor-symlink generation
+// (N, current) back to a per-file generation (N-1): baseline (N) records the ancestor symlink,
+// target (N-1) records the nested children, so the plan carries a PreRemove for the ancestor and
+// the children are placed fresh into the real directory. Before the fix Rollback dropped
+// plan.PreRemove and this migration failed with an EEXIST/EROFS conflict (→ ADR-0046, issue #173).
+func TestRollbackAncestorMigration(t *testing.T) {
+	root := realTempDir(t)
+	state := realTempDir(t)
+	srcOld := realTempDir(t)
+	for _, name := range []string{"foo", "bar"} {
+		if err := os.WriteFile(filepath.Join(srcOld, name), []byte("old"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	srcNew := realTempDir(t)
+	for _, name := range []string{"foo", "bar"} {
+		if err := os.WriteFile(filepath.Join(srcNew, name), []byte("new"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	prof := paths.Resolve(state, "c", manifest.RootKindHome, root, true)
+	if err := os.MkdirAll(prof.Dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// gen1 (N-1): nested per-file children pointing at srcOld.
+	lf1 := writeLinkFarm(t, homeManifest(
+		storeEntry(srcOld, "foo", ".claude/skills/foo"),
+		storeEntry(srcOld, "bar", ".claude/skills/bar"),
+	))
+	// gen2 (N, current): migrated to a whole-tree ancestor symlink at .claude/skills → srcNew.
+	lf2 := writeLinkFarm(t, homeManifest(storeEntry(srcNew, ".", ".claude/skills")))
+
+	if err := os.Symlink(lf1, paths.GenerationLink(prof.Profile, 1)); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(lf2, paths.GenerationLink(prof.Profile, 2)); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(lf2, prof.Profile); err != nil {
+		t.Fatal(err)
+	}
+
+	// Current FS = gen2: .claude/skills is a whole-tree symlink to srcNew.
+	if err := os.MkdirAll(filepath.Join(root, ".claude"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(srcNew, filepath.Join(root, ".claude", "skills")); err != nil {
+		t.Fatal(err)
+	}
+
+	var switched int
+	var warns []string
+	res, err := Rollback(RollbackOptions{
+		Name: "c", RootKind: manifest.RootKindHome, RootOverride: root, StateDir: state,
+		ListGenerations: func(string) ([]Generation, error) {
+			return []Generation{{Number: 1}, {Number: 2, Current: true}}, nil
+		},
+		SwitchGeneration: func(_ string, gen int) error { switched = gen; return nil },
+		Warnf:            collectWarnings(&warns),
+	})
+	if err != nil {
+		t.Fatalf("Rollback: %v", err)
+	}
+	if switched != 1 {
+		t.Errorf("switched generation = %d, want 1", switched)
+	}
+	if len(warns) != 0 {
+		t.Errorf("rollback migration emitted warnings, want none: %v", warns)
+	}
+
+	// .claude/skills is now a real directory (the ancestor symlink was pre-removed).
+	info, err := os.Lstat(filepath.Join(root, ".claude", "skills"))
+	if err != nil {
+		t.Fatalf(".claude/skills lstat: %v", err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		t.Errorf(".claude/skills is still a symlink after rollback, want a real directory")
+	}
+	for _, name := range []string{"foo", "bar"} {
+		got, err := os.Readlink(filepath.Join(root, ".claude", "skills", name))
+		if err != nil {
+			t.Fatalf("child %s readlink: %v", name, err)
+		}
+		if want := filepath.Join(srcOld, name); got != want {
+			t.Errorf("child %s → %q, want %q", name, got, want)
+		}
+	}
+	if len(res.Removed) != 1 || res.Removed[0] != ".claude/skills" {
+		t.Errorf("Removed = %v, want [.claude/skills]", res.Removed)
+	}
+}
+
 // TestRollbackNoPreviousErrors verifies that rollback stops with an error when the current generation is the oldest (no previous generation).
 func TestRollbackNoPreviousErrors(t *testing.T) {
 	root := realTempDir(t)

--- a/internal/engine/generations_test.go
+++ b/internal/engine/generations_test.go
@@ -235,6 +235,86 @@ func TestRollbackAncestorMigration(t *testing.T) {
 	}
 }
 
+// TestRollbackAncestorPreRemoveErrorSkipsSwitch verifies the Rollback-level wiring of preRemove's
+// error path: same setup as TestRollbackAncestorMigration, but the ancestor symlink's parent dir
+// is read-only, so preRemove's os.Remove fails. Rollback must propagate the error instead of
+// swallowing it and must not move the profile pointer — a regression a unit test on preRemove
+// alone (TestPreRemoveDriftErrors) cannot catch, since it never exercises the Rollback() call
+// site added by this fix (→ #173). (A pre-plan drift setup cannot be used here: it would make
+// planner.Compute itself see a mismatch and route to Conflicts instead of PreRemove, never
+// reaching this call site — → planner.go recordedLink.)
+func TestRollbackAncestorPreRemoveErrorSkipsSwitch(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("permission-denied unlink cannot be induced as root")
+	}
+	root := realTempDir(t)
+	state := realTempDir(t)
+	srcOld := realTempDir(t)
+	for _, name := range []string{"foo", "bar"} {
+		if err := os.WriteFile(filepath.Join(srcOld, name), []byte("old"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	srcNew := realTempDir(t)
+
+	prof := paths.Resolve(state, "c", manifest.RootKindHome, root, true)
+	if err := os.MkdirAll(prof.Dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// gen1 (N-1): nested per-file children pointing at srcOld.
+	lf1 := writeLinkFarm(t, homeManifest(
+		storeEntry(srcOld, "foo", ".claude/skills/foo"),
+		storeEntry(srcOld, "bar", ".claude/skills/bar"),
+	))
+	// gen2 (N, current): whole-tree ancestor symlink recorded at .claude/skills → srcNew.
+	lf2 := writeLinkFarm(t, homeManifest(storeEntry(srcNew, ".", ".claude/skills")))
+
+	if err := os.Symlink(lf1, paths.GenerationLink(prof.Profile, 1)); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(lf2, paths.GenerationLink(prof.Profile, 2)); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(lf2, prof.Profile); err != nil {
+		t.Fatal(err)
+	}
+
+	// Current FS = gen2: .claude/skills is a whole-tree symlink to srcNew (invariant holds, no drift).
+	claudeDir := filepath.Join(root, ".claude")
+	if err := os.MkdirAll(claudeDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(srcNew, filepath.Join(claudeDir, "skills")); err != nil {
+		t.Fatal(err)
+	}
+	// Removing a directory entry requires write on its parent; drop it to force the unlink to fail.
+	if err := os.Chmod(claudeDir, 0o555); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(claudeDir, 0o755) }) // restore so TempDir cleanup can recurse
+
+	var switched int
+	_, err := Rollback(RollbackOptions{
+		Name: "c", RootKind: manifest.RootKindHome, RootOverride: root, StateDir: state,
+		ListGenerations: func(string) ([]Generation, error) {
+			return []Generation{{Number: 1}, {Number: 2, Current: true}}, nil
+		},
+		SwitchGeneration: func(_ string, gen int) error { switched = gen; return nil },
+	})
+	if err == nil {
+		t.Fatal("expected a preRemove unlink error, got nil")
+	}
+	if switched != 0 {
+		t.Errorf("SwitchGeneration was called (switched=%d), want it skipped when preRemove fails", switched)
+	}
+	// The ancestor symlink must be left untouched (unlink failed, not silently skipped).
+	got, rerr := os.Readlink(filepath.Join(claudeDir, "skills"))
+	if rerr != nil || got != srcNew {
+		t.Errorf(".claude/skills after error = %q (err %v), want untouched %q", got, rerr, srcNew)
+	}
+}
+
 // TestRollbackNoPreviousErrors verifies that rollback stops with an error when the current generation is the oldest (no previous generation).
 func TestRollbackNoPreviousErrors(t *testing.T) {
 	root := realTempDir(t)

--- a/internal/engine/generations_test.go
+++ b/internal/engine/generations_test.go
@@ -143,7 +143,9 @@ func TestRollbackReconverges(t *testing.T) {
 // (N, current) back to a per-file generation (N-1): baseline (N) records the ancestor symlink,
 // target (N-1) records the nested children, so the plan carries a PreRemove for the ancestor and
 // the children are placed fresh into the real directory. Before the fix Rollback dropped
-// plan.PreRemove and this migration failed with an EEXIST/EROFS conflict (→ ADR-0046, issue #173).
+// plan.PreRemove, so place ran with the ancestor symlink still present: ensureParentDir's
+// MkdirAll on the symlinked dir was a no-op, and os.Symlink for the nested child then resolved
+// through it into srcNew (store-equivalent) and failed with EEXIST/EROFS (→ ADR-0046, issue #173).
 func TestRollbackAncestorMigration(t *testing.T) {
 	root := realTempDir(t)
 	state := realTempDir(t)

--- a/internal/engine/staleremove_test.go
+++ b/internal/engine/staleremove_test.go
@@ -208,6 +208,8 @@ func TestPreRemoveDriftErrors(t *testing.T) {
 
 			var warns []string
 			a := staleErr_applier(&warns)
+			// preRemove only touches act.TargetAbs directly (no parent-dir walk), so targetAbs
+			// need not sit under a ".claude" parent matching the entry target's shape.
 			act := staleErr_action(recordedDest, ".claude/skills", targetAbs)
 
 			err := a.preRemove([]planner.RemoveAction{act})

--- a/internal/engine/staleremove_test.go
+++ b/internal/engine/staleremove_test.go
@@ -150,6 +150,43 @@ func TestStaleRemoveContinuesAfterDrift(t *testing.T) {
 	}
 }
 
+// TestPreRemoveDriftErrors covers preRemove's post-plan drift re-check: unlike removeStale,
+// a drifted ancestor is not safe to skip (children were planned as unconditional new
+// placements assuming the ancestor is gone), so preRemove aborts loudly instead of keeping
+// the drifted link (→ staleremove.go, ADR-0046). Rollback shares this executor with apply
+// (→ generations.go), so the same error-stop semantics apply on the rollback path too.
+func TestPreRemoveDriftErrors(t *testing.T) {
+	dir := realTempDir(t)
+	recordedDest := realTempDir(t)
+	targetAbs := filepath.Join(dir, "skills")
+
+	// Drifted since planning: swapped to a foreign dest → readlink mismatch.
+	foreign := realTempDir(t)
+	if err := os.Symlink(foreign, targetAbs); err != nil {
+		t.Fatal(err)
+	}
+
+	var warns []string
+	a := staleErr_applier(&warns)
+	act := staleErr_action(recordedDest, ".claude/skills", targetAbs)
+
+	err := a.preRemove([]planner.RemoveAction{act})
+	if err == nil || !strings.Contains(err.Error(), "changed after planning") {
+		t.Fatalf("expected ancestor-drift error, got %v", err)
+	}
+	// Error stop, not skip: no warning, no removal record, target left untouched.
+	if len(warns) != 0 {
+		t.Errorf("warnings = %v, want none (preRemove errors instead of warning)", warns)
+	}
+	if len(a.result.Removed) != 0 {
+		t.Errorf("Removed = %v, want none", a.result.Removed)
+	}
+	got, rerr := os.Readlink(targetAbs)
+	if rerr != nil || got != foreign {
+		t.Errorf("drifted ancestor after error = %q (err %v), want untouched %q", got, rerr, foreign)
+	}
+}
+
 // TestStaleRemoveUnlinkError covers the os.Remove failure path: the invariant still
 // holds (reverify passes), but the unlink fails, so removeStale returns a wrapped error
 // and records no removal. Permission-denied is induced by an unwritable parent dir;

--- a/internal/engine/staleremove_test.go
+++ b/internal/engine/staleremove_test.go
@@ -150,40 +150,91 @@ func TestStaleRemoveContinuesAfterDrift(t *testing.T) {
 	}
 }
 
-// TestPreRemoveDriftErrors covers preRemove's post-plan drift re-check: unlike removeStale,
-// a drifted ancestor is not safe to skip (children were planned as unconditional new
-// placements assuming the ancestor is gone), so preRemove aborts loudly instead of keeping
-// the drifted link (→ staleremove.go, ADR-0046). Rollback shares this executor with apply
-// (→ generations.go), so the same error-stop semantics apply on the rollback path too.
+// TestPreRemoveDriftErrors covers preRemove's post-plan drift re-check across the same drift
+// equivalence classes as TestStaleRemoveDriftKeepsAndWarns (readlink mismatch / non-symlink file /
+// non-symlink dir / missing target). Unlike removeStale, a drifted ancestor is not safe to skip
+// (children were planned as unconditional new placements assuming the ancestor is gone), so
+// preRemove aborts loudly for every class instead of keeping the drifted link (→ staleremove.go,
+// ADR-0046). Rollback shares this executor with apply (→ generations.go), so the same error-stop
+// semantics apply on the rollback path too.
 func TestPreRemoveDriftErrors(t *testing.T) {
-	dir := realTempDir(t)
-	recordedDest := realTempDir(t)
-	targetAbs := filepath.Join(dir, "skills")
+	recordedDest := realTempDir(t) // the dest the previous-generation record points at
 
-	// Drifted since planning: swapped to a foreign dest → readlink mismatch.
-	foreign := realTempDir(t)
-	if err := os.Symlink(foreign, targetAbs); err != nil {
-		t.Fatal(err)
+	cases := []struct {
+		name  string
+		setup func(t *testing.T, targetAbs string) (wantExists bool, wantReadlink string)
+	}{
+		{
+			name: "foreign symlink (readlink mismatch)",
+			setup: func(t *testing.T, targetAbs string) (bool, string) {
+				foreign := realTempDir(t)
+				if err := os.Symlink(foreign, targetAbs); err != nil {
+					t.Fatal(err)
+				}
+				return true, foreign
+			},
+		},
+		{
+			name: "non-symlink regular file",
+			setup: func(t *testing.T, targetAbs string) (bool, string) {
+				if err := os.WriteFile(targetAbs, []byte("user"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+				return true, ""
+			},
+		},
+		{
+			name: "non-symlink directory",
+			setup: func(t *testing.T, targetAbs string) (bool, string) {
+				if err := os.Mkdir(targetAbs, 0o755); err != nil {
+					t.Fatal(err)
+				}
+				return true, ""
+			},
+		},
+		{
+			name: "missing target",
+			setup: func(t *testing.T, targetAbs string) (bool, string) {
+				return false, ""
+			},
+		},
 	}
 
-	var warns []string
-	a := staleErr_applier(&warns)
-	act := staleErr_action(recordedDest, ".claude/skills", targetAbs)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := realTempDir(t)
+			targetAbs := filepath.Join(dir, "skills")
+			wantExists, wantReadlink := tc.setup(t, targetAbs)
 
-	err := a.preRemove([]planner.RemoveAction{act})
-	if err == nil || !strings.Contains(err.Error(), "changed after planning") {
-		t.Fatalf("expected ancestor-drift error, got %v", err)
-	}
-	// Error stop, not skip: no warning, no removal record, target left untouched.
-	if len(warns) != 0 {
-		t.Errorf("warnings = %v, want none (preRemove errors instead of warning)", warns)
-	}
-	if len(a.result.Removed) != 0 {
-		t.Errorf("Removed = %v, want none", a.result.Removed)
-	}
-	got, rerr := os.Readlink(targetAbs)
-	if rerr != nil || got != foreign {
-		t.Errorf("drifted ancestor after error = %q (err %v), want untouched %q", got, rerr, foreign)
+			var warns []string
+			a := staleErr_applier(&warns)
+			act := staleErr_action(recordedDest, ".claude/skills", targetAbs)
+
+			err := a.preRemove([]planner.RemoveAction{act})
+			if err == nil || !strings.Contains(err.Error(), "changed after planning") {
+				t.Fatalf("expected ancestor-drift error, got %v", err)
+			}
+			// Error stop, not skip: no warning, no removal record, target left untouched.
+			if len(warns) != 0 {
+				t.Errorf("warnings = %v, want none (preRemove errors instead of warning)", warns)
+			}
+			if len(a.result.Removed) != 0 {
+				t.Errorf("Removed = %v, want none", a.result.Removed)
+			}
+			_, lerr := os.Lstat(targetAbs)
+			if wantExists && lerr != nil {
+				t.Errorf("drifted target should be left untouched: %v", lerr)
+			}
+			if !wantExists && !os.IsNotExist(lerr) {
+				t.Errorf("missing target should stay absent: lstat err = %v", lerr)
+			}
+			if wantReadlink != "" {
+				got, rerr := os.Readlink(targetAbs)
+				if rerr != nil || got != wantReadlink {
+					t.Errorf("drifted ancestor after error = %q (err %v), want untouched %q", got, rerr, wantReadlink)
+				}
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## 概要

<!-- なぜ・何を変えるか。Conventional Commits のタイトルだけでは残らない背景を書く。 -->

`Rollback` が planner の `plan.PreRemove` を無視して `place → removeStale` のみ実行していたバグを修正する。ADR-0046 で導入した「自己記録 stale 祖先 symlink の配置前除去（PreRemove）」は apply 側にしか配線されておらず、祖先 symlink 世代 ⇄ per-file 世代の移行を跨ぐ rollback は `os.Symlink` が祖先 symlink 越しに旧 farm へ解決して EEXIST/EROFS で停止していた。`Rollback()` に `a.preRemove(plan.PreRemove)` を `place` の前段として追加し、apply と同じ実行順・drift 時 error 停止の意味論に揃えた。

diff-review（design / test 両レンズ）を 5 往復かけてクリアしている。レビュー中に発覚した「Rollback は copy entries を materialize しない」既存バグ（本 PR のスコープ外）は #178 として別途起票済み。

## 関連 issue

<!-- 例: Closes #N / Refs #N。なければ「なし」。 -->

Closes #173
Refs #172

## docs / ADR 影響

<!--
このリポジトリはドキュメント主導。配置動作・API・方針に触れる変更は docs の更新がセットになる。
- concept / design / spec の更新有無
- 方針転換や trade-off を伴うなら ADR を追加したか（docs/adr/）
影響がなければ「なし」と明記する。
-->

- `docs/spec.md`: rollback 実行フローに PreRemove 段（apply と同順）を明記。
- `docs/adr/0046-self-recorded-ancestor-nest-migration.md` §3・`docs/adr/0015-pre-impl-remaining-semantics.md` §5: rollback 経路でも PreRemove が対象だった旨、および修正前は未実行だった旨の改訂注記を追加。新規 ADR の起票は無し（ADR-0046 で確定済みの設計を rollback にも適用する修正のため）。
