### PR TITLE
docs: home-manager との配置意味論の差分(manifest 由来の自動移行・安全性)を concept / README へ反映

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -25,7 +25,7 @@ nput は **フェッチ**(Nix 評価：`src` は store パス)と **配置**(固
 - **設定生成をしない。** nput はモジュールオプションを設定ファイルへ翻訳しない。リポジトリにすでにある内容を配置する。
 - **独立した単位。** 各配置 config(`nput.<name>`)はそれ自体が独立した Nix profile。役割ごとに独立して更新・適用でき、ある更新が別へ波及しない。
 - **home-manager 非依存。** `lib/` コアは nixpkgs のみに依存する。standalone で動き、module 統合(home-manager、devShell、将来の NixOS / nix-darwin)はエンジンを *起動するだけ* の薄い配線であって、自身でファイルを配置することはない。
-- **readlink パターンマッチではなく自己記録の manifest。** nput の配置エンジンは前世代の manifest に「自分が何を置いたか」を記録するため、home-manager の `home.file`(2026-07 時点)では原理的に困難な自動移行——例えば per-file 配置がディレクトリ symlink に変わるケース——を安全に行える。詳細は [`docs/concept.md`](docs/concept.md#home-manager-home-file-との配置意味論の差) を参照。
+- **readlink パターンマッチではなく自己記録の manifest。** nput の配置エンジンは前世代の manifest に「自分が何を置いたか」を記録するため、home-manager の `home.file`(2026-07 時点)では原理的に困難な自動移行——例えば per-file 配置がディレクトリ symlink に変わるケース——を安全に行える。詳細は [`docs/concept.md`](docs/concept.md#home-manager-homefile-との配置意味論の差) を参照。
 
 ---
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -25,6 +25,7 @@ nput は **フェッチ**(Nix 評価：`src` は store パス)と **配置**(固
 - **設定生成をしない。** nput はモジュールオプションを設定ファイルへ翻訳しない。リポジトリにすでにある内容を配置する。
 - **独立した単位。** 各配置 config(`nput.<name>`)はそれ自体が独立した Nix profile。役割ごとに独立して更新・適用でき、ある更新が別へ波及しない。
 - **home-manager 非依存。** `lib/` コアは nixpkgs のみに依存する。standalone で動き、module 統合(home-manager、devShell、将来の NixOS / nix-darwin)はエンジンを *起動するだけ* の薄い配線であって、自身でファイルを配置することはない。
+- **readlink パターンマッチではなく自己記録の manifest。** nput の配置エンジンは前世代の manifest に「自分が何を置いたか」を記録するため、home-manager の `home.file`(2026-07 時点)では原理的に困難な自動移行——例えば per-file 配置がディレクトリ symlink に変わるケース——を安全に行える。詳細は [`docs/concept.md`](docs/concept.md#home-manager-home-file-との配置意味論の差) を参照。
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ explicitly:
 - **A self-recorded manifest, not readlink pattern-matching.** nput's placement engine
   tracks what it placed in a manifest from the previous generation, so it can safely
   auto-migrate cases home-manager's `home.file` (as of 2026-07) cannot — e.g. a per-file
-  target becoming a directory symlink. See [`docs/concept.md`](docs/concept.md#home-manager-home-file-との配置意味論の差)
+  target becoming a directory symlink. See [`docs/concept.md`](docs/concept.md#home-manager-homefile-との配置意味論の差)
   for the full comparison.
 
 ---

--- a/README.md
+++ b/README.md
@@ -50,6 +50,11 @@ explicitly:
 - **No home-manager dependency.** The `lib/` core depends only on nixpkgs. It runs
   standalone; module integrations (home-manager, devShell, future NixOS/nix-darwin) are
   thin wiring that only *kick* the engine — they never place files themselves.
+- **A self-recorded manifest, not readlink pattern-matching.** nput's placement engine
+  tracks what it placed in a manifest from the previous generation, so it can safely
+  auto-migrate cases home-manager's `home.file` (as of 2026-07) cannot — e.g. a per-file
+  target becoming a directory symlink. See [`docs/concept.md`](docs/concept.md#home-manager-home-file-との配置意味論の差)
+  for the full comparison.
 
 ---
 

--- a/docs/concept.md
+++ b/docs/concept.md
@@ -18,6 +18,8 @@ home-manager は強力だが、全てを管理対象にすることを前提と�
 - あるツールの更新が別のツールの設定を壊す「共倒れ」が発生しうる
 - 更新のタイミングをツールごとに制御できない
 
+「全体管理」というモデルレベルの問題とは別に、配置エンジンの意味論そのものにも差がある（自己記録の manifest を持つかどうかに起因する所有判定・自動移行・安全性の違い。→「既存ツールとの比較」内「home-manager `home.file` との配置意味論の差」）。
+
 ### モジュール抽象がユーザーから配置の制御を奪う
 
 home-manager / NixOS / nix-darwin / system-manager はいずれも **Nix モジュールシステムで配置を宣言し、
@@ -330,6 +332,17 @@ lib（コア）は何にも依存しない（nixpkgs のみ）
 nput とほぼ同一のツールは存在しない。構成要素（symlink farm / nix profile / out-of-store / 任意パス symlink）は
 すべて既存だが、それらを「取得手段非依存 + 生成しない + エントリ個別適用 + HM 非依存の純粋関数コア +
 クロスプラットフォーム共通スキーマ + 任意パス配置 × 世代管理」として束ねたものは無い。
+
+### home-manager `home.file` との配置意味論の差
+
+home-manager の `home.file`（`files.nix`）と nput はどちらも「symlink を配置し前世代との diff で stale を除去する」という同型のモデルを持つ。しかし nput は配置のたびに**自己記録の manifest**（前世代 `manifest.json`）を持つのに対し、home-manager の cleanup 判定は on-disk の readlink パターンマッチに依存する。この一次情報の有無が、以下の観点で意味論の差として表れる（home-manager の現行実装〔2026-07 時点〕との比較）。
+
+1. **同名 leaf を含む per-file → dir symlink 遷移の自動移行**: `foo/main.sh`（per-file 配置）を `foo`（dir symlink）へ定義変更したとき、home-manager は cleanup の存在判定が新世代の dir symlink を辿って旧 leaf の残存を誤認し、部分適用で失敗しうる。nput は manifest 記録との一致判定（recorded ∧ stale）で安全に自動移行する（→ ADR-0046, ADR-0047）。
+2. **所有判定の厳密さ**: home-manager は readlink の glob パターンマッチ（`*-home-manager-files/*` 相当）で「自分が置いたものか」を判定する。nput は「記録した配置先 + on-disk の readlink が記録 dest と完全一致」で判定する。この厳密さが、実 dir target 配下の recorded ∧ stale leaf を漏れなく検出する自動移行の土台になっている。
+3. **祖先 symlink の安全性**: home-manager は配置先の祖先 component が symlink でも無検査で辿る（`os.MkdirAll` 相当が書込可能な先なら無警告で汚染し、read-only な先なら部分適用停止になりうる）。nput は foreign な祖先 symlink を conflict で停止し、自己記録の stale 祖先symlink のみ配置前除去（PreRemove）で migration する（→ ADR-0046）。
+4. **rename 可用性 + fail-fast drift**: home-manager は cleanup（除去）を配置より先に行うため、rename 相当（旧 target 削除 + 新 target 追加）の適用中にクラッシュすると、新旧どちらのパスにも実体が無い瞬間が生じうる。nput は「配置を塞ぐ依存除去のみ」を前段化し、独立した stale 除去は本流どおり最後に行う（ADR-0006 の「新規・張替を先に、stale 除去を最後に」は不変）。前段化した除去が drift（記録との不一致）を検出した場合は skip せず error で停止し、握りつぶさない（→ ADR-0047）。
+
+home-manager の空 dir 剪定・conflict 全件報告は nput も同等の挙動を持つ（パリティ項目・HM 超えではない）。method 変更（symlink → copy）を跨ぐ自動移行や、copy を含めた `reset` によるロールバックは copy という概念自体が home-manager に存在しないカテゴリであり、比較の対象外である。
 
 特に **system-manager** とは、パッケージ / systemd / `/etc` というドメインこそ重なるが、
 「モジュールで隠す」か「純粋関数でユーザーが握る」かというアプローチが思想レベルで異なるため競合しない。

--- a/docs/concept.md
+++ b/docs/concept.md
@@ -342,7 +342,7 @@ home-manager の `home.file`（`files.nix`）と nput はどちらも「symlink 
 3. **祖先 symlink の安全性**: home-manager は配置先の祖先 component が symlink でも無検査で辿る（`os.MkdirAll` 相当が書込可能な先なら無警告で汚染し、read-only な先なら部分適用停止になりうる）。nput は foreign な祖先 symlink を conflict で停止し、自己記録の stale 祖先symlink のみ配置前除去（PreRemove）で migration する（→ ADR-0046）。
 4. **rename 可用性 + fail-fast drift**: home-manager は cleanup（除去）を配置より先に行うため、rename 相当（旧 target 削除 + 新 target 追加）の適用中にクラッシュすると、新旧どちらのパスにも実体が無い瞬間が生じうる。nput は「配置を塞ぐ依存除去のみ」を前段化し、独立した stale 除去は本流どおり最後に行う（ADR-0006 の「新規・張替を先に、stale 除去を最後に」は不変）。前段化した除去が drift（記録との不一致）を検出した場合は skip せず error で停止し、握りつぶさない（→ ADR-0047）。
 
-home-manager の空 dir 剪定・conflict 全件報告は nput も同等の挙動を持つ（パリティ項目・HM 超えではない）。method 変更（symlink → copy）を跨ぐ自動移行や、copy を含めた `reset` によるロールバックは copy という概念自体が home-manager に存在しないカテゴリであり、比較の対象外である。
+home-manager の空 dir 剪定・conflict 全件報告は nput も同等の挙動を持つ（パリティ項目・HM 超えではない。→ `docs/spec.md`「空親ディレクトリ剪定」「conflict の全件報告」）。method 変更（symlink → copy）を跨ぐ自動移行や、copy を含めた `reset` によるロールバックは copy という概念自体が home-manager に存在しないカテゴリであり、比較の対象外である。
 
 特に **system-manager** とは、パッケージ / systemd / `/etc` というドメインこそ重なるが、
 「モジュールで隠す」か「純粋関数でユーザーが握る」かというアプローチが思想レベルで異なるため競合しない。


### PR DESCRIPTION
## 概要

<!-- なぜ・何を変えるか。Conventional Commits のタイトルだけでは残らない背景を書く。 -->

epic #172(grilling 2026-07-12)で確定した「home.file 意味論パリティ+α」のうち、home-manager を超えている観点を `docs/concept.md` と `README.md` / `README.ja.md` に明文化した。nput の差別化根拠である「manifest という自己記録を持つこと」をコンセプトレベルの一次情報にする。

`docs/concept.md`「既存ツールとの比較」に新セクション「home-manager `home.file` との配置意味論の差」を追加し、以下の4観点を記述した(いずれも #175 マージ済みの ADR-0046 / ADR-0047 の実装が裏付け)。

1. 同名 leaf を含む per-file → dir symlink 遷移の自動移行
2. 所有判定の厳密さ(readlink の glob マッチ vs 記録 dest との完全一致)
3. 祖先 symlink の安全性(foreign は停止・自己記録 stale のみ migration)
4. rename 可用性 + fail-fast drift(依存除去のみ前段化・drift は握りつぶさず error 停止)

空 dir 剪定(#174)・conflict 全件報告(#176)は home-manager と同等の「パリティ項目」であり HM 超えではないため、本文中で明確に区別した。README(英日)には概要 bullet を 1 つずつ追加し、詳細は concept.md へ誘導する形にした。

## 関連 issue

<!-- 例: Closes #N / Refs #N。なければ「なし」。 -->

Closes #177
Refs #172

## docs / ADR 影響

<!--
このリポジトリはドキュメント主導。配置動作・API・方針に触れる変更は docs の更新がセットになる。
- concept / design / spec の更新有無
- 方針転換や trade-off を伴うなら ADR を追加したか（docs/adr/）
影響がなければ「なし」と明記する。
-->

- `docs/concept.md` / `README.md` / `README.ja.md` を更新(本 PR の本体)。
- 新規 ADR は無し。既存の ADR-0006 / ADR-0046 / ADR-0047 と `docs/spec.md` の記述を一次情報として引用しているのみで、方針転換は含まない。
- `docs/spec.md` 自体の変更は無し(#175 で反映済み)。
