### PR TITLE
feat(engine): apply/rollback 途中失敗時のインメモリ undo ジャーナルを実装

### DIFF
--- a/docs/adr/0044-undo-journal-for-partial-apply-failure.md
+++ b/docs/adr/0044-undo-journal-for-partial-apply-failure.md
@@ -1,0 +1,88 @@
+# ADR-0044: apply 途中失敗の完全巻き戻し — インメモリ undo ジャーナル
+
+- ステータス: 採用
+- 日付: 2026-07-12
+- 関連: ADR-0002, ADR-0006, ADR-0015, ADR-0017, ADR-0020, ADR-0031, ADR-0046, ADR-0047, `docs/spec.md`, GitHub Issue #168, #172
+- 改訂対象: **ADR-0046 §5**「#168 に hard 依存させず本 ADR 単独で出荷する」/ **ADR-0047 影響節**「#168（undo ジャーナル）は本 ADR の Unlink/Rmdir 両方を undo 対象に含める前提で設計する」を実装として満たす。両 ADR の PreRemove（祖先 symlink・実 dir target・method 変更）の意味論自体は不変。
+- 起点: 旧 epic #167 から統合された epic #172 の grilling セッション（2026-07-11・2026-07-12）で確定
+
+## 背景
+
+現状、apply が途中で失敗すると世代は未コミットのまま（`nix-env --set` に到達しない）だが、**FS には部分的な配置が残る**。ADR-0006 は「積まれる世代は常に完全適用済み」を保証するが、これは「未コミット世代の内容を信じない」という世代側の保証であり、FS 上の部分状態そのものは復元されない。
+
+これが実運用で問題になる 2 点:
+
+1. **失敗 run が新規に置いた symlink / copy は前世代 manifest に記録が無い**。次の apply は前世代 manifest との diff で stale 除去するため、失敗 run が置いた「今の新世代にも無いはずの」ゴミを拾えない。
+2. **初回 apply（`prev == nil`）が途中失敗すると `reset` が完全 no-op になる**。`reset` は entries 定義から対象を決めるため巻き戻しには使えず、entries に無い旧世代の残骸は永久に残る。
+
+「失敗した apply は FS に痕跡を残さない」を apply の意味論として明文化し、途中失敗時に **その run が行った FS 変更を全て巻き戻し、pre-apply 状態へ復元する** ことを常時有効（フラグなし）の既定動作にする。
+
+## 決定
+
+### 1. インメモリ undo ジャーナル: 各 FS 変更を旧状態付きで記録し、逆順 unwind する
+
+`applier`（`internal/engine/engine.go`）に journal フィールドを追加する。PreRemove → place → materializeCopies（copy 部）→ removeStale の各実行段が FS へ 1 回書き込むたびに、その逆操作を journal へ 1 件 push する。いずれかの段でエラーが発生したら、**その時点までに push された journal を逆順（LIFO）に unwind** し、pre-apply 状態へ戻してからエラーを返す。
+
+対象と逆操作の対応（issue #168 の設計どおり）:
+
+| 順操作 | 逆操作 |
+|---|---|
+| 新規配置 symlink / copy | 削除 |
+| 張替え（`PlaceReplace` / `PlaceForeign`。unlink 前に readlink で旧リンク先を捕捉） | 旧リンク先で symlink を再作成 |
+| stale 除去したリンク（`removeStale`） | 前世代 manifest の記録 dest で symlink を再作成 |
+| `--recopy` の上書き（`recopyAll`） | 同一親ディレクトリ内の一時名へ rename 退避 → 成功で退避物削除 / 失敗（後続 unwind 含む）で rename back |
+| PreRemove の Unlink（祖先 symlink・実 dir 配下 leaf・method 変更 symlink → ADR-0046, ADR-0047） | 記録 dest で symlink を再作成 |
+| PreRemove の Rmdir（空 dir 除去 → ADR-0047） | `os.Mkdir` で再作成 |
+
+journal のエントリは「何を」「どこへ」だけで逆操作が定まる十分な情報（対象パス・旧リンク先・一時退避パスなど）を持つ。unwind は journal スライスの末尾から先頭へ辿ることで、生成順と厳密に逆の順序で実行される（例: PreRemove で消した祖先 symlink の下に子を新規配置していた場合、子の削除 → 祖先の再作成、という正しい順序になる）。
+
+### 2. unwind の発火範囲は PreRemove〜removeStale（+ 世代スキップの repairDrift）。commit 成功後は対象外
+
+journal を破棄せず持ち越すのは **FS 変更を行う 4 段 + 世代スキップの drift 修復**、つまり `preRemove` / `place` / `materializeCopies`（`placeCopies` / `recopyAll`）/ `removeStale` / `repairDrift` の呼び出し中に発生したエラーに限る。これらのいずれかが `error` を返したら、その `Apply` / `Rollback` 呼び出しは即座に unwind してから元エラーを返す。
+
+`nix-env --set`（commit）が成功した後は journal を破棄する。commit 成功は「この run の FS 変更が正式に新世代として確定した」ことを意味し、以後 FS を戻すのは巻き戻しではなく別世代への変更になるため、undo ジャーナルの責務ではない（rollback コマンドが担う領域）。commit 自体が失敗するケース（`--set` が失敗する）は対象外とする: この時点で FS 側の変更は全て成功済みであり、戻すべき理由がない。世代が進んでいないだけで、ADR-0006/0017 の冪等再実行で収束する既存の意味論のままでよい。
+
+### 3. undo 自体の失敗は best-effort 続行。失敗項目は元エラーと共に全報告
+
+unwind の実行中、個々の逆操作が失敗しても（例: 再作成しようとした親ディレクトリが別プロセスに消された）unwind 全体を中断しない。失敗した逆操作はスキップし、残りの journal エントリの unwind を続行する。すべての unwind 試行が終わった時点で、**元の apply エラー**と**巻き戻せなかった項目の一覧**を両方 stderr に全報告し、exit 1 で停止する。
+
+これは `reportConflicts`（→ ADR-0047 D6、grilling 2026-07-12）と同じ「1 回の実行で全件を可視化する」姿勢を踏襲する。ユーザーは未復元項目を手動で確認・修復できる。
+
+### 4. クラッシュ（SIGKILL・電源断）は対象外。永続 WAL は持たない
+
+undo ジャーナルはプロセスのメモリ上にのみ存在する。プロセスが `error` を返せずに終了する（SIGKILL・電源断・panic 未回収）ケースは、ジャーナルも失われて何も巻き戻せない。これは意図的なスコープ外である。
+
+- **エラー return 時の巻き戻し**（本 ADR の対象）と**クラッシュ耐性**（対象外）は異なる保証である。前者は「apply が失敗したと自分で報告できたケース全て」を完全に FS 未変更へ戻す。後者は永続 WAL・fsync 規律・クラッシュリカバリ手順を要し、コストに対して既存のバックストップ（ADR-0006 の「世代未コミット」+ ADR-0017 の「冪等再実行で FS が収束する」）で十分に運用できている。
+- 本 ADR 後も、クラッシュ時は変わらず「世代未コミット + 冪等再実行で最終的に正しい状態へ収束する」が保証全体を担う。undo ジャーナルはその上に「プロセスが生きている間の失敗は即座に完全復元する」という追加の品質を積む。
+
+### 5. PreRemove の Unlink/Rmdir も undo 対象に含める（一般化後の段構成に対応）
+
+ADR-0046 §5・ADR-0047 影響節が seam として残した「PreRemove を undo 対象に含める」を実装する。ADR-0047 で一般化された PreRemove は 1 バッチ内に複数の `RemoveUnlink`（子から）と `RemoveRmdir`（深い方から）を bottom-up 順で実行するため、journal もその実行順のまま記録し、unwind は当然その逆順（親の Rmdir を先に取り消して mkdir → 子の Unlink を取り消して symlink 再作成、という浅い方から深い方への順）になる。これは `classifyDirMigration` が返す実行順と、journal の LIFO 特性が自然に噛み合う（PreRemove 内の順序自体を undo 側で並べ替える必要はない）。
+
+`repairDrift`（世代スキップ経路）は ADR-0046/0047 の不変条件により PreRemove を構造的に受け取らない（`len(plan.PreRemove) > 0` は internal invariant violation として fail closed）。したがって drift 修復側で journal に積まれるのは `place` の再張り分のみであり、本 ADR はこの経路にも同じ journal/unwind 機構をそのまま適用する（専用分岐は増やさない）。
+
+## 根拠
+
+- **メモリ内 journal + 逆順 unwind** は、既に FS へ書き込んだ順操作の情報（旧リンク先・退避パス）を実行時に持っているため、追加の永続化コストなしに実装できる。プロセス生存中の失敗は 100% カバーし、クラッシュは既存のバックストップに委ねる、という線引きが ADR-0006/0017 の既存不変条件と整合する。
+- **commit 成功後は対象外**とするのは、「apply の途中失敗」と「コミット済み世代からの巻き戻し」を混同しないため。後者は `rollback` の責務であり、undo ジャーナルが世代境界を越えて FS を戻す機能を持つと、両者の意味論が曖昧になる。
+- **best-effort 続行 + 全件報告**は、1 個の unwind 失敗で残りの巻き戻しを止めると被害が拡大するため。個々の unwind 失敗は「巻き戻せなかった 1 項目」に閉じ込め、残りは正常に戻す方が pre-apply 状態に近づく。
+- **PreRemove を undo 対象に含める**のは、ADR-0046/0047 が一般化した除去（祖先 symlink・実 dir 配下 leaf・method 変更）も他の FS 変更と同じく「apply 中に行った変更」であり、undo ジャーナルの対象から除外する理由が無いため。除外すると、PreRemove を経由する移行（dotfiles でよく起きるレイアウト変更）だけ巻き戻しの粒度が粗いという非対称が生まれる。
+
+## 影響
+
+- **`internal/engine/engine.go`**: `applier` に journal フィールドを追加。`Apply` の 8. 節（PreRemove → place → materializeCopies → removeStale）と `repairDrift` 呼び出しをジャーナル対象としてラップし、エラー時に unwind してから return する。
+- **`internal/engine/place.go`**: `place` の各 symlink 作成・張替え直後に journal へ push。
+- **`internal/engine/copy.go`**: `placeCopies` の新規コピー、`recopyAll` の rename 退避/上書きを journal 化する（rename 退避は成功時に退避物削除、失敗時に rename back の往復操作として記録）。
+- **`internal/engine/staleremove.go`**: `removeStale` の unlink、`preRemove` の Unlink/Rmdir を journal 化する。
+- **`internal/engine/generations.go`**: `Rollback` も同じ journal/unwind 機構を通す（Rollback は独自に `preRemove` / `place` / `removeStale` を呼ぶため、Apply と同じラップを適用する）。
+- **`docs/spec.md`**: 実行フロー・エラー仕様表・張替え意味論に「途中失敗時は全巻き戻し」を追記する。
+- **`docs/adr/0046-*.md`**: §5 の「#168 に hard 依存させず出荷する」への改訂注記（本 ADR による実装完了の back-reference）。
+- **`docs/adr/0047-*.md`**: 影響節の「#168（undo ジャーナル）は…前提で設計する」への改訂注記（同上）。
+- **cross-epic**: #169（`--backup`）は本 ADR に完全直列 stack。`--backup` の退避操作も journal 化対象になる（別 PR）。
+
+## 棄却した代替案
+
+- **永続 WAL（ディスク上の undo ログ）**: クラッシュ耐性まで含めて保証できるが、fsync 規律・リカバリ手順・WAL 自体の破損時フォールバックが要り、実装・保守コストが「apply 途中失敗を完全に戻す」という目的に対して過大。ADR-0006/0017 の既存バックストップ（冪等再実行での収束）で電源断ケースは十分にカバーされている。
+- **rename ベースの atomic スナップショット（apply 前に対象ツリー全体を退避）**: target ごとに一時コピーを作る必要があり、大きなツリーではコストが跳ねる。undo ジャーナルは「変更した分だけ」逆操作を記録するため、変更量に比例したコストで済む。
+- **unwind 失敗時に即中断**: 1 個の失敗で残りの巻き戻しを諦めると、まだ戻せたはずの項目まで未復元のまま放置される。best-effort 続行の方が pre-apply 状態への近さを最大化する。
+- **PreRemove を undo 対象外にする（ADR-0046/0047 の移行は冪等再実行の収束のみに委ねる）**: ADR-0046 §5 が容認した選択だが、本 ADR で undo ジャーナルを実装する以上、PreRemove だけ例外的に粗い保証のままにする理由がない。一般化する方が意味論として一貫する。

--- a/docs/adr/0044-undo-journal-for-partial-apply-failure.md
+++ b/docs/adr/0044-undo-journal-for-partial-apply-failure.md
@@ -36,6 +36,8 @@
 
 journal のエントリは「何を」「どこへ」だけで逆操作が定まる十分な情報（対象パス・旧リンク先・一時退避パスなど）を持つ。unwind は journal スライスの末尾から先頭へ辿ることで、生成順と厳密に逆の順序で実行される（例: PreRemove で消した祖先 symlink の下に子を新規配置していた場合、子の削除 → 祖先の再作成、という正しい順序になる）。
 
+**スコープ外**: `ensureParentDir`（配置直前の `mkdir -p` 相当）が新規作成する中間ディレクトリは journal 化しない。unwind が leaf（symlink / copy）を削除すれば、その target は呼び出し側から見て「不在」に戻り、残る空の中間ディレクトリは非 rollback run が残す通常の mkdir -p 残骸（例: 次世代で entry が config から消えたケース）と区別がつかない cosmetic な取りこぼしに過ぎない。既存の `pruneEmptyAncestors`（Issue #174）が次回の除去・apply で回収する対象であり、undo ジャーナルの責務ではない。複数 leaf が同じ新規親ディレクトリを共有するケースの dedup を journal 側に持ち込むコストに対し、データ損失リスクがゼロであることを踏まえた判断。
+
 ### 2. unwind の発火範囲は PreRemove〜removeStale（+ 世代スキップの repairDrift）。commit 成功後は対象外
 
 journal を破棄せず持ち越すのは **FS 変更を行う 4 段 + 世代スキップの drift 修復**、つまり `preRemove` / `place` / `materializeCopies`（`placeCopies` / `recopyAll`）/ `removeStale` / `repairDrift` の呼び出し中に発生したエラーに限る。これらのいずれかが `error` を返したら、その `Apply` / `Rollback` 呼び出しは即座に unwind してから元エラーを返す。

--- a/docs/adr/0046-self-recorded-ancestor-nest-migration.md
+++ b/docs/adr/0046-self-recorded-ancestor-nest-migration.md
@@ -19,6 +19,12 @@
 > method 変更 symlink→copy も migration 対象になった（copy→symlink は非対称に conflict のまま）。`Plan.PreRemove` の
 > 要素は `RemoveAction{Kind, Entry, TargetAbs}` に拡張され、`Kind = RemoveRmdir` は `Entry` を持たない空 dir 除去を表す。
 > drift 時に skip せず error 停止する意味論（§3）は一般化後の全 PreRemove 発生源に共通して適用される（→ ADR-0047）。
+>
+> **2026-07-12 改訂注記（ADR-0044）**: 本 ADR §5 が「#168 に hard 依存させず本 ADR 単独で出荷する」とし、undo ジャー
+> ナルを PreRemove の seam としてのみ残していた点は、#168（ADR-0044）で実装が完了した。apply / Rollback が PreRemove
+> の Unlink（祖先 symlink 除去）を実行した後に途中失敗すると、その Unlink はインメモリ undo ジャーナルにより自動で
+> 巻き戻される（記録 dest で symlink を再作成）。§5 の「#168 マージ後は中間失敗が atomic に巻き戻る」という記述が
+> そのまま実現された形であり、§3 の drift 時 error 停止・§1〜§4 の緩和条件自体は不変（→ ADR-0044）。
 
 ## 背景
 

--- a/docs/adr/0047-preremove-generalization.md
+++ b/docs/adr/0047-preremove-generalization.md
@@ -86,6 +86,12 @@ ADR-0046 §3 で導入した「PreRemove は最終段の removeStale と違い�
 - **`docs/spec.md`**: 配置動作仕様（実 dir target の migration・method 変更）・エラー仕様表・実行フローへ反映。
 - **cross-epic**: #173（Rollback への PreRemove 配線）は本 ADR の一般化 executor（`preRemove`）をそのまま利用できる設計にしてある。マージ順による rebase 調整は後工程。#176（conflict 全件報告）はスコープ外のまま。#168（undo ジャーナル）は本 ADR の Unlink/Rmdir 両方を undo 対象に含める前提で設計する。
 
+> **2026-07-12 改訂注記（ADR-0044）**: 本 ADR が影響節で予告した「#168（undo ジャーナル）は本 ADR の Unlink/Rmdir
+> 両方を undo 対象に含める前提で設計する」は #168（ADR-0044）で実装された。PreRemove の `RemoveUnlink`（記録
+> symlink 除去）・`RemoveRmdir`（空 dir 除去）はいずれも apply / Rollback 途中失敗時にインメモリ undo ジャーナルで
+> 自動巻き戻しされる（Unlink → 記録 dest で symlink 再作成・Rmdir → `os.Mkdir` で再作成）。本 ADR の migration 判定
+> 条件（D1〜D5）・drift 時 error 停止（D3）自体は不変（→ ADR-0044）。
+
 ## 棄却した代替案
 
 - **全面反転（home-manager 型の remove→place の完全対称・2 段化）**: 依存除去のみ前段化する現行方式（ADR-0006 の本流順序は不変）ではなく、独立 stale 除去まで含めて全面的に「先に全部消してから全部置く」設計にすると、rename（target A 削除 + B 追加）のような独立除去まで前段化することになる。除去後・配置前でクラッシュすると新旧どちらのパスにも実体が無い瞬間が生じる（home-manager はこれを受容しているが、nput は成功時の挙動を home-manager と同一に保ちながらクラッシュ耐性は上位互換にしたい）。依存除去のみ前段化すれば、この窓は開かない。

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -334,6 +334,8 @@ nput apply <name> [-f <ep>] [--root <p>]
         ドリフトした entry だけ再張りする（完全 no-op にしない・→ ADR-0017）
      e. manifest.json を新旧 diff → 配置を塞ぐ自己記録 stale（祖先 symlink・実 dir target・method 変更）を配置前除去
         （PreRemove・migration・→ ADR-0046, ADR-0047）→ 新規/張替を配置 → 保守的 stale 除去（ネイティブ FS）
+        ※ e の 4 段（PreRemove / 配置 / copy 反映 / stale 除去）のいずれかが途中失敗すると、この run が行った
+           FS 変更を全てインメモリ undo ジャーナルで巻き戻し pre-apply 状態へ戻す（→ ADR-0044, 後述「途中失敗時の巻き戻し」）
      f. nix-env --profile <profileDir>/profile --set <link-farm>（サブプロセス・コミット点）
      g. --set 成功後に <profileDir>/.pending を削除（世代リンクが gcroot を引き継ぐ・→ ADR-0011）
 ```
@@ -589,11 +591,34 @@ engine が**ネイティブ FS 操作**で行う（`ln` / `rsync` は使わな�
    - out-of-store:      配置元 = marker の絶対パス
 ```
 
-- 既存 symlink の張替えは **unlink + symlink の 2 操作**で行う（rename ベースの atomic swap は採らない）。間でクラッシュすると target が一時消失しうるが、**冪等な再実行で収束**する（ADR-0006「積まれる世代は常に完全適用済み」と整合・→ ADR-0017）。
+- 既存 symlink の張替えは **unlink + symlink の 2 操作**で行う（rename ベースの atomic swap は採らない）。間でクラッシュすると target が一時消失しうるが、**冪等な再実行で収束**する（ADR-0006「積まれる世代は常に完全適用済み」と整合・→ ADR-0017）。クラッシュ（SIGKILL・電源断）以外でこの run 自身が後続の段でエラーを検知した場合は、unlink 前の張替え先を undo ジャーナルが記録しており re-symlink で復元する（→ ADR-0044）。
 - target に通常ファイルまたはディレクトリが存在する場合はエラーで停止（上書きしない）。ただし実 dir は §0.5 の条件を満たせば例外的に PreRemove で除去して配置する（→ ADR-0047）
 - subpath がファイル・ディレクトリどちらでも同じ処理
 - 別 config（別 profile）が同一 target を狙うのは基本「衝突させない前提」。後勝ちを許容しつつ foreign symlink 上書きは warning で可視化する（→ ADR-0015）
 - method 変更 copy→symlink は自動移行しない（ユーザー編集済み copy データの保護を優先し、従来通り conflict のまま・→ ADR-0047 D5）
+
+### 途中失敗時の巻き戻し（インメモリ undo ジャーナル・→ ADR-0044）
+
+apply / rollback が PreRemove・配置（symlink / copy）・stale 除去のいずれかの段で途中失敗すると、その run が行った FS 変更を**全て**巻き戻し、pre-apply 状態へ復元する（「失敗した apply は FS に痕跡を残さない」）。フラグなし・常時有効。
+
+```
+各段（PreRemove / place / copy 反映 / stale 除去）の FS 書き込みごとに、インメモリの undo ジャーナルへ逆操作を 1 件記録する:
+  新規配置 symlink / copy         → 削除
+  張替え（unlink 前に旧リンク先を捕捉）→ 旧リンク先で symlink を再作成
+  stale 除去したリンク            → 前世代 manifest の記録 dest で symlink を再作成
+  PreRemove の Unlink             → 記録 dest で symlink を再作成
+  PreRemove の Rmdir              → 空 dir を再作成
+  --recopy の rename 退避         → 退避物を rename back（成功時は退避物を削除）
+
+いずれかの段でエラーが発生したら、それまでに記録したジャーナルを逆順（LIFO）で巻き戻してからエラーを返す。
+nix-env --set（コミット）が成功した後はジャーナルを破棄する（--set 自体の失敗は巻き戻し対象外・冪等再実行で収束）。
+```
+
+- **巻き戻し自体の失敗は best-effort 続行**: 個々の逆操作が失敗してもジャーナルの残りの巻き戻しは続行する。全ての巻き戻し試行が終わった時点で、元の apply エラーと巻き戻せなかった項目の一覧を stderr へ全報告して停止する（`reportConflicts` と同じ「全件列挙してから 1 本の集約エラー」の形）。
+- **報告は常時 stderr**（失敗経路のため沈黙対象外・既定 silent の対象にしない・→ ADR-0031）。
+- **クラッシュ（SIGKILL・電源断）は対象外**。undo ジャーナルはプロセスメモリ上にのみ存在し、永続 WAL は持たない。この場合は変わらず「世代未コミット + 冪等再実行で収束」（ADR-0006, ADR-0017）が保証を担う。
+- 世代スキップ経路の drift 修復（repairDrift）も同じ機構で巻き戻される。ただし ADR-0046/0047 の不変条件により、この経路が PreRemove を受け取ることは構造的に無い。
+- `rollback` も apply と同じ機構（PreRemove → place → stale 除去）で途中失敗時に巻き戻す。プロファイルポインタ移動（`--switch-generation`）はこの時点で全 FS 変更が成功済みのため巻き戻し対象外。
 
 ### copy モード（place-once・ユーザー管理）
 
@@ -627,12 +652,15 @@ place-once（copy は触らない）と保守的 stale 除去（copy は消さ�
 
 ```
 config 内の各 copy entry について:
-  target が存在 → 削除してから <src>/<subpath> を再コピー（mode 保存 + owner-write 付与・symlink 複製は通常 copy と同じ）
+  target が存在 → 同一親ディレクトリ内の一時名へ rename 退避してから <src>/<subpath> を再コピー
+                  （mode 保存 + owner-write 付与・symlink 複製は通常 copy と同じ）。この apply run が
+                  最終的に成功すれば退避物を削除、途中失敗して巻き戻すときは rename back（→ ADR-0044）
   target が不在 → 通常の place-once コピー
 ```
 
 - 全 copy entry を**無条件**に上書き（差分判定なし）。ローカル編集は破棄され src 内容に戻る。上書き target をレポート表示。
 - symlink 部の通常 apply（stale 除去 + 世代コミット）は同時に行う。copy は世代外のまま（世代を増やさない）。
+- 上書きは削除ではなく**rename 退避**で行う（rename はメタデータ操作のみで ENOSPC 下でも退避物が壊れない・→ ADR-0044）。同一 apply run 内で後続の段が失敗した場合、退避物から元の内容が復元される（後述「途中失敗時の巻き戻し」）。
 
 **reset（`nput reset <name> [target...]`）** — 配置物を無い状態へ戻す FS-only teardown。
 
@@ -966,6 +994,8 @@ devShells.default = pkgs.mkShell {
 | 同一 `target` で method が symlink→copy に変更、前世代が記録した symlink で on-disk が記録通り | 配置前に除去（PreRemove）し copy を新規配置（silent・`-v` で可視・readlink drift 時は通常の foreign 判定へフォールバック・→ ADR-0047 D5）|
 | 同一 `target` で method が copy→symlink に変更 | 自動移行しない。エラーで停止（`target` に既存ファイルとして扱う・`--backup` が脱出ハッチ・→ ADR-0047 D5）|
 | PreRemove 対象（祖先 symlink / 実 dir 配下 leaf・dir / method 変更 symlink）が計画後に drift（記録不一致・ENOTEMPTY 等）| skip せずエラーで停止（冪等再実行で収束・→ ADR-0046 §3, ADR-0047 D3）|
+| apply / rollback が PreRemove・配置・stale 除去のいずれかの段で途中失敗（`--set` 到達前）| この run が行った FS 変更を全てインメモリ undo ジャーナルで巻き戻し pre-apply 状態へ復元してから停止（exit 1・フラグなし常時有効・→ ADR-0044, 前述「途中失敗時の巻き戻し」）|
+| 巻き戻し（undo）自体が一部失敗（対象が既に他プロセスに変更された等）| 失敗項目はスキップして残りの巻き戻しを続行（best-effort）。元の apply エラー + 未復元項目一覧を stderr に全報告して停止（→ ADR-0044）|
 | `subpath` がディレクトリのとき `target` に通常ファイルが既存（copy モード）| conflict。全件を stderr へ列挙して停止（→ 後述「conflict の全件報告」）|
 | `subpath` がファイルのとき `target` がディレクトリとして既存（copy モード）| conflict。全件を stderr へ列挙して停止（→ 後述「conflict の全件報告」）|
 | copy モードで `target` が既存（前世代 manifest に entry あり = nput 配置済み）| place-once により何もしない（上書きしない）。`apply --recopy` 時のみ無条件上書き（→ ADR-0020）|

--- a/internal/engine/copy.go
+++ b/internal/engine/copy.go
@@ -35,15 +35,19 @@ func (a *applier) placeCopies(actions []planner.CopyAction) error {
 			return fmt.Errorf("nput: copy placement failed (%s -> %s): %w", act.Src, act.TargetAbs, err)
 		}
 		a.result.Copied = append(a.result.Copied, act.Entry.Target)
+		a.journalPlacedCopy(act.TargetAbs)
 	}
 	return nil
 }
 
 // recopyAll is the copy overwrite path of apply --recopy (→ ADR-0020, docs/spec.md "recopy").
-// For every copy entry in the config, if the target exists it is removed and then
-// re-copied unconditionally (no diff check · local edits are discarded). It does not use
-// the place-once classification (planner.Copies) but scans the manifest directly; ancestor
-// symlinks / structural mismatches are already rejected by the planner's conflict gate before apply.
+// For every copy entry in the config, if the target exists it is renamed aside within the same
+// parent directory (a metadata-only operation that survives ENOSPC · → ADR-0044) and then
+// re-copied unconditionally (no diff check · local edits are discarded); the aside copy is
+// removed once the fresh copy lands, or renamed back if anything after it in this Apply fails and
+// the journal is unwound. It does not use the place-once classification (planner.Copies) but
+// scans the manifest directly; ancestor symlinks / structural mismatches are already rejected by
+// the planner's conflict gate before apply.
 func (a *applier) recopyAll() error {
 	for _, e := range a.manifest.Entries {
 		if e.Method != manifest.MethodCopy {
@@ -51,10 +55,12 @@ func (a *applier) recopyAll() error {
 		}
 		targetAbs := filepath.Join(a.root, filepath.Clean(e.Target))
 		existed := false
+		aside := ""
 		if _, err := os.Lstat(targetAbs); err == nil {
 			existed = true
-			if err := os.RemoveAll(targetAbs); err != nil {
-				return fmt.Errorf("nput: cannot remove recopy target (%s): %w", targetAbs, err)
+			aside = asidePath(targetAbs)
+			if err := os.Rename(targetAbs, aside); err != nil {
+				return fmt.Errorf("nput: cannot move aside recopy target (%s): %w", targetAbs, err)
 			}
 		} else if !os.IsNotExist(err) {
 			return fmt.Errorf("nput: cannot lstat recopy target (%s): %w", targetAbs, err)
@@ -68,11 +74,21 @@ func (a *applier) recopyAll() error {
 		}
 		if existed {
 			a.result.Recopied = append(a.result.Recopied, e.Target)
+			a.journalRenamedAside(targetAbs, aside)
 		} else {
 			a.result.Copied = append(a.result.Copied, e.Target)
+			a.journalPlacedCopy(targetAbs)
 		}
 	}
 	return nil
+}
+
+// asidePath returns a same-parent-directory temporary name for targetAbs, used by recopyAll to
+// move an existing copy target aside before overwriting it (→ ADR-0044 §1). Renaming within the
+// same directory is a metadata-only operation that cannot fail partway under ENOSPC, unlike a
+// remove-then-recopy that would lose the pre-overwrite content if the recopy itself then failed.
+func asidePath(targetAbs string) string {
+	return targetAbs + ".nput-recopy-aside"
 }
 
 // copyTree natively copies src (file / directory / symlink) to dst

--- a/internal/engine/copy.go
+++ b/internal/engine/copy.go
@@ -31,11 +31,15 @@ func (a *applier) placeCopies(actions []planner.CopyAction) error {
 		if err := ensureParentDir(act.TargetAbs); err != nil {
 			return err
 		}
+		// Journaled before copyTree, not after: copyTree can write a partial tree (e.g. some
+		// files copied before a later one fails), and os.RemoveAll tolerates a fully- or
+		// partially-absent target, so recording the undo up front means a mid-copy failure still
+		// gets its partial tree cleaned up on unwind instead of leaving debris (→ ADR-0044).
+		a.journalPlacedCopy(act.TargetAbs)
 		if err := copyTree(act.Src, act.TargetAbs); err != nil {
 			return fmt.Errorf("nput: copy placement failed (%s -> %s): %w", act.Src, act.TargetAbs, err)
 		}
 		a.result.Copied = append(a.result.Copied, act.Entry.Target)
-		a.journalPlacedCopy(act.TargetAbs)
 	}
 	return nil
 }
@@ -55,15 +59,23 @@ func (a *applier) recopyAll() error {
 		}
 		targetAbs := filepath.Join(a.root, filepath.Clean(e.Target))
 		existed := false
-		aside := ""
 		if _, err := os.Lstat(targetAbs); err == nil {
 			existed = true
-			aside = asidePath(targetAbs)
+			aside := asidePath(targetAbs)
 			if err := os.Rename(targetAbs, aside); err != nil {
 				return fmt.Errorf("nput: cannot move aside recopy target (%s): %w", targetAbs, err)
 			}
+			// Journaled immediately after the rename-aside, before the fresh copy: if copyTree
+			// below fails partway, undoRestoreRename's os.RemoveAll tolerates a partial/absent
+			// target and still renames the aside back, restoring the pre-apply content instead of
+			// leaving it stranded under the aside name (→ ADR-0044).
+			a.journalRenamedAside(targetAbs, aside)
 		} else if !os.IsNotExist(err) {
 			return fmt.Errorf("nput: cannot lstat recopy target (%s): %w", targetAbs, err)
+		} else {
+			// Same reasoning as placeCopies: journal before copyTree so a mid-copy failure still
+			// gets its partial tree cleaned up on unwind (→ ADR-0044).
+			a.journalPlacedCopy(targetAbs)
 		}
 
 		if err := ensureParentDir(targetAbs); err != nil {
@@ -74,10 +86,8 @@ func (a *applier) recopyAll() error {
 		}
 		if existed {
 			a.result.Recopied = append(a.result.Recopied, e.Target)
-			a.journalRenamedAside(targetAbs, aside)
 		} else {
 			a.result.Copied = append(a.result.Copied, e.Target)
-			a.journalPlacedCopy(targetAbs)
 		}
 	}
 	return nil

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -224,9 +224,13 @@ func Apply(opts Options) (*Result, error) {
 			// When the previous generation's link-farm cannot be resolved, fall back to the safe side: normal apply (commit a new generation).
 			a.opts.Warnf("nput: could not resolve the previous generation's link-farm; recommitting without a generation skip: %v", err)
 		} else if same {
-			if err := a.repairDrift(plan, opts.Recopy); err != nil {
+			// The drift repair's re-links are journaled the same as normal placement (→ ADR-0044); this
+			// path commits no generation, so there is no commit success to discard the journal on —
+			// discard immediately once the repair itself succeeds (nothing here to roll back further).
+			if err := a.runJournaled(func() error { return a.repairDrift(plan, opts.Recopy) }); err != nil {
 				return nil, err
 			}
+			a.discardJournal()
 			a.result.GenerationSkipped = true
 			a.cleanupPending()
 			return a.result, nil
@@ -239,20 +243,25 @@ func Apply(opts Options) (*Result, error) {
 	//    lands on an empty/absent target · local exception to ADR-0006 · → ADR-0046, ADR-0047),
 	//    then new / re-link, then stale removal last (→ ADR-0006). copy branches: on --recopy overwrite
 	//    all copy targets unconditionally, normally place-once (new copy only when target is absent) (→ ADR-0020).
-	if err := a.preRemove(plan.PreRemove); err != nil {
+	//    Each stage journals its own FS writes; a failure in any of the four unwinds everything this
+	//    run has done so far (across all four, not just the failing stage) before returning (→ ADR-0044).
+	if err := a.runJournaled(func() error { return a.preRemove(plan.PreRemove) }); err != nil {
 		return nil, err
 	}
-	if err := a.place(plan.Place); err != nil {
+	if err := a.runJournaled(func() error { return a.place(plan.Place) }); err != nil {
 		return nil, err
 	}
-	if err := a.materializeCopies(plan, opts.Recopy); err != nil {
+	if err := a.runJournaled(func() error { return a.materializeCopies(plan, opts.Recopy) }); err != nil {
 		return nil, err
 	}
-	if err := a.removeStale(plan.Remove); err != nil {
+	if err := a.runJournaled(func() error { return a.removeStale(plan.Remove) }); err != nil {
 		return nil, err
 	}
 
-	// 9. generation commit (→ docs/spec.md execution flow 2f).
+	// 9. generation commit (→ docs/spec.md execution flow 2f). A commit failure is NOT unwound: every
+	//    FS write up to this point already succeeded, so there is nothing wrong to roll back — the run
+	//    simply fails to advance the generation, and idempotent re-apply converges (→ ADR-0006, ADR-0017,
+	//    ADR-0044 §2).
 	commit := opts.Commit
 	if commit == nil {
 		commit = nixEnvCommit
@@ -260,6 +269,7 @@ func Apply(opts Options) (*Result, error) {
 	if err := commit(a.profile.Profile, a.opts.LinkFarm); err != nil {
 		return nil, fmt.Errorf("nput: generation commit (nix-env --set) failed: %w", err)
 	}
+	a.discardJournal()
 
 	// 10. remove .pending after --set succeeds (the generation link inherits the gcroot · → ADR-0011, ADR-0025).
 	a.cleanupPending()
@@ -284,6 +294,21 @@ type applier struct {
 	profile  paths.Profile
 	root     string
 	result   *Result
+	journal  []undoOp
+}
+
+// runJournaled runs an FS-mutating stage and unwinds the journal recorded so far — by this
+// stage and any earlier ones in the same Apply/Rollback call — if it fails (→ ADR-0044). Stages
+// covered: preRemove, place, materializeCopies, removeStale, repairDrift. A stage succeeding
+// simply leaves its journal entries in place for the next stage (or for the final discard on
+// commit success); nothing here decides when the journal is discarded — that is the caller's
+// job once every stage in the call has succeeded and (for Apply) commit has landed.
+func (a *applier) runJournaled(stage func() error) error {
+	if err := stage(); err != nil {
+		a.unwind(err)
+		return err
+	}
+	return nil
 }
 
 // dryRun is the read-only short-circuit of apply --dryrun (→ ADR-0006, ADR-0023). It resolves

--- a/internal/engine/generations.go
+++ b/internal/engine/generations.go
@@ -182,20 +182,25 @@ func Rollback(opts RollbackOptions) (*RollbackResult, error) {
 	a.profile = prof
 	a.root = root
 	a.emitWarnings(plan.Warnings, false)
-	if err := a.preRemove(plan.PreRemove); err != nil {
+	// Each stage journals its own FS writes; a failure in any of the three unwinds everything
+	// this Rollback call has done so far before returning (→ ADR-0044, same shape as Apply).
+	if err := a.runJournaled(func() error { return a.preRemove(plan.PreRemove) }); err != nil {
 		return nil, err
 	}
-	if err := a.place(plan.Place); err != nil {
+	if err := a.runJournaled(func() error { return a.place(plan.Place) }); err != nil {
 		return nil, err
 	}
-	if err := a.removeStale(plan.Remove); err != nil {
+	if err := a.runJournaled(func() error { return a.removeStale(plan.Remove) }); err != nil {
 		return nil, err
 	}
 
-	// 7. finally move the profile pointer to N-1 (→ docs/spec.md rollback step 3).
+	// 7. finally move the profile pointer to N-1 (→ docs/spec.md rollback step 3). Not unwound on
+	//    failure: every FS write up to this point already succeeded, so there is nothing to roll
+	//    back — only the pointer move itself failed, and re-running Rollback retries it (→ ADR-0044 §2).
 	if err := switchFn(prof.Profile, prev.Number); err != nil {
 		return nil, fmt.Errorf("nput: failed to move the profile pointer (--switch-generation %d): %w", prev.Number, err)
 	}
+	a.discardJournal()
 
 	return &RollbackResult{Result: *a.result, From: cur.Number, To: prev.Number}, nil
 }

--- a/internal/engine/generations_test.go
+++ b/internal/engine/generations_test.go
@@ -139,6 +139,81 @@ func TestRollbackReconverges(t *testing.T) {
 	}
 }
 
+// TestRollbackSwitchGenerationFailureDoesNotUnwind verifies Rollback's own asymmetry, mirroring
+// Apply's commit-failure asymmetry (→ ADR-0044 §2): every FS write (PreRemove/place/removeStale)
+// has already succeeded by the time SwitchGeneration runs, so a failure there is not rolled back —
+// discardJournal is only reached after SwitchGeneration succeeds. Same setup as
+// TestRollbackReconverges, but SwitchGeneration fails.
+func TestRollbackSwitchGenerationFailureDoesNotUnwind(t *testing.T) {
+	root := realTempDir(t)
+	state := realTempDir(t)
+	srcA := makeSrc(t, "x")
+	srcB := makeSrc(t, "x")
+	srcC := makeSrc(t, "x")
+
+	prof := paths.Resolve(state, "vim", manifest.RootKindHome, root, true)
+	if err := os.MkdirAll(prof.Dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	lf1 := writeLinkFarm(t, homeManifest(
+		storeEntry(srcA, ".", "a"),
+		storeEntry(srcB, ".", "b"),
+	))
+	lf2 := writeLinkFarm(t, homeManifest(
+		storeEntry(srcA, ".", "a"),
+		storeEntry(srcC, ".", "c"),
+	))
+
+	if err := os.Symlink(lf1, paths.GenerationLink(prof.Profile, 1)); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(lf2, paths.GenerationLink(prof.Profile, 2)); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(lf2, prof.Profile); err != nil {
+		t.Fatal(err)
+	}
+
+	// Current FS = gen2: place a→srcA, c→srcC.
+	if err := os.Symlink(srcA, filepath.Join(root, "a")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(srcC, filepath.Join(root, "c")); err != nil {
+		t.Fatal(err)
+	}
+
+	var warns []string
+	_, err := Rollback(RollbackOptions{
+		Name:         "vim",
+		RootKind:     manifest.RootKindHome,
+		RootOverride: root,
+		StateDir:     state,
+		ListGenerations: func(string) ([]Generation, error) {
+			return []Generation{{Number: 1}, {Number: 2, Current: true}}, nil
+		},
+		SwitchGeneration: func(string, int) error { return os.ErrPermission },
+		Warnf:            collectFormatted(&warns),
+	})
+	if err == nil {
+		t.Fatal("expected the SwitchGeneration failure to propagate, got nil")
+	}
+
+	// All FS writes already succeeded before SwitchGeneration ran, and must survive untouched:
+	// b was newly placed (re-converged to gen1) and c was stale-removed. Neither is rolled back.
+	if dest, rerr := os.Readlink(filepath.Join(root, "b")); rerr != nil || dest != srcB {
+		t.Errorf("b must survive a SwitchGeneration failure untouched: dest=%q, err=%v, want %q", dest, rerr, srcB)
+	}
+	if _, lerr := os.Lstat(filepath.Join(root, "c")); !os.IsNotExist(lerr) {
+		t.Errorf("c's stale removal must survive a SwitchGeneration failure, lstat err = %v", lerr)
+	}
+	for _, w := range warns {
+		if strings.Contains(w, "rolled back this run's filesystem changes") {
+			t.Errorf("warns = %v, must not report a rollback for a SwitchGeneration-only failure", warns)
+		}
+	}
+}
+
 // TestRollbackAncestorMigration verifies rollback from a whole-tree-ancestor-symlink generation
 // (N, current) back to a per-file generation (N-1): baseline (N) records the ancestor symlink,
 // target (N-1) records the nested children, so the plan carries a PreRemove for the ancestor and

--- a/internal/engine/generations_test.go
+++ b/internal/engine/generations_test.go
@@ -242,6 +242,99 @@ func TestRollbackAncestorMigration(t *testing.T) {
 	}
 }
 
+// TestRollbackMidBatchFailureRollsBackPreRemoveMigration verifies Rollback's own undo-journal
+// wiring (→ ADR-0044, issue #168): same ancestor-migration setup as TestRollbackAncestorMigration
+// (PreRemove unlinks the whole-tree symlink so the per-file child can be placed), plus an
+// unrelated second entry in the same target manifest whose placement is blocked by a
+// permission-denied parent directory. Both PreRemove's ancestor unlink AND the child placement it
+// enabled must be rolled back when the later, unrelated placement fails — Rollback must not leave
+// the migration half-done, unlike relying solely on a subsequent idempotent re-run to converge.
+func TestRollbackMidBatchFailureRollsBackPreRemoveMigration(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("permission-denied placement cannot be induced as root")
+	}
+	root := realTempDir(t)
+	state := realTempDir(t)
+	srcOld := realTempDir(t)
+	if err := os.WriteFile(filepath.Join(srcOld, "foo"), []byte("old"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	srcNew := realTempDir(t)
+
+	prof := paths.Resolve(state, "c", manifest.RootKindHome, root, true)
+	if err := os.MkdirAll(prof.Dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	blockWrite(t, filepath.Join(root, "ro"))
+
+	// gen1 (N-1, rollback target): the per-file child, plus an unrelated entry whose parent denies
+	// write access so its placement fails after the ancestor migration has already succeeded.
+	lf1 := writeLinkFarm(t, homeManifest(
+		storeEntry(srcOld, "foo", ".claude/skills/foo"),
+		storeEntry(realTempDir(t), ".", "ro/leaf"),
+	))
+	// gen2 (N, current/baseline): whole-tree ancestor symlink at .claude/skills → srcNew.
+	lf2 := writeLinkFarm(t, homeManifest(storeEntry(srcNew, ".", ".claude/skills")))
+
+	if err := os.Symlink(lf1, paths.GenerationLink(prof.Profile, 1)); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(lf2, paths.GenerationLink(prof.Profile, 2)); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(lf2, prof.Profile); err != nil {
+		t.Fatal(err)
+	}
+
+	// Current FS = gen2: .claude/skills is a whole-tree symlink to srcNew.
+	claudeDir := filepath.Join(root, ".claude")
+	if err := os.MkdirAll(claudeDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(srcNew, filepath.Join(claudeDir, "skills")); err != nil {
+		t.Fatal(err)
+	}
+
+	var switched int
+	var warns []string
+	_, err := Rollback(RollbackOptions{
+		Name: "c", RootKind: manifest.RootKindHome, RootOverride: root, StateDir: state,
+		ListGenerations: func(string) ([]Generation, error) {
+			return []Generation{{Number: 1}, {Number: 2, Current: true}}, nil
+		},
+		SwitchGeneration: func(_ string, gen int) error { switched = gen; return nil },
+		Warnf:            collectFormatted(&warns),
+	})
+	if err == nil {
+		t.Fatal("expected an error, got nil")
+	}
+	if switched != 0 {
+		t.Errorf("SwitchGeneration was called (switched=%d), want it skipped when placement fails", switched)
+	}
+
+	// The whole migration must be undone: .claude/skills is the ancestor symlink again, and the
+	// child that PreRemove made room for is gone (undone in the correct order: unlink the child
+	// first, then recreate the ancestor symlink where PreRemove had cleared it).
+	info, serr := os.Lstat(filepath.Join(claudeDir, "skills"))
+	if serr != nil || info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf(".claude/skills must be restored as the ancestor symlink, got mode %v, err %v", info, serr)
+	}
+	got, rerr := os.Readlink(filepath.Join(claudeDir, "skills"))
+	if rerr != nil || got != srcNew {
+		t.Errorf("restored ancestor readlink = %q, err %v; want %q", got, rerr, srcNew)
+	}
+	foundRollbackMsg := false
+	for _, w := range warns {
+		if strings.Contains(w, "rolled back this run's filesystem changes") {
+			foundRollbackMsg = true
+		}
+	}
+	if !foundRollbackMsg {
+		t.Errorf("warns = %v, want a rollback-reported message", warns)
+	}
+}
+
 // TestRollbackAncestorPreRemoveErrorSkipsSwitch verifies the Rollback-level wiring of preRemove's
 // error path: same setup as TestRollbackAncestorMigration, but the ancestor symlink's parent dir
 // is read-only, so preRemove's os.Remove fails. Rollback must propagate the error instead of

--- a/internal/engine/place.go
+++ b/internal/engine/place.go
@@ -12,6 +12,16 @@ import (
 // rejected as conflicts by the planner · → ADR-0015), wrapping any failure with the
 // target path for diagnosability. Shared by all place-execution entry points that write
 // to targetAbs (place, placeCopies, recopyAll).
+//
+// The directories it creates are NOT journaled for undo (→ ADR-0044 §1 scope note): unwind
+// removing the leaf symlink/copy it made room for already returns the target to "absent" from
+// the caller's perspective, and any now-empty intermediate directories left behind are
+// indistinguishable from the plain mkdir -p residue apply has always left after non-rollback
+// runs (e.g. an entry deleted from config the next run down) — a case the existing
+// pruneEmptyAncestors backstop, not the undo journal, already exists to sweep up on the next
+// removal/apply. Adding mkdir/rmdir entries here would track a directory that may be shared by
+// several journal entries (multiple leaves under the same fresh parent), complicating dedup for
+// a cosmetic leftover with no data-loss risk.
 func ensureParentDir(targetAbs string) error {
 	if err := os.MkdirAll(filepath.Dir(targetAbs), 0o755); err != nil {
 		return fmt.Errorf("nput: cannot create parent directory (%s): %w", filepath.Dir(targetAbs), err)

--- a/internal/engine/place.go
+++ b/internal/engine/place.go
@@ -36,15 +36,25 @@ func (a *applier) place(actions []planner.PlaceAction) error {
 		case planner.PlaceReplace, planner.PlaceForeign:
 			// Re-link is unlink + symlink (no rename-based atomic swap · → ADR-0017).
 			// The foreign-overwrite warning is already emitted via planner.Warnings by emitWarnings (→ ADR-0015).
+			prevDest, err := os.Readlink(act.TargetAbs)
+			if err != nil {
+				return fmt.Errorf("nput: cannot read existing symlink before re-link (%s): %w", act.TargetAbs, err)
+			}
 			if err := os.Remove(act.TargetAbs); err != nil {
 				return fmt.Errorf("nput: cannot remove existing symlink (%s): %w", act.TargetAbs, err)
 			}
 			a.result.Replaced = append(a.result.Replaced, act.Entry.Target)
+			if err := os.Symlink(act.Dest, act.TargetAbs); err != nil {
+				return fmt.Errorf("nput: cannot create symlink (%s -> %s): %w", act.TargetAbs, act.Dest, err)
+			}
+			a.journalRelinkedSymlink(act.TargetAbs, prevDest)
+			continue
 		}
 
 		if err := os.Symlink(act.Dest, act.TargetAbs); err != nil {
 			return fmt.Errorf("nput: cannot create symlink (%s -> %s): %w", act.TargetAbs, act.Dest, err)
 		}
+		a.journalPlacedSymlink(act.TargetAbs)
 	}
 	return nil
 }

--- a/internal/engine/place.go
+++ b/internal/engine/place.go
@@ -43,11 +43,15 @@ func (a *applier) place(actions []planner.PlaceAction) error {
 			if err := os.Remove(act.TargetAbs); err != nil {
 				return fmt.Errorf("nput: cannot remove existing symlink (%s): %w", act.TargetAbs, err)
 			}
+			// Journaled immediately after the unlink, before the re-symlink: if the symlink
+			// creation below fails, undoRelinkOld's own os.Remove tolerates the target already
+			// being absent and still recreates it at prevDest — so this target is restorable even
+			// when this run never got as far as writing the new symlink (→ ADR-0044).
+			a.journalRelinkedSymlink(act.TargetAbs, prevDest)
 			a.result.Replaced = append(a.result.Replaced, act.Entry.Target)
 			if err := os.Symlink(act.Dest, act.TargetAbs); err != nil {
 				return fmt.Errorf("nput: cannot create symlink (%s -> %s): %w", act.TargetAbs, act.Dest, err)
 			}
-			a.journalRelinkedSymlink(act.TargetAbs, prevDest)
 			continue
 		}
 

--- a/internal/engine/staleremove.go
+++ b/internal/engine/staleremove.go
@@ -32,6 +32,7 @@ func (a *applier) removeStale(actions []planner.RemoveAction) error {
 			return fmt.Errorf("nput: cannot remove stale symlink (%s): %w", act.TargetAbs, err)
 		}
 		a.result.Removed = append(a.result.Removed, act.Entry.Target)
+		a.journalRelinkedSymlink(act.TargetAbs, planner.LinkDest(act.Entry))
 		if err := a.pruneEmptyAncestors(act.TargetAbs); err != nil {
 			a.opts.Warnf("nput: could not prune an empty ancestor directory: %v", err)
 		}
@@ -81,6 +82,7 @@ func (a *applier) preRemove(actions []planner.RemoveAction) error {
 			switch {
 			case err == nil:
 				a.result.Pruned = append(a.result.Pruned, act.TargetAbs)
+				a.journalRemovedEmptyDir(act.TargetAbs)
 			case os.IsNotExist(err):
 				// already absent; the Rmdir's goal is met, nothing to report.
 			case errors.Is(err, syscall.ENOTEMPTY), errors.Is(err, syscall.EEXIST):
@@ -96,6 +98,7 @@ func (a *applier) preRemove(actions []planner.RemoveAction) error {
 				return fmt.Errorf("nput: cannot remove recorded symlink for migration (%s): %w", act.TargetAbs, err)
 			}
 			a.result.Removed = append(a.result.Removed, act.Entry.Target)
+			a.journalRelinkedSymlink(act.TargetAbs, planner.LinkDest(act.Entry))
 		}
 	}
 	return nil
@@ -144,6 +147,7 @@ func (a *applier) pruneEmptyAncestors(removedAbs string) error {
 			return fmt.Errorf("nput: cannot remove empty ancestor directory (%s): %w", dir, err)
 		}
 		a.result.Pruned = append(a.result.Pruned, dir)
+		a.journalRemovedEmptyDir(dir)
 		dir = filepath.Dir(dir)
 	}
 }

--- a/internal/engine/staleremove.go
+++ b/internal/engine/staleremove.go
@@ -78,11 +78,19 @@ func (a *applier) preRemove(actions []planner.RemoveAction) error {
 			// gone" as success rather than a hard error keeps this branch robust without relying on
 			// that invariant. It is NOT folded into result.Pruned: Pruned means "this run rmdir-ed
 			// it", and a dir that was already gone before this run touched it was not (→ diff-review).
+			//
+			// The mode is captured before the removal purely so undo can recreate an identical
+			// directory (→ ADR-0044); os.Remove itself, not this Lstat, is what re-verifies
+			// emptiness against drift (TOCTOU-safe per the comment above).
+			mode := os.FileMode(0o755)
+			if info, lerr := os.Lstat(act.TargetAbs); lerr == nil {
+				mode = info.Mode().Perm()
+			}
 			err := os.Remove(act.TargetAbs)
 			switch {
 			case err == nil:
 				a.result.Pruned = append(a.result.Pruned, act.TargetAbs)
-				a.journalRemovedEmptyDir(act.TargetAbs)
+				a.journalRemovedEmptyDir(act.TargetAbs, mode)
 			case os.IsNotExist(err):
 				// already absent; the Rmdir's goal is met, nothing to report.
 			case errors.Is(err, syscall.ENOTEMPTY), errors.Is(err, syscall.EEXIST):
@@ -135,6 +143,12 @@ func (a *applier) pruneEmptyAncestors(removedAbs string) error {
 		if hasSymlink {
 			return nil
 		}
+		// The mode is captured before the removal purely so undo can recreate an identical
+		// directory (→ ADR-0044); it plays no role in the TOCTOU-safe emptiness re-check below.
+		mode := os.FileMode(0o755)
+		if info, lerr := os.Lstat(dir); lerr == nil {
+			mode = info.Mode().Perm()
+		}
 		if err := os.Remove(dir); err != nil {
 			if os.IsNotExist(err) {
 				return nil
@@ -147,7 +161,7 @@ func (a *applier) pruneEmptyAncestors(removedAbs string) error {
 			return fmt.Errorf("nput: cannot remove empty ancestor directory (%s): %w", dir, err)
 		}
 		a.result.Pruned = append(a.result.Pruned, dir)
-		a.journalRemovedEmptyDir(dir)
+		a.journalRemovedEmptyDir(dir, mode)
 		dir = filepath.Dir(dir)
 	}
 }

--- a/internal/engine/undo.go
+++ b/internal/engine/undo.go
@@ -151,7 +151,11 @@ func undoOne(op undoOp) error {
 	case undoMkdir:
 		mode := op.mode
 		if mode == 0 {
-			mode = 0o755 // defensive fallback: the removal site always captures a real mode before recording this op.
+			// Defensive fallback for the case the removal site's Lstat failed to capture a mode
+			// (see journalRemovedEmptyDir's callers). A genuinely mode-0o000 directory would also
+			// hit this branch and come back as 0o755 instead — an accepted, vanishingly rare edge
+			// case, not a real invariant violation.
+			mode = 0o755
 		}
 		return os.Mkdir(op.path, mode)
 	default:

--- a/internal/engine/undo.go
+++ b/internal/engine/undo.go
@@ -41,9 +41,10 @@ const (
 // already succeeded (→ ADR-0044).
 type undoOp struct {
 	kind     undoKind
-	path     string // the target path the forward operation wrote to
-	prevDest string // undoRelinkOld: the symlink destination to restore
-	tmpPath  string // undoRestoreRename: the aside path holding the pre-overwrite content
+	path     string      // the target path the forward operation wrote to
+	prevDest string      // undoRelinkOld: the symlink destination to restore
+	tmpPath  string      // undoRestoreRename: the aside path holding the pre-overwrite content
+	mode     os.FileMode // undoMkdir: the removed directory's mode, to recreate it identically
 }
 
 // journalPlacedSymlink records a freshly created symlink (target was absent) for undo (→ ADR-0044).
@@ -70,9 +71,10 @@ func (a *applier) journalRenamedAside(path, tmpPath string) {
 	a.journal = append(a.journal, undoOp{kind: undoRestoreRename, path: path, tmpPath: tmpPath})
 }
 
-// journalRemovedEmptyDir records an empty directory this run rmdir-ed (PreRemove's RemoveRmdir → ADR-0047).
-func (a *applier) journalRemovedEmptyDir(path string) {
-	a.journal = append(a.journal, undoOp{kind: undoMkdir, path: path})
+// journalRemovedEmptyDir records an empty directory this run rmdir-ed (PreRemove's RemoveRmdir →
+// ADR-0047), capturing its mode so undo recreates it identically rather than with a fixed default.
+func (a *applier) journalRemovedEmptyDir(path string, mode os.FileMode) {
+	a.journal = append(a.journal, undoOp{kind: undoMkdir, path: path, mode: mode})
 }
 
 // discardJournal drops the accumulated journal once it no longer needs undoing: after a
@@ -147,7 +149,11 @@ func undoOne(op undoOp) error {
 		}
 		return os.Rename(op.tmpPath, op.path)
 	case undoMkdir:
-		return os.Mkdir(op.path, 0o755)
+		mode := op.mode
+		if mode == 0 {
+			mode = 0o755 // defensive fallback: the removal site always captures a real mode before recording this op.
+		}
+		return os.Mkdir(op.path, mode)
 	default:
 		return fmt.Errorf("nput: internal error: unknown undo kind %d", op.kind)
 	}

--- a/internal/engine/undo.go
+++ b/internal/engine/undo.go
@@ -1,0 +1,154 @@
+package engine
+
+import (
+	"fmt"
+	"os"
+)
+
+// Package-level undo journal (→ ADR-0044, issue #168): apply's FS-mutating stages — PreRemove,
+// place, materializeCopies, removeStale, and the generation-skip drift repair — each push one
+// undoOp per successful FS write onto applier.journal. If any stage in the same Apply/Rollback
+// call later fails, the journal accumulated so far is unwound in reverse (LIFO) order, restoring
+// the pre-apply state before the error is returned. Once `nix-env --set` (commit) succeeds the
+// journal is discarded by the caller: FS changes are then part of the new generation, and undoing
+// them is rollback's job, not this run's.
+//
+// Process crashes (SIGKILL, power loss) are out of scope: the journal lives only in memory. That
+// gap is intentionally left to the existing backstop — an uncommitted generation plus idempotent
+// re-run convergence (→ ADR-0006, ADR-0017) — rather than a persisted WAL (→ ADR-0044 §4).
+
+// undoKind identifies which inverse operation an undoOp performs.
+type undoKind int
+
+const (
+	// undoUnlinkNew removes a symlink this run newly created at path (PlaceNew / PlaceAction
+	// appendAbsentPlacement's absent case).
+	undoUnlinkNew undoKind = iota
+	// undoRelinkOld removes the symlink now at path and recreates it pointing at prevDest (a
+	// re-link: PlaceReplace / PlaceForeign, or a stale-removed entry — → ADR-0006, ADR-0015).
+	undoRelinkOld
+	// undoRemoveCopy removes a copy tree this run newly placed at path (placeCopies /
+	// recopyAll's "target was absent" branch).
+	undoRemoveCopy
+	// undoRestoreRename renames tmpPath back to path (recopyAll's rename-aside of an existing
+	// copy target before overwriting it — → ADR-0044 §1, ADR-0047 D5 boundary).
+	undoRestoreRename
+	// undoMkdir recreates the empty directory removed at path (PreRemove's RemoveRmdir → ADR-0047).
+	undoMkdir
+)
+
+// undoOp is one entry in applier.journal: enough information to invert a single FS write that
+// already succeeded (→ ADR-0044).
+type undoOp struct {
+	kind     undoKind
+	path     string // the target path the forward operation wrote to
+	prevDest string // undoRelinkOld: the symlink destination to restore
+	tmpPath  string // undoRestoreRename: the aside path holding the pre-overwrite content
+}
+
+// journalPlacedSymlink records a freshly created symlink (target was absent) for undo (→ ADR-0044).
+func (a *applier) journalPlacedSymlink(path string) {
+	a.journal = append(a.journal, undoOp{kind: undoUnlinkNew, path: path})
+}
+
+// journalRelinkedSymlink records a symlink this run removed and (for a re-link) replaced,
+// capturing the destination it pointed at before this run touched it, so undo can recreate it.
+// Covers place's PlaceReplace/PlaceForeign re-link, and removeStale/PreRemove's RemoveUnlink
+// (which removes without replacing — the same inverse applies: recreate at prevDest → ADR-0044).
+func (a *applier) journalRelinkedSymlink(path, prevDest string) {
+	a.journal = append(a.journal, undoOp{kind: undoRelinkOld, path: path, prevDest: prevDest})
+}
+
+// journalPlacedCopy records a freshly placed copy tree (target was absent) for undo (→ ADR-0044).
+func (a *applier) journalPlacedCopy(path string) {
+	a.journal = append(a.journal, undoOp{kind: undoRemoveCopy, path: path})
+}
+
+// journalRenamedAside records a --recopy overwrite's rename-aside: path's pre-overwrite content
+// was moved to tmpPath before the fresh copy landed at path (→ ADR-0044 §1, ADR-0047 D5).
+func (a *applier) journalRenamedAside(path, tmpPath string) {
+	a.journal = append(a.journal, undoOp{kind: undoRestoreRename, path: path, tmpPath: tmpPath})
+}
+
+// journalRemovedEmptyDir records an empty directory this run rmdir-ed (PreRemove's RemoveRmdir → ADR-0047).
+func (a *applier) journalRemovedEmptyDir(path string) {
+	a.journal = append(a.journal, undoOp{kind: undoMkdir, path: path})
+}
+
+// discardJournal drops the accumulated journal once it no longer needs undoing: after a
+// successful commit (the FS changes are now part of the new generation — undoing them is
+// rollback's job, not this run's · → ADR-0044 §2). A recopy rename-aside entry's tmpPath still
+// holds the pre-overwrite content at this point (undo was never triggered), so it is cleaned up
+// here rather than left to linger — a warning-only best-effort, since the fresh copy already
+// landed successfully and a leftover aside file is cosmetic, not a correctness issue.
+func (a *applier) discardJournal() {
+	for _, op := range a.journal {
+		if op.kind != undoRestoreRename {
+			continue
+		}
+		if err := os.RemoveAll(op.tmpPath); err != nil && !os.IsNotExist(err) {
+			a.opts.Warnf("nput: could not remove recopy aside file (%s): %v", op.tmpPath, err)
+		}
+	}
+	a.journal = nil
+}
+
+// unwind reverses applier.journal in LIFO order, restoring the pre-apply state after origErr
+// aborted an Apply/Rollback call mid-flight (→ ADR-0044). Each inverse operation is attempted
+// independently (best-effort): a failure is recorded but does not stop the rest of the unwind, so
+// one unrestorable item never leaves other, restorable items undone (→ ADR-0044 §3). When done,
+// it reports origErr plus every item that could not be restored to opts.Warnf, mirroring
+// reportConflicts's "list everything, then one aggregate error" shape. The journal is cleared
+// regardless of outcome — a partially-unwound run has nothing left it can safely retry the same
+// way, and the failure list has already been surfaced.
+func (a *applier) unwind(origErr error) {
+	journal := a.journal
+	a.journal = nil
+	if len(journal) == 0 {
+		a.opts.Warnf("nput: apply failed; no filesystem changes had been made yet: %v", origErr)
+		return
+	}
+
+	var failed []string
+	for i := len(journal) - 1; i >= 0; i-- {
+		if err := undoOne(journal[i]); err != nil {
+			failed = append(failed, fmt.Sprintf("%s: %v", journal[i].path, err))
+		}
+	}
+
+	a.opts.Warnf("nput: apply failed; rolled back this run's filesystem changes: %v", origErr)
+	if len(failed) == 0 {
+		return
+	}
+	a.opts.Warnf("nput: %d item(s) could not be restored during rollback:", len(failed))
+	for _, f := range failed {
+		a.opts.Warnf("nput:   → %s", f)
+	}
+}
+
+// undoOne performs the single inverse FS operation described by op.
+func undoOne(op undoOp) error {
+	switch op.kind {
+	case undoUnlinkNew:
+		if err := os.Remove(op.path); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+		return nil
+	case undoRelinkOld:
+		if err := os.Remove(op.path); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+		return os.Symlink(op.prevDest, op.path)
+	case undoRemoveCopy:
+		return os.RemoveAll(op.path)
+	case undoRestoreRename:
+		if err := os.RemoveAll(op.path); err != nil {
+			return err
+		}
+		return os.Rename(op.tmpPath, op.path)
+	case undoMkdir:
+		return os.Mkdir(op.path, 0o755)
+	default:
+		return fmt.Errorf("nput: internal error: unknown undo kind %d", op.kind)
+	}
+}

--- a/internal/engine/undo_journal_test.go
+++ b/internal/engine/undo_journal_test.go
@@ -237,53 +237,6 @@ func TestApplyRecopyMidBatchFailureRestoresAsideFile(t *testing.T) {
 	}
 }
 
-// TestApplyUnwindBestEffortReportsUnrestorableItem verifies that when unwind cannot restore one
-// journal entry (its parent directory was itself removed by an intervening, unrelated FS change),
-// Apply's own aggregate failure message is still surfaced via Warnf, and everything else in the
-// journal is still restored despite that one failure (→ ADR-0044 §3). This drives applier.unwind
-// directly (rather than through the full Apply call) to construct the "one entry became
-// unrestorable" condition deterministically, since provoking it through Apply's own execution
-// would require a genuine external race.
-func TestApplyUnwindBestEffortReportsUnrestorableItem(t *testing.T) {
-	root := realTempDir(t)
-	restorableDest := realTempDir(t)
-	restorable := filepath.Join(root, "a")
-	unrestorableDest := realTempDir(t)
-	unrestorable := filepath.Join(root, "sub", "b")
-
-	// Simulate removeStale having already removed both recorded symlinks (the forward operations
-	// this journal describes: undoRelinkOld recreates them at their recorded dest), then something
-	// else removing "sub" entirely before the failure that triggers unwind — making "sub/b"
-	// impossible to recreate (os.Symlink into a missing parent fails with ENOENT, a real error, not
-	// the tolerated "already gone" case that undoUnlinkNew treats as success).
-	var warns []string
-	a := &applier{opts: Options{Warnf: collectFormatted(&warns)}, result: &Result{}}
-	a.journalRelinkedSymlink(restorable, restorableDest)
-	a.journalRelinkedSymlink(unrestorable, unrestorableDest)
-
-	a.unwind(os.ErrInvalid)
-
-	foundRollbackMsg, foundUnrestorablePath := false, false
-	for _, w := range warns {
-		if strings.Contains(w, "rolled back this run's filesystem changes") {
-			foundRollbackMsg = true
-		}
-		if strings.Contains(w, unrestorable) {
-			foundUnrestorablePath = true
-		}
-	}
-	if !foundRollbackMsg {
-		t.Errorf("warns = %v, want a rollback-reported message", warns)
-	}
-	if !foundUnrestorablePath {
-		t.Errorf("warns = %v, want the unrestorable path named", warns)
-	}
-	got, rerr := os.Readlink(restorable)
-	if rerr != nil || got != restorableDest {
-		t.Errorf("the restorable entry (\"a\") must still be undone despite \"sub/b\" failing: readlink=%q, err=%v, want %q", got, rerr, restorableDest)
-	}
-}
-
 // TestPreRemoveJournalRmdirThenUnlinkOrder directly exercises preRemove with a batch containing
 // both a RemoveUnlink and a RemoveRmdir (the shape classifyDirMigration produces: children before
 // parents), verifying the journal records them such that unwind restores the parent directory
@@ -324,5 +277,75 @@ func TestPreRemoveJournalRmdirThenUnlinkOrder(t *testing.T) {
 	got, rerr := os.Readlink(leaf)
 	if rerr != nil || got != leafDest {
 		t.Fatalf("leaf symlink must be recreated inside the recreated parent: readlink=%q, err=%v, want %q", got, rerr, leafDest)
+	}
+}
+
+// TestApplyCommitFailureDoesNotUnwind verifies ADR-0044 §2's asymmetry: a commit (`nix-env --set`)
+// failure is NOT rolled back, unlike every FS-mutating stage before it. Every FS write for this run
+// already succeeded by the time commit runs, so there is nothing wrong to undo — the run simply
+// fails to advance the generation, and idempotent re-apply converges (→ ADR-0006, ADR-0017).
+func TestApplyCommitFailureDoesNotUnwind(t *testing.T) {
+	root := realTempDir(t)
+	state := realTempDir(t)
+	src := realTempDir(t)
+
+	lf := writeLinkFarm(t, projectManifest(storeEntry(src, ".", "a")))
+	failingCommit := func(string, string) error { return os.ErrPermission }
+
+	var warns []string
+	_, err := Apply(Options{
+		LinkFarm: lf, Name: "c", RootOverride: root, StateDir: state, Commit: failingCommit,
+		Warnf: collectFormatted(&warns),
+	})
+	if err == nil {
+		t.Fatal("expected the commit failure to propagate, got nil")
+	}
+
+	// The placement must survive untouched — commit failure is not an unwind trigger.
+	got, rerr := os.Readlink(filepath.Join(root, "a"))
+	if rerr != nil || got != src {
+		t.Errorf("placement must survive a commit failure untouched: readlink=%q, err=%v, want %q", got, rerr, src)
+	}
+	for _, w := range warns {
+		if strings.Contains(w, "rolled back this run's filesystem changes") {
+			t.Errorf("warns = %v, must not report a rollback for a commit-only failure", warns)
+		}
+	}
+}
+
+// TestApplyCommitFailureLeavesRecopyAsideFile verifies the same asymmetry for --recopy: a commit
+// failure after a successful rename-aside overwrite must leave the aside file in place (neither
+// cleaned up by discardJournal, which only runs after a successful commit, nor renamed back by
+// unwind, which commit failure does not trigger) — the fresh copy stays live and recoverable from
+// its pre-apply content is still sitting in the aside file for manual inspection if needed.
+func TestApplyCommitFailureLeavesRecopyAsideFile(t *testing.T) {
+	root := realTempDir(t)
+	state := realTempDir(t)
+	copySrc := makeSrc(t, "tool.conf")
+
+	lf1 := writeLinkFarm(t, projectManifest(copyEntry(copySrc, "tool.conf", "tool.conf")))
+	if _, err := Apply(Options{LinkFarm: lf1, Name: "c", RootOverride: root, StateDir: state, Commit: fakeCommit(nil)}); err != nil {
+		t.Fatalf("first Apply: %v", err)
+	}
+
+	// A distinct link-farm (home mode has no generation-skip concept in the first place, but a
+	// second, content-identical project-mode link-farm would still hit generationUnchanged and skip
+	// straight to repairDrift, bypassing commit entirely) — home mode side-steps that branch so
+	// this Apply call actually reaches step 9 (commit) and can be made to fail there.
+	lf2 := writeLinkFarm(t, homeManifest(copyEntry(copySrc, "tool.conf", "tool.conf")))
+	failingCommit := func(string, string) error { return os.ErrPermission }
+	_, err := Apply(Options{
+		LinkFarm: lf2, Name: "c", RootOverride: root, StateDir: state, Commit: failingCommit, Recopy: true,
+	})
+	if err == nil {
+		t.Fatal("expected the commit failure to propagate, got nil")
+	}
+
+	data, rerr := os.ReadFile(filepath.Join(root, "tool.conf"))
+	if rerr != nil || string(data) != "content" {
+		t.Errorf("the fresh recopy must survive a commit failure: data=%q, err=%v", data, rerr)
+	}
+	if _, lerr := os.Lstat(filepath.Join(root, "tool.conf.nput-recopy-aside")); lerr != nil {
+		t.Errorf("the aside file must survive (neither cleaned up nor renamed back) after a commit failure, lstat err = %v", lerr)
 	}
 }

--- a/internal/engine/undo_journal_test.go
+++ b/internal/engine/undo_journal_test.go
@@ -1,0 +1,328 @@
+package engine
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/yasunori0418/nput/internal/planner"
+)
+
+// Tests for apply's end-to-end undo journal (→ ADR-0044, issue #168): a mid-run failure in any
+// FS-mutating stage (PreRemove / place / copy materialization / stale removal) must roll back
+// every FS change this run made before returning, leaving pre-apply state intact.
+
+// blockWrite creates dir as a mode-0o555 (read+exec, no write) directory, so it exists and is
+// lstat-able (the planner's pre-flight classification sees an ordinary, empty directory and
+// schedules a plain PlaceNew/CopyAction for anything beneath it — no conflict), but any later
+// write inside it at *execution* time (os.Symlink / os.OpenFile for a copy / os.Mkdir for a new
+// child) fails with EACCES. This is what lets these tests fail a placement mid-*execution* batch
+// rather than during planning: blocking write access (rather than substituting a regular file for
+// the directory, which would make even Lstat of a path beneath it fail with ENOTDIR at *plan*
+// time) keeps Lstat/ReadDir succeeding, so planner.Compute completes and the failure surfaces only
+// once place/materializeCopies actually tries to write (→ ADR-0044). Skips the test outright when
+// running as root, since root bypasses directory write-permission checks entirely and this
+// technique would not observe any failure at all.
+func blockWrite(t *testing.T, dir string) {
+	t.Helper()
+	if os.Geteuid() == 0 {
+		t.Skip("running as root: directory write-permission checks are bypassed, cannot force a mid-execution failure this way")
+	}
+	if err := os.Mkdir(dir, 0o555); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o755) })
+}
+
+// TestApplyPlaceMidBatchFailureRollsBackEarlierPlacements verifies that when the second of three
+// new-symlink placements fails (its target's parent directory denies write access), the first
+// placement — already written to the real FS — is undone before Apply returns an error.
+func TestApplyPlaceMidBatchFailureRollsBackEarlierPlacements(t *testing.T) {
+	root := realTempDir(t)
+	state := realTempDir(t)
+	src1 := realTempDir(t)
+	src3 := realTempDir(t)
+
+	blockWrite(t, filepath.Join(root, "ro"))
+
+	lf := writeLinkFarm(t, projectManifest(
+		storeEntry(src1, ".", "a"),
+		storeEntry(realTempDir(t), ".", "ro/leaf"),
+		storeEntry(src3, ".", "c"),
+	))
+	_, err := Apply(Options{LinkFarm: lf, Name: "c", RootOverride: root, StateDir: state, Commit: fakeCommit(nil)})
+	if err == nil {
+		t.Fatal("expected an error from the blocked mid-batch placement, got nil")
+	}
+
+	// "a" was placed before the failure; it must be rolled back.
+	if _, lerr := os.Lstat(filepath.Join(root, "a")); !os.IsNotExist(lerr) {
+		t.Errorf("entry \"a\" must be rolled back after the mid-batch failure, lstat err = %v", lerr)
+	}
+	// "c" comes after the failing entry in the batch; it must never have been placed.
+	if _, lerr := os.Lstat(filepath.Join(root, "c")); !os.IsNotExist(lerr) {
+		t.Errorf("entry \"c\" must never have been placed, lstat err = %v", lerr)
+	}
+	// The read-only blocker directory itself must survive untouched, and "leaf" must never appear.
+	info, serr := os.Lstat(filepath.Join(root, "ro"))
+	if serr != nil || !info.IsDir() {
+		t.Errorf("blocker at \"ro\" must survive as a directory: info=%v, err=%v", info, serr)
+	}
+	if _, lerr := os.Lstat(filepath.Join(root, "ro", "leaf")); !os.IsNotExist(lerr) {
+		t.Errorf("\"ro/leaf\" must never have been created, lstat err = %v", lerr)
+	}
+
+	// No profile should have been committed (the generation commit is never reached).
+	if _, serr := os.Stat(filepath.Join(profileDirFor(t, state, root, "c"), "profile")); !os.IsNotExist(serr) {
+		t.Errorf("no generation must be committed after a rolled-back apply")
+	}
+}
+
+// TestApplyPlaceMidBatchFailureRollsBackEarlierRelink verifies that a re-link (PlaceReplace)
+// already performed earlier in the same batch is restored to its pre-apply destination when a
+// later placement in the same batch fails.
+func TestApplyPlaceMidBatchFailureRollsBackEarlierRelink(t *testing.T) {
+	root := realTempDir(t)
+	state := realTempDir(t)
+	oldDest := realTempDir(t)
+
+	lf1 := writeLinkFarm(t, projectManifest(storeEntry(oldDest, ".", "a")))
+	if _, err := Apply(Options{LinkFarm: lf1, Name: "c", RootOverride: root, StateDir: state, Commit: fakeCommit(nil)}); err != nil {
+		t.Fatalf("first Apply: %v", err)
+	}
+
+	newDest := realTempDir(t)
+	blockWrite(t, filepath.Join(root, "ro"))
+	lf2 := writeLinkFarm(t, projectManifest(
+		storeEntry(newDest, ".", "a"),              // re-link: "a" already exists from gen 1
+		storeEntry(realTempDir(t), ".", "ro/leaf"), // fails: "ro" denies write access
+	))
+	_, err := Apply(Options{LinkFarm: lf2, Name: "c", RootOverride: root, StateDir: state, Commit: fakeCommit(nil)})
+	if err == nil {
+		t.Fatal("expected an error from the blocked mid-batch placement, got nil")
+	}
+
+	got, rerr := os.Readlink(filepath.Join(root, "a"))
+	if rerr != nil || got != oldDest {
+		t.Errorf("re-linked entry \"a\" must be restored to its pre-apply dest: readlink=%q, err=%v, want %q", got, rerr, oldDest)
+	}
+}
+
+// TestApplyCopyMidBatchFailureRollsBackEarlierCopy verifies a copy placement already materialized
+// earlier in the same Apply call is removed when a later stage (removeStale) fails. materializeCopies
+// runs after place but before removeStale (→ engine.go Apply step 8), so a copy entry always
+// finishes placing before removeStale even starts; to observe copy's own journal entry get undone
+// by a later-stage failure, this test forces removeStale to fail on a stale symlink whose parent
+// directory has since had its write permission revoked (the unlink itself needs write access to
+// the containing directory, matching blockWrite's technique applied to an existing parent instead
+// of a fresh one).
+func TestApplyCopyMidBatchFailureRollsBackEarlierCopy(t *testing.T) {
+	root := realTempDir(t)
+	state := realTempDir(t)
+	copySrc := makeSrc(t, "tool.conf")
+	staleDest := realTempDir(t)
+
+	lf1 := writeLinkFarm(t, projectManifest(storeEntry(staleDest, ".", "ro/stale")))
+	if _, err := Apply(Options{LinkFarm: lf1, Name: "c", RootOverride: root, StateDir: state, Commit: fakeCommit(nil)}); err != nil {
+		t.Fatalf("first Apply: %v", err)
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("running as root: directory write-permission checks are bypassed, cannot force removeStale to fail this way")
+	}
+	if err := os.Chmod(filepath.Join(root, "ro"), 0o555); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(filepath.Join(root, "ro"), 0o755) })
+
+	lf2 := writeLinkFarm(t, projectManifest(copyEntry(copySrc, "tool.conf", "copied.conf"))) // "ro/stale" dropped → removeStale target
+	_, err := Apply(Options{LinkFarm: lf2, Name: "c", RootOverride: root, StateDir: state, Commit: fakeCommit(nil)})
+	if err == nil {
+		t.Fatal("expected an error from the permission-denied stale removal, got nil")
+	}
+
+	if _, lerr := os.Lstat(filepath.Join(root, "copied.conf")); !os.IsNotExist(lerr) {
+		t.Errorf("copy placement must be rolled back after removeStale's failure, lstat err = %v", lerr)
+	}
+	got, rerr := os.Readlink(filepath.Join(root, "ro", "stale"))
+	if rerr != nil || got != staleDest {
+		t.Errorf("stale symlink removeStale failed to remove must still be there untouched: readlink=%q, err=%v", got, rerr)
+	}
+}
+
+// TestApplyPreRemoveMidBatchFailureRollsBackUnlink verifies that when PreRemove's Unlink+Rmdir (a
+// real-dir-target migration → ADR-0047) and the resulting new dir-symlink placement both succeed,
+// but a later placement in the same Apply call fails, the whole migration is undone — the new dir
+// symlink removed, the real directory recreated, and the original per-file leaf symlink restored
+// inside it — landing back on the exact pre-apply state, not left half-migrated.
+func TestApplyPreRemoveMidBatchFailureRollsBackUnlink(t *testing.T) {
+	root := realTempDir(t)
+	state := realTempDir(t)
+	srcOld := makeSrc(t, "foo/main.sh")
+
+	lf1 := writeLinkFarm(t, projectManifest(storeEntry(srcOld, "foo/main.sh", ".claude/hooks/foo/main.sh")))
+	if _, err := Apply(Options{LinkFarm: lf1, Name: "c", RootOverride: root, StateDir: state, Commit: fakeCommit(nil)}); err != nil {
+		t.Fatalf("first Apply: %v", err)
+	}
+
+	// A second, unrelated entry in the same batch will fail to place, after PreRemove has already
+	// migrated the occupying real directory (unlinked "foo/main.sh", rmdir-ed "foo" then
+	// ".claude/hooks" itself) and place has already placed the new ".claude/hooks" dir symlink
+	// (Place actions run after PreRemove but before this second entry, since planner.Compute emits
+	// Place actions in manifest entry order).
+	srcNew := realTempDir(t)
+	blockWrite(t, filepath.Join(root, "ro"))
+	lf2 := writeLinkFarm(t, projectManifest(
+		storeEntry(srcNew, ".", ".claude/hooks"),
+		storeEntry(realTempDir(t), ".", "ro/leaf"),
+	))
+	_, err := Apply(Options{LinkFarm: lf2, Name: "c", RootOverride: root, StateDir: state, Commit: fakeCommit(nil)})
+	if err == nil {
+		t.Fatal("expected an error from the blocked mid-batch placement, got nil")
+	}
+
+	// The whole migration must be undone: ".claude/hooks" is a real directory again (not the new
+	// dir symlink place put there), and the original per-file leaf symlink is back inside it.
+	info, serr := os.Lstat(filepath.Join(root, ".claude", "hooks"))
+	if serr != nil || !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+		t.Fatalf(".claude/hooks must be restored as a real directory (the pre-apply state), got mode %v, err %v", info, serr)
+	}
+	wantDest := filepath.Join(srcOld, "foo", "main.sh")
+	got, rerr := os.Readlink(filepath.Join(root, ".claude", "hooks", "foo", "main.sh"))
+	if rerr != nil || got != wantDest {
+		t.Errorf("restored leaf readlink = %q, err %v; want %q", got, rerr, wantDest)
+	}
+}
+
+// TestApplyRecopyMidBatchFailureRestoresAsideFile verifies --recopy's rename-aside is rolled back
+// (rename back, not left as a stray .nput-recopy-aside file) when a later placement in the same
+// batch fails, and that the fresh recopy content is discarded in favor of the pre-apply content.
+func TestApplyRecopyMidBatchFailureRestoresAsideFile(t *testing.T) {
+	root := realTempDir(t)
+	state := realTempDir(t)
+	copySrc := makeSrc(t, "tool.conf")
+
+	lf1 := writeLinkFarm(t, projectManifest(copyEntry(copySrc, "tool.conf", "tool.conf")))
+	if _, err := Apply(Options{LinkFarm: lf1, Name: "c", RootOverride: root, StateDir: state, Commit: fakeCommit(nil)}); err != nil {
+		t.Fatalf("first Apply: %v", err)
+	}
+	// Simulate a local edit so we can tell "restored" apart from "recopied".
+	if err := os.WriteFile(filepath.Join(root, "tool.conf"), []byte("locally-edited"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Update the copy src's content so a successful recopy would be observably different from the
+	// restored (locally-edited) content.
+	if err := os.WriteFile(filepath.Join(copySrc, "tool.conf"), []byte("updated"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	blockWrite(t, filepath.Join(root, "ro"))
+	lf2 := writeLinkFarm(t, projectManifest(
+		copyEntry(copySrc, "tool.conf", "tool.conf"),
+		storeEntry(realTempDir(t), ".", "ro/leaf"),
+	))
+	_, err := Apply(Options{
+		LinkFarm: lf2, Name: "c", RootOverride: root, StateDir: state, Commit: fakeCommit(nil), Recopy: true,
+	})
+	if err == nil {
+		t.Fatal("expected an error from the blocked mid-batch placement, got nil")
+	}
+
+	data, rerr := os.ReadFile(filepath.Join(root, "tool.conf"))
+	if rerr != nil || string(data) != "locally-edited" {
+		t.Errorf("recopy target must be restored to its pre-apply (locally-edited) content: data=%q, err=%v", data, rerr)
+	}
+	if _, lerr := os.Lstat(filepath.Join(root, "tool.conf.nput-recopy-aside")); !os.IsNotExist(lerr) {
+		t.Errorf("aside file must not be left behind after a rolled-back recopy, lstat err = %v", lerr)
+	}
+}
+
+// TestApplyUnwindBestEffortReportsUnrestorableItem verifies that when unwind cannot restore one
+// journal entry (its parent directory was itself removed by an intervening, unrelated FS change),
+// Apply's own aggregate failure message is still surfaced via Warnf, and everything else in the
+// journal is still restored despite that one failure (→ ADR-0044 §3). This drives applier.unwind
+// directly (rather than through the full Apply call) to construct the "one entry became
+// unrestorable" condition deterministically, since provoking it through Apply's own execution
+// would require a genuine external race.
+func TestApplyUnwindBestEffortReportsUnrestorableItem(t *testing.T) {
+	root := realTempDir(t)
+	restorableDest := realTempDir(t)
+	restorable := filepath.Join(root, "a")
+	unrestorableDest := realTempDir(t)
+	unrestorable := filepath.Join(root, "sub", "b")
+
+	// Simulate removeStale having already removed both recorded symlinks (the forward operations
+	// this journal describes: undoRelinkOld recreates them at their recorded dest), then something
+	// else removing "sub" entirely before the failure that triggers unwind — making "sub/b"
+	// impossible to recreate (os.Symlink into a missing parent fails with ENOENT, a real error, not
+	// the tolerated "already gone" case that undoUnlinkNew treats as success).
+	var warns []string
+	a := &applier{opts: Options{Warnf: collectFormatted(&warns)}, result: &Result{}}
+	a.journalRelinkedSymlink(restorable, restorableDest)
+	a.journalRelinkedSymlink(unrestorable, unrestorableDest)
+
+	a.unwind(os.ErrInvalid)
+
+	foundRollbackMsg, foundUnrestorablePath := false, false
+	for _, w := range warns {
+		if strings.Contains(w, "rolled back this run's filesystem changes") {
+			foundRollbackMsg = true
+		}
+		if strings.Contains(w, unrestorable) {
+			foundUnrestorablePath = true
+		}
+	}
+	if !foundRollbackMsg {
+		t.Errorf("warns = %v, want a rollback-reported message", warns)
+	}
+	if !foundUnrestorablePath {
+		t.Errorf("warns = %v, want the unrestorable path named", warns)
+	}
+	got, rerr := os.Readlink(restorable)
+	if rerr != nil || got != restorableDest {
+		t.Errorf("the restorable entry (\"a\") must still be undone despite \"sub/b\" failing: readlink=%q, err=%v, want %q", got, rerr, restorableDest)
+	}
+}
+
+// TestPreRemoveJournalRmdirThenUnlinkOrder directly exercises preRemove with a batch containing
+// both a RemoveUnlink and a RemoveRmdir (the shape classifyDirMigration produces: children before
+// parents), verifying the journal records them such that unwind restores the parent directory
+// before recreating the child symlink inside it — LIFO of a bottom-up forward batch naturally
+// yields a top-down (parent-first) undo (→ ADR-0044 §5, ADR-0047).
+func TestPreRemoveJournalRmdirThenUnlinkOrder(t *testing.T) {
+	root := realTempDir(t)
+	leafDest := realTempDir(t)
+	dir := filepath.Join(root, "parent")
+	leaf := filepath.Join(dir, "leaf")
+	if err := os.Mkdir(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(leafDest, leaf); err != nil {
+		t.Fatal(err)
+	}
+
+	var warns []string
+	a := &applier{opts: Options{Warnf: collectWarnings(&warns)}, result: &Result{}}
+	a.root = root
+	actions := []planner.RemoveAction{
+		{Kind: planner.RemoveUnlink, Entry: storeEntry(leafDest, ".", "parent/leaf"), TargetAbs: leaf},
+		{Kind: planner.RemoveRmdir, TargetAbs: dir},
+	}
+	if err := a.preRemove(actions); err != nil {
+		t.Fatalf("preRemove: %v", err)
+	}
+	if _, lerr := os.Lstat(dir); !os.IsNotExist(lerr) {
+		t.Fatalf("setup: dir must be gone after preRemove, lstat err = %v", lerr)
+	}
+
+	a.unwind(os.ErrInvalid)
+
+	info, serr := os.Lstat(dir)
+	if serr != nil || !info.IsDir() {
+		t.Fatalf("parent dir must be recreated: info=%v, err=%v", info, serr)
+	}
+	got, rerr := os.Readlink(leaf)
+	if rerr != nil || got != leafDest {
+		t.Fatalf("leaf symlink must be recreated inside the recreated parent: readlink=%q, err=%v, want %q", got, rerr, leafDest)
+	}
+}

--- a/internal/engine/undo_test.go
+++ b/internal/engine/undo_test.go
@@ -1,0 +1,260 @@
+package engine
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// --- undo unit tests (→ ADR-0044, issue #168) --------------------------------
+
+// TestUndoOneUnlinksNewSymlink verifies undoUnlinkNew removes a freshly placed symlink.
+func TestUndoOneUnlinksNewSymlink(t *testing.T) {
+	dir := realTempDir(t)
+	target := filepath.Join(dir, "link")
+	if err := os.Symlink(dir, target); err != nil {
+		t.Fatal(err)
+	}
+	if err := undoOne(undoOp{kind: undoUnlinkNew, path: target}); err != nil {
+		t.Fatalf("undoOne: %v", err)
+	}
+	if _, err := os.Lstat(target); !os.IsNotExist(err) {
+		t.Fatalf("target must be gone after undo, lstat err = %v", err)
+	}
+}
+
+// TestUndoOneUnlinkNewToleratesAlreadyGone verifies undoUnlinkNew does not error when the
+// forward operation's own place already vanished (e.g. removed by an earlier, unrelated FS
+// change) — undo should not fail just because there is nothing left to remove.
+func TestUndoOneUnlinkNewToleratesAlreadyGone(t *testing.T) {
+	dir := realTempDir(t)
+	target := filepath.Join(dir, "already-gone")
+	if err := undoOne(undoOp{kind: undoUnlinkNew, path: target}); err != nil {
+		t.Fatalf("undoOne on an absent path must not error, got: %v", err)
+	}
+}
+
+// TestUndoOneRestoresRelink verifies undoRelinkOld removes the current symlink and recreates
+// it pointing at prevDest — the inverse of both a re-link (place's PlaceReplace/PlaceForeign)
+// and a plain removal (removeStale / PreRemove's RemoveUnlink).
+func TestUndoOneRestoresRelink(t *testing.T) {
+	dir := realTempDir(t)
+	target := filepath.Join(dir, "link")
+	oldDest := realTempDir(t)
+	newDest := realTempDir(t)
+	if err := os.Symlink(newDest, target); err != nil {
+		t.Fatal(err)
+	}
+	if err := undoOne(undoOp{kind: undoRelinkOld, path: target, prevDest: oldDest}); err != nil {
+		t.Fatalf("undoOne: %v", err)
+	}
+	got, err := os.Readlink(target)
+	if err != nil || got != oldDest {
+		t.Fatalf("readlink = %q, err %v; want %q", got, err, oldDest)
+	}
+}
+
+// TestUndoOneRestoresRelinkWhenTargetAbsent verifies undoRelinkOld recreates the symlink even
+// when the current path is already gone (removeStale/PreRemove's RemoveUnlink case: nothing to
+// unlink first, just recreate at prevDest).
+func TestUndoOneRestoresRelinkWhenTargetAbsent(t *testing.T) {
+	dir := realTempDir(t)
+	target := filepath.Join(dir, "removed")
+	oldDest := realTempDir(t)
+	if err := undoOne(undoOp{kind: undoRelinkOld, path: target, prevDest: oldDest}); err != nil {
+		t.Fatalf("undoOne: %v", err)
+	}
+	got, err := os.Readlink(target)
+	if err != nil || got != oldDest {
+		t.Fatalf("readlink = %q, err %v; want %q", got, err, oldDest)
+	}
+}
+
+// TestUndoOneRemovesCopy verifies undoRemoveCopy removes a freshly placed copy tree.
+func TestUndoOneRemovesCopy(t *testing.T) {
+	dir := realTempDir(t)
+	target := filepath.Join(dir, "copied")
+	if err := os.MkdirAll(filepath.Join(target, "nested"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(target, "nested", "f"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := undoOne(undoOp{kind: undoRemoveCopy, path: target}); err != nil {
+		t.Fatalf("undoOne: %v", err)
+	}
+	if _, err := os.Lstat(target); !os.IsNotExist(err) {
+		t.Fatalf("copy target must be gone after undo, lstat err = %v", err)
+	}
+}
+
+// TestUndoOneRestoresRename verifies undoRestoreRename discards the freshly recopied content
+// and renames the aside file back to its original path (→ ADR-0044 §1, --recopy rename-aside).
+func TestUndoOneRestoresRename(t *testing.T) {
+	dir := realTempDir(t)
+	target := filepath.Join(dir, "tool.conf")
+	aside := target + ".nput-recopy-aside"
+	if err := os.WriteFile(aside, []byte("original"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(target, []byte("freshly-recopied"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := undoOne(undoOp{kind: undoRestoreRename, path: target, tmpPath: aside}); err != nil {
+		t.Fatalf("undoOne: %v", err)
+	}
+	data, err := os.ReadFile(target)
+	if err != nil || string(data) != "original" {
+		t.Fatalf("target content = %q, err %v; want %q", data, err, "original")
+	}
+	if _, err := os.Lstat(aside); !os.IsNotExist(err) {
+		t.Fatalf("aside file must be consumed by the rename, lstat err = %v", err)
+	}
+}
+
+// TestUndoOneRecreatesEmptyDir verifies undoMkdir recreates a directory PreRemove's RemoveRmdir removed.
+func TestUndoOneRecreatesEmptyDir(t *testing.T) {
+	dir := realTempDir(t)
+	target := filepath.Join(dir, "emptied")
+	if err := undoOne(undoOp{kind: undoMkdir, path: target}); err != nil {
+		t.Fatalf("undoOne: %v", err)
+	}
+	info, err := os.Lstat(target)
+	if err != nil || !info.IsDir() {
+		t.Fatalf("target must be a recreated directory, lstat = %v, err %v", info, err)
+	}
+}
+
+// TestUnwindReversesJournalInLIFOOrder verifies unwind restores multiple journal entries in
+// last-in-first-out order — the order that correctly reverses a batch like "PreRemove unlinked a
+// child then rmdir-ed its now-empty parent": undo must mkdir the parent back before it can
+// recreate the child symlink inside it.
+func TestUnwindReversesJournalInLIFOOrder(t *testing.T) {
+	dir := realTempDir(t)
+	parent := filepath.Join(dir, "parent")
+	child := filepath.Join(parent, "child")
+	childDest := realTempDir(t)
+
+	// Simulate the forward operations PreRemove would have performed: unlink the child symlink,
+	// then rmdir the now-empty parent.
+	if err := os.Mkdir(parent, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(childDest, child); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(child); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(parent); err != nil {
+		t.Fatal(err)
+	}
+
+	var warns []string
+	a := &applier{opts: Options{Warnf: collectWarnings(&warns)}, result: &Result{}}
+	a.journalRelinkedSymlink(child, childDest) // pushed first (child unlinked first)
+	a.journalRemovedEmptyDir(parent)           // pushed second (parent rmdir-ed second)
+
+	a.unwind(errors.New("simulated failure"))
+
+	if _, err := os.Lstat(parent); err != nil {
+		t.Fatalf("parent must be recreated: %v", err)
+	}
+	got, err := os.Readlink(child)
+	if err != nil || got != childDest {
+		t.Fatalf("child readlink = %q, err %v; want %q (parent must exist before child recreation)", got, err, childDest)
+	}
+	if len(a.journal) != 0 {
+		t.Errorf("journal must be cleared after unwind, got %d entries", len(a.journal))
+	}
+}
+
+// TestUnwindBestEffortContinuesPastFailureAndReportsAll verifies unwind's best-effort contract
+// (→ ADR-0044 §3): when one journal entry cannot be undone (its path was removed out from under
+// it by something else), the rest of the journal is still unwound, and both the original error
+// and the specific unrestorable item are reported to Warnf.
+func TestUnwindBestEffortContinuesPastFailureAndReportsAll(t *testing.T) {
+	dir := realTempDir(t)
+	restorable := filepath.Join(dir, "restorable")
+	restorableDest := realTempDir(t)
+	unrestorable := filepath.Join(dir, "sub", "unrestorable") // parent "sub" does not exist → mkdir/symlink fails
+
+	var warns []string
+	a := &applier{opts: Options{Warnf: collectFormatted(&warns)}, result: &Result{}}
+	// Pushed in this order; unwind runs LIFO, so "unrestorable" is attempted first, then "restorable".
+	a.journalRelinkedSymlink(restorable, restorableDest)
+	a.journalRelinkedSymlink(unrestorable, realTempDir(t))
+
+	origErr := errors.New("simulated mid-apply failure")
+	a.unwind(origErr)
+
+	got, err := os.Readlink(restorable)
+	if err != nil || got != restorableDest {
+		t.Errorf("restorable entry must still be undone despite the other failing: readlink=%q, err=%v", got, err)
+	}
+
+	var sawOrigErr, sawUnrestorablePath bool
+	for _, w := range warns {
+		if strings.Contains(w, origErr.Error()) {
+			sawOrigErr = true
+		}
+		if strings.Contains(w, unrestorable) {
+			sawUnrestorablePath = true
+		}
+	}
+	if !sawOrigErr {
+		t.Errorf("warnings = %v, want the original error reported", warns)
+	}
+	if !sawUnrestorablePath {
+		t.Errorf("warnings = %v, want the unrestorable path named", warns)
+	}
+	if len(a.journal) != 0 {
+		t.Errorf("journal must be cleared even after a partial unwind failure, got %d entries", len(a.journal))
+	}
+}
+
+// TestUnwindNoJournalReportsOrigErrOnly verifies unwind on an empty journal (a failure before any
+// FS write happened yet) just reports the original error without a spurious "N item(s)" line.
+func TestUnwindNoJournalReportsOrigErrOnly(t *testing.T) {
+	var warns []string
+	a := &applier{opts: Options{Warnf: collectFormatted(&warns)}, result: &Result{}}
+	origErr := errors.New("failed before any FS write")
+	a.unwind(origErr)
+
+	if len(warns) != 1 {
+		t.Fatalf("warns = %v, want exactly one line", warns)
+	}
+	if !strings.Contains(warns[0], origErr.Error()) {
+		t.Errorf("warns[0] = %q, want it to mention the original error", warns[0])
+	}
+}
+
+// TestDiscardJournalRemovesRecopyAsideFiles verifies discardJournal — called after a successful
+// commit — cleans up any --recopy rename-aside files left behind, since undo was never triggered
+// and the fresh copies already landed successfully (→ ADR-0044).
+func TestDiscardJournalRemovesRecopyAsideFiles(t *testing.T) {
+	dir := realTempDir(t)
+	target := filepath.Join(dir, "tool.conf")
+	aside := target + ".nput-recopy-aside"
+	if err := os.WriteFile(aside, []byte("old"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(target, []byte("new"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var warns []string
+	a := &applier{opts: Options{Warnf: collectWarnings(&warns)}, result: &Result{}}
+	a.journalRenamedAside(target, aside)
+
+	a.discardJournal()
+
+	if _, err := os.Lstat(aside); !os.IsNotExist(err) {
+		t.Errorf("aside file must be removed by discardJournal, lstat err = %v", err)
+	}
+	if len(a.journal) != 0 {
+		t.Errorf("journal must be cleared, got %d entries", len(a.journal))
+	}
+}

--- a/internal/engine/undo_test.go
+++ b/internal/engine/undo_test.go
@@ -155,7 +155,7 @@ func TestUnwindReversesJournalInLIFOOrder(t *testing.T) {
 	var warns []string
 	a := &applier{opts: Options{Warnf: collectWarnings(&warns)}, result: &Result{}}
 	a.journalRelinkedSymlink(child, childDest) // pushed first (child unlinked first)
-	a.journalRemovedEmptyDir(parent)           // pushed second (parent rmdir-ed second)
+	a.journalRemovedEmptyDir(parent, 0o755)    // pushed second (parent rmdir-ed second)
 
 	a.unwind(errors.New("simulated failure"))
 


### PR DESCRIPTION
## 概要

<!-- なぜ・何を変えるか。Conventional Commits のタイトルだけでは残らない背景を書く。 -->

apply / rollback が途中で失敗したとき、その run が行った FS 変更を全て巻き戻し pre-apply 状態へ復元する「インメモリ undo ジャーナル」を実装する（フラグなし・常時有効）。

現状、途中失敗は世代未コミットのままだが FS には部分配置が残り、失敗 run が置いた新規 entry は前世代 manifest に記録されず `reset` でも拾えない（初回 apply 失敗時は `reset` が完全 no-op）。本 PR で「失敗した apply は FS に痕跡を残さない」を apply の意味論として仕様化する。

- `applier` に journal を追加し、PreRemove / place / materializeCopies / removeStale の各 FS 書き込み成功ごとに逆操作を記録する。いずれかの段でエラーが発生したら journal を LIFO で巻き戻し、pre-apply 状態を復元してからエラーを返す
- `--recopy` の上書きは削除ではなく同一親内への rename 退避に変更し、成功時は退避物を削除、途中失敗時は rename back する（rename はメタデータ操作のみで ENOSPC 下でも退避が壊れない）
- `nix-env --set`（commit）成功後は journal を破棄する。commit 自体の失敗は巻き戻し対象外（既存の冪等再実行による収束に委ねる）
- undo 自体の失敗は best-effort で継続し、元エラーと未復元項目を全件 stderr へ報告する
- クラッシュ（SIGKILL・電源断）はスコープ外（ADR-0006 / ADR-0017 の既存バックストップに委ねる）
- Apply・Rollback の双方に同じ機構を配線し、世代スキップ経路の drift 修復（repairDrift）も同じ journal/unwind を通す

diff-review（design / test 両レンズ）を 3 往復かけてクリアしている。

## 関連 issue

<!-- 例: Closes #N / Refs #N。なければ「なし」。 -->

Closes #168
Refs #172

## docs / ADR 影響

<!--
このリポジトリはドキュメント主導。配置動作・API・方針に触れる変更は docs の更新がセットになる。
- concept / design / spec の更新有無
- 方針転換や trade-off を伴うなら ADR を追加したか（docs/adr/）
影響がなければ「なし」と明記する。
-->

- `docs/adr/0044-undo-journal-for-partial-apply-failure.md` を新規起票（本 PR の設計決定）
- `docs/adr/0046-*.md` §5・`docs/adr/0047-*.md` 影響節に、両 ADR が undo ジャーナル実装への seam として残していた記述への改訂注記を追記
- `docs/spec.md` の実行フロー・張替え意味論・エラー仕様表・recopy 節に、途中失敗時の巻き戻し仕様を反映
