### PR TITLE
feat(cli,hm): apply --backup[=suffix] を追加する

### DIFF
--- a/cmd/nput/apply.go
+++ b/cmd/nput/apply.go
@@ -24,6 +24,7 @@ func newApplyCmd() *cobra.Command {
 			"--all applies all of nput.* in lexical order; --project-root / --home-root / --system-root narrow by root mode.",
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			flagBackupEnabled = cmd.Flags().Changed("backup")
 			if flagApplyAll {
 				if len(args) > 0 {
 					return fmt.Errorf("nput: apply cannot combine <name> with --all")
@@ -47,6 +48,9 @@ func newApplyCmd() *cobra.Command {
 		"Show place/replace/remove/conflict/no-op with zero side effects (exit 2 on conflict; see ADR-0006)")
 	cmd.Flags().StringVar(&flagManifest, "manifest", "",
 		"Apply a pre-built manifest (link-farm path) directly (host/module activation seam; no entrypoint discovery or nix eval/build; see ADR-0026)")
+	cmd.Flags().StringVar(&flagBackup, "backup", "",
+		"Back up an occupying foreign entity to \"<target>.<suffix>\" before placing, instead of stopping on conflict (bare --backup uses suffix \"nput-backup\"; \"=\" form required for a custom suffix, e.g. --backup=bak; see ADR-0045)")
+	cmd.Flags().Lookup("backup").NoOptDefVal = "nput-backup"
 	return cmd
 }
 
@@ -66,6 +70,8 @@ func runApplyManifest(name string) error {
 		RootOverride: flagRoot,
 		NoWait:       flagNoWait,
 		Recopy:       flagRecopy,
+		Backup:       flagBackupEnabled,
+		BackupSuffix: flagBackup,
 	})
 	if err != nil {
 		if errors.Is(err, engine.ErrSkipped) {
@@ -120,6 +126,8 @@ func runApply(name string) error {
 			FixedRoot:    fixedRoot,
 			RootOverride: flagRoot,
 			Recopy:       flagRecopy,
+			Backup:       flagBackupEnabled,
+			BackupSuffix: flagBackup,
 			DryRun:       true,
 			Build:        dryBuildFunc(ep, system, name),
 		})
@@ -169,6 +177,9 @@ func printApplyPlan(res *engine.Result) {
 	for _, t := range res.Removed {
 		fmt.Printf("remove\t%s\n", t)
 	}
+	for _, t := range res.BackedUp {
+		fmt.Printf("backup\t%s\n", t)
+	}
 	for _, c := range res.Conflicts {
 		fmt.Printf("conflict\t%s\n", c)
 	}
@@ -184,6 +195,8 @@ func applyOne(ep *entrypoint, system, name, rootKind, fixedRoot string) (*engine
 		RootOverride: flagRoot,
 		NoWait:       flagNoWait,
 		Recopy:       flagRecopy,
+		Backup:       flagBackupEnabled,
+		BackupSuffix: flagBackup,
 		Build:        buildFunc(ep, system, name),
 	})
 }
@@ -269,6 +282,8 @@ func runApplyAllDryRun(ep *entrypoint, system string, selected []string, roots m
 			FixedRoot:    ri.Root,
 			RootOverride: flagRoot,
 			Recopy:       flagRecopy,
+			Backup:       flagBackupEnabled,
+			BackupSuffix: flagBackup,
 			DryRun:       true,
 			Build:        dryBuildFunc(ep, system, name),
 		})
@@ -395,7 +410,10 @@ func reportResult(res *engine.Result, name string) {
 	for _, t := range res.Pruned {
 		fmt.Fprintf(os.Stderr, "  pruned   %s\n", t)
 	}
-	if len(res.Placed)+len(res.Replaced)+len(res.Copied)+len(res.Recopied)+len(res.Removed)+len(res.Pruned) == 0 {
+	for _, t := range res.BackedUp {
+		fmt.Fprintf(os.Stderr, "  backedUp %s\n", t)
+	}
+	if len(res.Placed)+len(res.Replaced)+len(res.Copied)+len(res.Recopied)+len(res.Removed)+len(res.Pruned)+len(res.BackedUp) == 0 {
 		fmt.Fprintln(os.Stderr, "  no-op")
 	}
 }

--- a/cmd/nput/apply_test.go
+++ b/cmd/nput/apply_test.go
@@ -50,6 +50,27 @@ func captureStdout(t *testing.T, f func()) string {
 	return <-done
 }
 
+// captureStderr is captureStdout's stderr counterpart (verifies reportResult's placement report,
+// which is stderr-owned by ADR-0023's stream discipline · → docs/spec.md "出力ストリームと終了コード").
+func captureStderr(t *testing.T, f func()) string {
+	t.Helper()
+	old := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stderr = w
+	done := make(chan string, 1)
+	go func() {
+		b, _ := io.ReadAll(r)
+		done <- string(b)
+	}()
+	f()
+	_ = w.Close()
+	os.Stderr = old
+	return <-done
+}
+
 // Verifies aggregateDryRun's aggregate exit code and plan output (stdout ownership) by injecting the apply
 // implementation, without nix. This is the regression guard for the real path of #14 AC-4 "error(1) > conflict(2) > 0".
 func TestAggregateDryRun(t *testing.T) {
@@ -186,4 +207,43 @@ func TestSelectedRootFilter(t *testing.T) {
 			t.Fatal("specifying multiple should be an error")
 		}
 	})
+}
+
+// TestPrintApplyPlanBackupLine verifies apply --dryrun's plan output includes a "backup\t<target>"
+// line for a planned backup, alongside the existing place/replace/copy/remove lines (→ ADR-0045).
+func TestPrintApplyPlanBackupLine(t *testing.T) {
+	out := captureStdout(t, func() {
+		printApplyPlan(&engine.Result{BackedUp: []string{".config/foo"}})
+	})
+	if !strings.Contains(out, "backup\t.config/foo") {
+		t.Errorf("printApplyPlan output = %q, want a line containing %q", out, "backup\t.config/foo")
+	}
+}
+
+// TestReportResultBackupLineAndNoOp verifies reportResult's -v placement report includes a
+// "backedUp <target>" line for a backup-only run, and does NOT report it as "no-op" — a run that
+// only backed up an entity still did something, even though Placed/Replaced/Copied/Removed/Pruned
+// are all empty (→ ADR-0045; regression guard: reportResult's no-op check must count BackedUp too).
+func TestReportResultBackupLineAndNoOp(t *testing.T) {
+	out := captureStderr(t, func() {
+		reportResult(&engine.Result{Root: "/root", BackedUp: []string{".config/foo"}}, "c")
+	})
+	if !strings.Contains(out, "backedUp .config/foo") {
+		t.Errorf("reportResult output = %q, want a line containing %q", out, "backedUp .config/foo")
+	}
+	if strings.Contains(out, "no-op") {
+		t.Errorf("reportResult output = %q, must not report no-op when BackedUp is non-empty", out)
+	}
+}
+
+// TestReportResultAllEmptyIsNoOp is the counterpart of TestReportResultBackupLineAndNoOp: a truly
+// empty Result (including BackedUp) must still report "no-op" (pre-existing behavior, unchanged by
+// the BackedUp addition to the no-op check).
+func TestReportResultAllEmptyIsNoOp(t *testing.T) {
+	out := captureStderr(t, func() {
+		reportResult(&engine.Result{Root: "/root"}, "c")
+	})
+	if !strings.Contains(out, "no-op") {
+		t.Errorf("reportResult output = %q, want it to report no-op for a fully empty Result", out)
+	}
 }

--- a/cmd/nput/backup_flag_test.go
+++ b/cmd/nput/backup_flag_test.go
@@ -1,0 +1,58 @@
+package main
+
+import "testing"
+
+// TestApplyBackupFlagParsing verifies apply --backup[=suffix]'s cobra optional-value wiring
+// (→ ADR-0045, issue #169): bare --backup uses the NoOptDefVal default suffix, --backup=<suffix>
+// (the "=" form) takes the given suffix, and a bare next token is NOT consumed as the flag's value
+// (it is left as a positional argument) — the spec's "=" 区切り必須 requirement.
+func TestApplyBackupFlagParsing(t *testing.T) {
+	t.Run("absent: Changed is false", func(t *testing.T) {
+		cmd := newApplyCmd()
+		if err := cmd.ParseFlags([]string{"name"}); err != nil {
+			t.Fatalf("ParseFlags: %v", err)
+		}
+		if cmd.Flags().Changed("backup") {
+			t.Error("Changed(\"backup\") = true, want false when --backup is absent")
+		}
+	})
+
+	t.Run("bare --backup uses the default suffix", func(t *testing.T) {
+		cmd := newApplyCmd()
+		if err := cmd.ParseFlags([]string{"--backup", "name"}); err != nil {
+			t.Fatalf("ParseFlags: %v", err)
+		}
+		if !cmd.Flags().Changed("backup") {
+			t.Error("Changed(\"backup\") = false, want true")
+		}
+		got, err := cmd.Flags().GetString("backup")
+		if err != nil {
+			t.Fatalf("GetString(backup): %v", err)
+		}
+		if got != "nput-backup" {
+			t.Errorf("bare --backup value = %q, want %q (NoOptDefVal)", got, "nput-backup")
+		}
+		// The bare form must not swallow the next token as its value (space-separated form
+		// rejected by design): "name" must remain a positional arg, not the flag's value.
+		if args := cmd.Flags().Args(); len(args) != 1 || args[0] != "name" {
+			t.Errorf("positional args after bare --backup = %v, want [name] (next token must not be consumed as the flag value)", args)
+		}
+	})
+
+	t.Run("--backup=<suffix> takes the custom suffix", func(t *testing.T) {
+		cmd := newApplyCmd()
+		if err := cmd.ParseFlags([]string{"--backup=bak", "name"}); err != nil {
+			t.Fatalf("ParseFlags: %v", err)
+		}
+		if !cmd.Flags().Changed("backup") {
+			t.Error("Changed(\"backup\") = false, want true")
+		}
+		got, err := cmd.Flags().GetString("backup")
+		if err != nil {
+			t.Fatalf("GetString(backup): %v", err)
+		}
+		if got != "bak" {
+			t.Errorf("--backup=bak value = %q, want %q", got, "bak")
+		}
+	})
+}

--- a/cmd/nput/main.go
+++ b/cmd/nput/main.go
@@ -31,6 +31,14 @@ var (
 	flagHomeRoot    bool   // --home-root: apply --all modifier; apply only homeRoot configs
 	flagSystemRoot  bool   // --system-root: apply --all modifier; apply only systemRoot configs (future seam)
 	flagManifest    string // --manifest: apply a pre-built manifest (link-farm) directly (for module activation)
+	// flagBackup / flagBackupEnabled are --backup[=suffix] (apply modifier; → ADR-0045, issue #169): a
+	// cobra optional-value flag (NoOptDefVal = "nput-backup"). Bare --backup sets flagBackup to the
+	// default suffix; --backup=<suffix> (the "=" form only — cobra's NoOptDefVal treats a bare next
+	// token as a positional arg, not a space-separated value) sets it to <suffix>. flagBackupEnabled
+	// distinguishes "flag absent" from "flag present" (flagBackup alone can't: its value is never empty
+	// either way), set from cmd.Flags().Changed("backup") in apply's RunE.
+	flagBackup        string
+	flagBackupEnabled bool
 )
 
 // exitError is an error carrying a specific exit code that cobra RunE returns (→ docs/spec.md exit code table).

--- a/docs/adr/0044-undo-journal-for-partial-apply-failure.md
+++ b/docs/adr/0044-undo-journal-for-partial-apply-failure.md
@@ -88,3 +88,12 @@ ADR-0046 §5・ADR-0047 影響節が seam として残した「PreRemove を und
 - **rename ベースの atomic スナップショット（apply 前に対象ツリー全体を退避）**: target ごとに一時コピーを作る必要があり、大きなツリーではコストが跳ねる。undo ジャーナルは「変更した分だけ」逆操作を記録するため、変更量に比例したコストで済む。
 - **unwind 失敗時に即中断**: 1 個の失敗で残りの巻き戻しを諦めると、まだ戻せたはずの項目まで未復元のまま放置される。best-effort 続行の方が pre-apply 状態への近さを最大化する。
 - **PreRemove を undo 対象外にする（ADR-0046/0047 の移行は冪等再実行の収束のみに委ねる）**: ADR-0046 §5 が容認した選択だが、本 ADR で undo ジャーナルを実装する以上、PreRemove だけ例外的に粗い保証のままにする理由がない。一般化する方が意味論として一貫する。
+
+> **2026-07-12 改訂注記（ADR-0045）**: 本 ADR §5 影響節が予告した「#169（`--backup`）は本 ADR に完全直列 stack。
+> `--backup` の退避操作も journal 化対象になる」は #169（ADR-0045）で実装された。`apply --backup` の rename 退避は
+> Plan の新しいステージ `Backup`（PreRemove → Backup → Place / Copies → 除去）として実行され、新しい undo kind
+> `undoRestoreBackup` で本 ADR の journal/unwind 機構にそのまま乗る。ただし commit 成功後の扱いは非対称: `--recopy`
+> の退避物（`undoRestoreRename`）は成功時に `discardJournal` が削除するが、`--backup` の退避物は成功時も削除せず
+> 永続的に残す（ユーザー所有物として引き渡す・→ ADR-0045 §5）。この非対称のために `undoRestoreRename` とは別の
+> undo kind を割り当てている。本 ADR の journal/unwind の骨格（逆順 LIFO・best-effort 続行・commit 後は対象外）
+> 自体は不変。

--- a/docs/adr/0045-backup-flag-for-foreign-entity-rename-aside.md
+++ b/docs/adr/0045-backup-flag-for-foreign-entity-rename-aside.md
@@ -1,0 +1,89 @@
+# ADR-0045: `apply --backup[=suffix]` — 配置を塞ぐ記録外実体の rename 退避
+
+- ステータス: 採用
+- 日付: 2026-07-12
+- 関連: ADR-0002, ADR-0006, ADR-0015, ADR-0017, ADR-0020, ADR-0044, ADR-0046, ADR-0047, `docs/spec.md`, GitHub Issue #169, #172
+- 起点: 旧 epic #167 から統合された epic #172 の grilling セッション（2026-07-11・2026-07-12）で確定
+
+## 背景
+
+nput は配置先に記録外の実体（foreign な通常ファイル・ディレクトリ、copy の構造不一致、method 変更 copy→symlink 等）があると、保守的不変条件（→ ADR-0002, ADR-0006, ADR-0015）に従って **conflict で停止し上書きしない**。これはユーザーデータを誤って失わないための正しい既定だが、実運用では「このファイルは既に見て、上書きして問題ないと分かっている」場面が頻発する（dotfiles を nput 管理へ移行する初回・手動で作った設定ファイルを置き換える等）。現状の唯一の回避策は毎回手動 `mv` してから再実行することで、複数 entry が同時に conflict すると 1 件ずつ「確認 → 手動退避 → 再実行」を繰り返す運用コストが高い。
+
+ADR-0047（PreRemove 一般化）は「自己記録の stale」を自動移行する範囲を広げたが、**foreign（記録外）実体は意図的にスコープ外**のままにした（他人のデータを nput が判定なしに動かすのは危険なため）。`--backup` はこのギャップを埋める、**ユーザーが明示 opt-in したときだけ**foreign 実体を退避する脱出ハッチである。
+
+## 決定
+
+### 1. CLI: `apply --backup[=suffix]`（cobra `NoOptDefVal`・`=` 区切り必須）
+
+`--backup` は値なしで指定すると既定 suffix `nput-backup` を使う。`--backup=bak` のように `=` で明示すればその suffix を使う。cobra の `NoOptDefVal`（optional-value flag）で実装するため、**スペース区切り `--backup bak` は次の位置引数として扱われ suffix にならない**（`bak` は `apply` の `<name>` 引数と誤認されるか、位置引数エラーになる）。これは `NoOptDefVal` フラグの一般的な制約であり、ユーザーには spec で明記して周知する。
+
+退避先は常に `<target>` に `.` を付与した `<target>.<suffix>` で固定する（entry ごとの退避先カスタマイズは提供しない）。
+
+### 2. 適用範囲: 配置を塞ぐ記録外実体全般。祖先 symlink conflict は対象外
+
+`--backup` が退避対象にするのは、実体を持つ既存物のうち以下（全て「記録外 = foreign、または nput 管理下でも安全に自動移行できないと ADR-0047 が判断したケース」）:
+
+- symlink モードの通常ファイル / ディレクトリ conflict（`ConflictForeignEntity`）
+- symlink モードで実 dir target の migration が失敗するケース（ADR-0047 の「配下に中身のある foreign が 1 つでもあれば dir 全体を conflict」）— **dir 全体を 1 回の rename で退避**する。ADR-0047 D2 の「部分除去はしない」方針をそのまま踏襲し、退避も全か無かで行う
+- copy モードの構造不一致（`ConflictCopyStructureMismatch`）
+- copy モードで foreign な実ファイルが place-once の skip 対象になるケース（`WarnCopyForeign`）— 通常は skip + warning だが、`--backup` 有効時は退避してから copy を新規配置する（この場合 warning は出さない。退避自体が可視化を兼ねるため）
+- method 変更 copy→symlink（ADR-0047 D5 が「ユーザー編集済み copy データの保護を優先し自動移行しない」と決めたケース）— `--backup` はこの D5 が明示的に残した脱出ハッチ
+
+**祖先 symlink conflict（`ConflictForeignAncestor` / `ConflictSelfContradictoryAncestor`）は `--backup` の対象外のまま**にする。これは「実体の有無」ではなく「ネスト構造がそもそも成立しない」という構造問題であり、退避しても解決しない（祖先を退避すると配下の別 entry のネスト前提が崩れる可能性があり、単純な 1:1 rename では表現できない）。祖先 symlink 問題の解消手段は entry 定義の見直しであって `--backup` の役割ではない。
+
+### 3. 退避先が既存なら conflict で停止（黙って上書きしない）
+
+`<target>.<suffix>` が既に存在する場合（前回の `--backup` 実行の退避物が残っている等）、新しい `ConflictKind`（`ConflictBackupTargetExists`）で conflict にし、ADR-0044 の巻き戻しで apply 全体を pre-apply 状態へ戻す。前回の退避物を黙って上書き・消去しない — `--backup` はユーザーデータを守るための機能であり、その退避物自体を粗雑に扱っては本末転倒になる。
+
+### 4. `--backup` の rename も undo ジャーナル対象（ADR-0044 に統合）
+
+`--backup` の rename 退避は Plan の新しいステージ `Backup`（実行順序: PreRemove → **Backup** → Place / Copies → 除去）として engine が実行し、ADR-0044 の undo ジャーナルにそのまま乗る。apply が後続の段で失敗すれば、退避した実体は自動的に元の場所へ rename back される。
+
+ただし **commit 成功後の扱いは `--recopy` の rename 退避と非対称**にする: `--recopy` の退避物（`asidePath`）は成功時に削除される一時的な overwrite debris だが、`--backup` の退避物は**成功時も削除せず永続的に残す**（§5 参照）。undo journal の内部実装では、この非対称を表現するために `--recopy` と異なる undo kind（`undoRestoreBackup`）を割り当て、`discardJournal`（commit 成功後のクリーンアップ）がこの kind だけをスイープ対象から除外する。
+
+世代スキップ経路（project mode の drift 修復・`repairDrift`）にも `--backup` は適用する。PreRemove と異なり、Backup が発火する条件（target に記録外の実体がある）は manifest / derivation の変化を前提としない（他ツールが shell 再入の間に target へファイルを置く、といった FS 状態変化だけで起こり得る）ため、「derivation 不変なら PreRemove は構造的に空」という ADR-0047 の不変条件を Backup には適用できない。
+
+### 5. `reset` は退避物を復元しない。退避物はユーザー所有物として残置する
+
+`--backup` で退避されたファイルは、以後 nput の管理対象に一切ならない。`nput reset` はそれを検出も復元もしない（reset レポートにも現れない）。復元が必要な場合はユーザーが手動 `mv` する。これは「nput が動かした事実は必ず可視化するが、動かした後の所有権はユーザーに戻す」という単純な線引きで、`--recopy` の rename 退避（apply 内で完結する一時操作）とは性質が異なる。
+
+### 6. 出力規律: 退避発動は warning 級・常時 stderr。`--dryrun --backup` は非 conflict
+
+退避が発生した事実は「ユーザー所有物を動かした」という重い意味を持つため、**既定 silent（→ ADR-0031）の対象にせず、常に stderr へ出す**（`-v` 無しでも出る）。`apply --dryrun --backup` は、`--backup` 無しなら conflict（exit 2）になる箇所を「backup + 配置予定」という非 conflict のプランに変える（exit 0）。退避先が既存の場合は `--dryrun --backup` でも conflict のままである（§3 は dryrun でも計算されるため）。
+
+### 7. JSON: `backedUp` を niface 枠内へ追加
+
+`--json`（→ ADR-0043）の結果ペイロードに、`removed` / `pruned` 等と並ぶ形で `backedUp`（退避した target の配列）を追加する。詳細なフィールド設計は epic #126 の niface 詳細化と合わせて詰める（本 ADR は「追加する」という方針のみ確定し、実装は #126 との seam 調整に委ねる）。
+
+### 8. HM モジュール: `nput.backup.enable` + `nput.backup.suffix`
+
+`nput.backup`（submodule。`enable :: bool`・`suffix :: str`、既定 `nput-backup`）を全モジュール共通オプションに追加する。`enable = true` のとき、activation の `nput apply --manifest <link-farm>` 起動へ `--backup=<suffix>` を付加する。これは**起動配線レイヤーのみの変更**であり、manifest v1 契約（`lib/types.nix` の `entriesType` / `mkManifest` の出力）には一切触れない。`nput.entries` の各 entry に `backup` 相当のオプションは追加しない（`--backup` は apply 全体の modifier であり、entry 単位の粒度は提供しない — CLI と同じ設計）。
+
+## 根拠
+
+- **祖先 symlink conflict を対象外にする**のは、ADR-0015/0046/0047 が「実体を持つ記録外物」と「ネスト構造の破綻」を明確に区別してきた設計を崩さないため。`--backup` は前者（rename で解決できる問題）にのみ効く道具であり、後者に無理に適用すると「動いたように見えて実は別の問題を隠す」footgun になる。
+- **dir target の migration 失敗を全体 1 回で退避する**のは、ADR-0047 D2 の「部分除去はしない」という一貫性を保つため。dir 内の一部だけ退避すると、退避後の残骸と新配置後の状態が入り混じり、ユーザーが何が起きたか把握しにくくなる。
+- **退避先が既存なら conflict にする**のは、`--backup` が守ろうとしているのがまさに「ユーザーの既存データ」であり、その退避物自体を上書きしては目的と矛盾するため。冪等な繰り返し実行より安全側に倒す。
+- **成功時に退避物を残置する（`--recopy` と非対称にする）**のは、`--recopy` の退避が「apply 内で完結する一時的な overwrite 手順」であるのに対し、`--backup` の退避は「ユーザーへの成果物の引き渡し」だから。`--recopy` と同じ扱いで自動削除すると、`--backup` の存在意義（データを失わず確認できる）が消える。
+- **世代スキップ経路でも Backup を実行する**のは、target への foreign 実体の出現が config 内容と無関係な FS イベントであり、drift 修復のたびに `--backup` が無効化されると "shell を再入したら安全機構が働かなかった" という驚きを生むため。
+- **HM の `nput.backup` を manifest 契約から独立させる**のは、`--backup` が「配置ロジックの一部」ではなく「起動時の modifier」だから。ADR-0026（`--manifest` seam）の設計と同じく、モジュールは engine の CLI 引数を組み立てるだけで、engine 自体の判定ロジックには関与しない。
+
+## 影響
+
+- **`internal/planner/planner.go`**: `Compute` に `Options{Backup bool; Suffix string}` を追加。`Plan` に `Backup []BackupAction` を追加。既存の conflict / skip 発生源（`ConflictForeignEntity` の一部・実 dir migration 失敗・`ConflictCopyStructureMismatch`・`WarnCopyForeign`・method 変更 copy→symlink）を、`Options.Backup` が有効なとき conflict/skip の代わりに `BackupAction` へ振り替える共通ヘルパー（`appendBackupOrConflict` / `appendBackup`）を追加。新しい `ConflictKind`（`ConflictBackupTargetExists`）を追加。祖先 symlink 分岐（`ancestorSymlink` 由来）には手を入れない。
+- **`internal/engine/backup.go`**（新設）: `applier.backup(actions []planner.BackupAction) error` — PreRemove の後・Place/materializeCopies の前に実行し、rename 退避を行う。TOCTOU 再検証（rename 直前に退避先の非存在を再確認）を行う。
+- **`internal/engine/undo.go`**: 新しい undo kind `undoRestoreBackup` を追加（`undoRestoreRename` と同じ逆操作だが、`discardJournal` のクリーンアップ対象から除外する点が異なる）。
+- **`internal/engine/engine.go`**: `Apply` の実行順序に Backup ステージを追加（PreRemove → Backup → Place → Copies → 除去）。`Options` に `Backup bool` / `BackupSuffix string` を追加。`Result` に `BackedUp []string` を追加。`dryRun` にも同じ分類を反映。`repairDrift`（世代スキップ）にも Backup 実行を追加。`conflictGuidance` に `ConflictBackupTargetExists` のガイダンスを追加。
+- **`cmd/nput/apply.go`**: `--backup` フラグ（`StringVar` + `NoOptDefVal = "nput-backup"`）を追加し、`cmd.Flags().Changed("backup")` で有効判定する。`printApplyPlan` / `reportResult` に `backup` / `backedUp` 行を追加。
+- **`modules/common.nix`**: `nput.backup`（submodule: `enable` / `suffix`）を追加。
+- **`modules/home-manager.nix`**: activation スクリプトへ `--backup=<suffix>` を条件付きで付加する配線を追加。
+- **`docs/spec.md`**: CLI リファレンス・グローバルフラグ・配置動作仕様（symlink/copy モード）・途中失敗時の巻き戻し・エラー仕様表・conflict の全件報告・モジュールオプション仕様を更新。
+- **cross-epic**: 本 ADR は #168（ADR-0044）に完全直列 stack。#126（`--json` epic）とは `backedUp` フィールドの詳細設計で seam 調整が必要（本 ADR は方針のみ確定）。
+
+## 棄却した代替案
+
+- **entry 単位の `backup` オプション（`nput.entries.<key>.backup`）**: 個々の entry ごとに退避可否を制御できて柔軟に見えるが、実運用で「この apply 実行だけ安全側に倒したい」というのはほぼ全 entry 一括の要求であり、entry 単位の粒度は使われない複雑さを追加するだけになる。CLI の `--backup` は apply 全体の modifier として設計されており、HM モジュールもそれをそのまま反映する方が一貫する。
+- **祖先 symlink conflict も `--backup` の対象に含める**: 祖先を退避すると配下の複数 entry のネスト前提が同時に崩れる可能性があり、単純な 1 target ↔ 1 backup destination のモデルでは表現しきれない。将来必要になれば別 ADR で設計する。
+- **退避先が既存でも上書きする（`--force` 的な二段階オプトイン）**: 「安全のための機能」自身が別のデータ損失経路になるのは本末転倒。二段階オプトインは UX の複雑化に対して得られる利便性が小さい。
+- **成功時に退避物を自動削除する（`--recopy` と同じ扱い）**: `--backup` の目的が「安全に確認してから消せるようにする」ことである以上、apply 成功と同時に消えてしまっては目的を果たさない。
+- **`.` ではなく別の区切り文字、または dotfile 形式（`.<target>.bak`）にする**: `<target>.<suffix>` は既存の `--recopy` の `asidePath`（`<target>.nput-recopy-aside`）と同じ命名規則で一貫性があり、ユーザーが `ls` で見たときに一目で分かる。dotfile 形式は隠しファイル化してしまい、退避の可視性という本 ADR の目的（§6）と逆行する。

--- a/docs/adr/0047-preremove-generalization.md
+++ b/docs/adr/0047-preremove-generalization.md
@@ -92,6 +92,14 @@ ADR-0046 §3 で導入した「PreRemove は最終段の removeStale と違い�
 > 自動巻き戻しされる（Unlink → 記録 dest で symlink 再作成・Rmdir → `os.Mkdir` で再作成）。本 ADR の migration 判定
 > 条件（D1〜D5）・drift 時 error 停止（D3）自体は不変（→ ADR-0044）。
 
+> **2026-07-12 改訂注記（ADR-0045）**: 本 ADR §2 が「copy→symlink は自動移行しない。`--backup`（#169・別 issue）が
+> 脱出ハッチになる」と予告した動作は #169（ADR-0045）で実装された。`apply --backup` は copy→symlink の method 変更
+> だけでなく、本 ADR がスコープ外のまま残した「配置を塞ぐ記録外（foreign）実体」全般（symlink モードの foreign
+> 実 file/dir・実 dir migration 失敗・copy 構造不一致・copy foreign skip）を、ユーザーの明示 opt-in のもとで
+> `<target>.<suffix>` へ rename 退避してから配置する。本 ADR の migration 判定条件（D1〜D5。「foreign は対象外」の
+> 既定・祖先 symlink conflict の扱い）自体は不変 — `--backup` はこれらの conflict を消すのではなく、conflict の代わりに
+> 退避という選択肢を追加するオプトイン層である（→ ADR-0045）。
+
 ## 棄却した代替案
 
 - **全面反転（home-manager 型の remove→place の完全対称・2 段化）**: 依存除去のみ前段化する現行方式（ADR-0006 の本流順序は不変）ではなく、独立 stale 除去まで含めて全面的に「先に全部消してから全部置く」設計にすると、rename（target A 削除 + B 追加）のような独立除去まで前段化することになる。除去後・配置前でクラッシュすると新旧どちらのパスにも実体が無い瞬間が生じる（home-manager はこれを受容しているが、nput は成功時の挙動を home-manager と同一に保ちながらクラッシュ耐性は上位互換にしたい）。依存除去のみ前段化すれば、この窓は開かない。

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -200,6 +200,8 @@ nput apply                     # name 省略時は nput.default を適用（flak
 nput apply <name>              # nput.<name> をビルドし新世代を作って適用
 nput apply <name> --dryrun     # dry-run。副作用ゼロで place/replace/remove/conflict/no-op を表示
 nput apply <name> --recopy     # 通常 apply に加え config 内の全 copy target を src から無条件上書き再コピー（→ ADR-0020）
+nput apply <name> --backup           # 既存の記録外実体を <target>.nput-backup へ rename 退避してから配置（既定 suffix・→ ADR-0045）
+nput apply <name> --backup=<suffix>  # 退避 suffix を明示（"=" 区切り必須・スペース区切り不可・→ ADR-0045）
 nput apply --manifest <link-farm>  # ビルド済み link-farm を直接適用（entrypoint 発見・eval/build なし・host/module activation seam・→ ADR-0026）
 nput reset <name> [target...]  # 配置物を無い状態へ戻す。target 省略で全 entry、指定でその entry のみ。名指し必須（--all 非対応）（→ ADR-0020, ADR-0021）
 nput reset <name> --dryrun     # 副作用ゼロで削除対象（symlink / copy target）を表示して exit（confirm/flock なし・→ ADR-0021）
@@ -226,6 +228,8 @@ nput init <template>           # nix flake init -t <nput>#<template> のラッ�
 --home-root         # --all の修飾。homeRoot の config のみ適用
 --system-root       # --all の修飾。systemRoot の config のみ適用（system mode は未実装のため当面マッチなし・将来 seam）
 --recopy            # apply の修飾。config 内の全 copy target を src から無条件上書き再コピー（→ ADR-0020）
+--backup[=<suffix>] # apply 専用。既存の記録外実体を <target>.<suffix> へ rename 退避してから配置（cobra NoOptDefVal。
+                    # 値なし = suffix "nput-backup"。suffix 指定は "=" 区切り必須・スペース区切り不可・→ ADR-0045）
 --manifest <path>   # apply 専用。ビルド済み link-farm を直接適用（entrypoint 発見・eval/build なし・host/module activation seam・→ ADR-0026）
 -y, --yes           # reset の確認プロンプトをスキップ（スクリプト / CI 用・→ ADR-0020）
 ```
@@ -240,11 +244,12 @@ nput init <template>           # nix flake init -t <nput>#<template> のラッ�
 - `rollback` は **名指し必須**（`--all` 非対応）。全 config を一斉に戻すのは破壊的で footgun、途中失敗で状態が不揃いになり得るため（→ ADR-0018）。
 - `list-generations --all` は home mode の全 config の世代を一覧（読み取り専用）。`gitignore --all` は projectRoot の全 config の target を **ソート + 重複除去**して出力する（repo の `.gitignore` は 1 つなので一括列挙が自然・→ ADR-0018）。
 - `apply <name> --recopy` は通常 apply に加え **config 内の全 copy target を現 `src`/`subpath` から無条件に上書き再コピー**する（→ ADR-0020）。copy は世代外で hash 追跡しないため差分判定はせず無条件。上書きした target をレポート表示し、フラグ自体が opt-in なので確認は出さない。**ローカルの copy 編集は破棄され src 内容に戻る**（= upstream 追従の意図）。symlink 部の世代コミット挙動は不変（copy は世代を増やさない）。
+- `apply <name> --backup[=<suffix>]` は、配置を塞ぐ既存の**記録外**実体（foreign な通常ファイル / ディレクトリ・copy 構造不一致・copy foreign 実ファイル・method 変更 copy→symlink）を `<target>.<suffix>` へ rename 退避してから配置する、conflict の脱出ハッチ（→ ADR-0045, issue #169）。値なし = suffix `nput-backup`。suffix 指定は cobra `NoOptDefVal` の制約で **`=` 区切り必須**（`--backup=bak`。スペース区切り `--backup bak` は次の位置引数として扱われ suffix にならない）。**祖先 symlink conflict は対象外のまま**（構造問題であり退避では解消しない・→ ADR-0015, ADR-0046）。退避発動は warning 級で**常時 stderr** に出す。退避先 `<target>.<suffix>` が既に存在する（前回の退避物が残っている）ときは conflict で停止し、黙って上書きしない。退避も途中失敗時の undo ジャーナル対象（→「途中失敗時の巻き戻し」節）。**`reset` は退避物を復元しない**（ユーザー所有物として残置。復元は手動 `mv`）。
 - `reset <name> [target...]` は配置物を**無い状態へ戻す** teardown（→ ADR-0020）。symlink は stale 除去と同じ**保守的不変条件**（nput 管理・記録通りのみ・foreign は warning で残す）で除去し、**copy target も削除**する（copy を消す唯一の明示手段）。symlink・copy いずれの除去後も空親ディレクトリ剪定を適用する（→「空親ディレクトリ剪定」節）。データ損失リスクのため**確認プロンプト**を出すか `--yes` で同意を要求し、削除 target をレポート表示する。**profile / 世代は触らない FS-only teardown** で、config が entry を残す限り次の apply で再配置される（transient・project mode は ADR-0017 の lstat 検査で復帰）。恒久除去は config から entry を消して apply、profile 完全除去は `nix-env --profile <profileDir>/profile --delete-generations`。home / project 両モード可。
 - `reset` は **名指し必須（`--all` 非対応）**（一斉撤去は破壊的 footgun・`rollback --all` 却下と一貫・→ ADR-0018, ADR-0021）。複数撤去は名指しを複数回。**解決後 `profileDir` 単位の blocking flock を取得**して並行 apply / reset と直列化する（→ ADR-0013, ADR-0021）。profileDir 確定のため **rootKind 先取り eval → root 解決**を build しないコマンドでも先行する（apply と共通の前段・`--root` 時は同じ roothash キー・→ ADR-0024）。
 - `reset <name> --dryrun` は**副作用ゼロ**で削除対象（symlink / copy target）を表示して exit する（FS 削除・confirm・flock いずれも行わない・`apply --dryrun` と対称・→ ADR-0021）。終了コードは削除対象の有無に依らず 0。
-- `apply --all --recopy` は**合成可**。`--all`（必要なら `--project-root` 等フィルタ）が選んだ各 config に `--recopy` を適用する（`--recopy` は apply 修飾で `--all` と直交・→ ADR-0021）。
-- `apply <name> --dryrun` は FS 書込・`--set`・flock いずれも行わない読み取り専用。`conflict` があれば非ゼロ終了（CI の事前 gate に使える）（→ ADR-0006）。
+- `apply --all --recopy` は**合成可**。`--all`（必要なら `--project-root` 等フィルタ）が選んだ各 config に `--recopy` を適用する（`--recopy` は apply 修飾で `--all` と直交・→ ADR-0021）。`--all --backup[=<suffix>]` も同様に合成可（`--backup` も apply 修飾・→ ADR-0045）。
+- `apply <name> --dryrun` は FS 書込・`--set`・flock いずれも行わない読み取り専用。`conflict` があれば非ゼロ終了（CI の事前 gate に使える）（→ ADR-0006）。**`--dryrun --backup` は組み合わせ可**で、`--backup` 無しなら conflict（exit 2）になる箇所が「backup + 配置予定」の非 conflict プランへ変わる（exit 0・→ ADR-0045）。退避先が既存の場合は `--backup` 下でも conflict のまま。
 - `gitignore <name>` は配置 target を `.gitignore` 向けに列挙して stdout に出力するだけで、ファイルは書き込まない。更新責務はプロジェクト管理者（→ ADR-0005）。出力は **root 相対 target に先頭 `/` を付けたアンカー形式**（例: `/.claude/skills/nix`）で 1 行 1 件。project mode の root = git toplevel = `.gitignore` 置き場所なので先頭 `/` が正しくアンカーし、別階層の同名パスを誤って無視しない。ディレクトリ / ファイルとも末尾 `/` は付けない（→ ADR-0013）。
 - `gitignore` は **project mode 限定**。単体 `gitignore <name>` も project mode の config のみ受理し、**非 project config（home / fixed）を指定したらエラーで停止**する（出力のアンカー形式が git toplevel = `.gitignore` 置き場所を前提とし、home / fixed では意味を成さないため）。`rollback` / `list-generations` が home mode 限定なのと対称（→ ADR-0023）。
 - `gitignore` は **`method` を区別せず全 target を列挙**する（copy target も含む・→ ADR-0019）。project mode の copy target も ephemeral 扱いで、各 clone で place-once で再マテリアライズされ**編集は clone local / 使い捨て**（`git clean` で消える）。copy を committed（vendoring）にするのは nput の責務外（手動コミット）で、project mode の ephemeral 原則は崩さない（→ ADR-0019）。
@@ -582,6 +587,11 @@ engine が**ネイティブ FS 操作**で行う（`ln` / `rsync` は使わな�
 0.6. target と同一 target で method が symlink→copy に変わるとき、前世代が記録した symlink で on-disk が
    記録通りなら → 配置前に除去（PreRemove・silent）してから copy を新規配置（→ ADR-0047 D5）。
    readlink drift（on-disk が記録と不一致）は移行せず通常の foreign 判定へフォールバックする。
+0.7. `apply --backup` 有効時、上記 0〜0.6 が「エラーで停止」または「copy foreign スキップ」と判定した
+   記録外実体（foreign な通常ファイル/ディレクトリ・実 dir migration 失敗・copy 構造不一致・
+   copy foreign 実ファイル・method 変更 copy→symlink）を、配置前に `<target>.<suffix>` へ rename 退避
+   （Backup。PreRemove の後・配置の前）してから新規配置する（→ ADR-0045）。祖先 symlink conflict は
+   対象外のまま（構造問題であり退避では解消しない）。退避先が既存なら conflict で停止する。
 1. target の親ディレクトリを作成（mkdir -p 相当。緩和対象の祖先 symlink / 実 dir target は PreRemove 除去済み・foreign は 0 で弾き済み）
 2. target が既存 symlink のとき:
    - 自身の前世代 manifest が記録した symlink → そのまま置き換える（silent）
@@ -595,20 +605,21 @@ engine が**ネイティブ FS 操作**で行う（`ln` / `rsync` は使わな�
 - target に通常ファイルまたはディレクトリが存在する場合はエラーで停止（上書きしない）。ただし実 dir は §0.5 の条件を満たせば例外的に PreRemove で除去して配置する（→ ADR-0047）
 - subpath がファイル・ディレクトリどちらでも同じ処理
 - 別 config（別 profile）が同一 target を狙うのは基本「衝突させない前提」。後勝ちを許容しつつ foreign symlink 上書きは warning で可視化する（→ ADR-0015）
-- method 変更 copy→symlink は自動移行しない（ユーザー編集済み copy データの保護を優先し、従来通り conflict のまま・→ ADR-0047 D5）
+- method 変更 copy→symlink は自動移行しない（ユーザー編集済み copy データの保護を優先し、従来通り conflict のまま・→ ADR-0047 D5）。`--backup` を付ければ conflict の代わりに退避 + 配置される（→ ADR-0045）
 
 ### 途中失敗時の巻き戻し（インメモリ undo ジャーナル・→ ADR-0044）
 
-apply / rollback が PreRemove・配置（symlink / copy）・stale 除去のいずれかの段で途中失敗すると、その run が行った FS 変更を**全て**巻き戻し、pre-apply 状態へ復元する（「失敗した apply は FS に痕跡を残さない」）。フラグなし・常時有効。
+apply / rollback が PreRemove・Backup（`--backup`）・配置（symlink / copy）・stale 除去のいずれかの段で途中失敗すると、その run が行った FS 変更を**全て**巻き戻し、pre-apply 状態へ復元する（「失敗した apply は FS に痕跡を残さない」）。フラグなし・常時有効。
 
 ```
-各段（PreRemove / place / copy 反映 / stale 除去）の FS 書き込みごとに、インメモリの undo ジャーナルへ逆操作を 1 件記録する:
+各段（PreRemove / Backup / place / copy 反映 / stale 除去）の FS 書き込みごとに、インメモリの undo ジャーナルへ逆操作を 1 件記録する:
   新規配置 symlink / copy         → 削除
   張替え（unlink 前に旧リンク先を捕捉）→ 旧リンク先で symlink を再作成
   stale 除去したリンク            → 前世代 manifest の記録 dest で symlink を再作成
   PreRemove の Unlink             → 記録 dest で symlink を再作成
   PreRemove の Rmdir              → 空 dir を再作成
   --recopy の rename 退避         → 退避物を rename back（成功時は退避物を削除）
+  --backup の rename 退避         → 退避物を rename back（成功時も退避物は削除せず残置・→ ADR-0045）
 
 いずれかの段でエラーが発生したら、それまでに記録したジャーナルを逆順（LIFO）で巻き戻してからエラーを返す。
 nix-env --set（コミット）が成功した後はジャーナルを破棄する（--set 自体の失敗は巻き戻し対象外・冪等再実行で収束）。
@@ -617,8 +628,8 @@ nix-env --set（コミット）が成功した後はジャーナルを破棄す�
 - **巻き戻し自体の失敗は best-effort 続行**: 個々の逆操作が失敗してもジャーナルの残りの巻き戻しは続行する。全ての巻き戻し試行が終わった時点で、元の apply エラーと巻き戻せなかった項目の一覧を stderr へ全報告して停止する（`reportConflicts` と同じ「全件列挙してから 1 本の集約エラー」の形）。
 - **報告は常時 stderr**（失敗経路のため沈黙対象外・既定 silent の対象にしない・→ ADR-0031）。
 - **クラッシュ（SIGKILL・電源断）は対象外**。undo ジャーナルはプロセスメモリ上にのみ存在し、永続 WAL は持たない。この場合は変わらず「世代未コミット + 冪等再実行で収束」（ADR-0006, ADR-0017）が保証を担う。
-- 世代スキップ経路の drift 修復（repairDrift）も同じ機構で巻き戻される。ただし ADR-0046/0047 の不変条件により、この経路が PreRemove を受け取ることは構造的に無い。
-- `rollback` も apply と同じ機構（PreRemove → place → stale 除去）で途中失敗時に巻き戻す。プロファイルポインタ移動（`--switch-generation`）はこの時点で全 FS 変更が成功済みのため巻き戻し対象外。
+- 世代スキップ経路の drift 修復（repairDrift）も同じ機構で巻き戻される。PreRemove は ADR-0046/0047 の不変条件によりこの経路に到達しないが、**Backup（`--backup`）はその不変条件の対象外**（target の記録外実体の出現は manifest/derivation の変化を伴わず、shell 再入間でも起こり得るため）で、drift 修復の一環として通常 apply と同じく退避 + 配置される。
+- `rollback` も apply と同じ機構（PreRemove → place → stale 除去）で途中失敗時に巻き戻す。プロファイルポインタ移動（`--switch-generation`）はこの時点で全 FS 変更が成功済みのため巻き戻し対象外。`rollback` に `--backup` 相当のフラグはなく、Backup ステージは常に空。
 
 ### copy モード（place-once・ユーザー管理）
 
@@ -632,12 +643,12 @@ subpath がファイルの場合:
   target が存在するとき: 何もしない
 ```
 
-- **foreign 実ファイルの skip は warning で可視化する**: target が存在し**かつ前世代 manifest にこの copy entry が無い**（= nput が置いていない foreign ファイル）のとき、place-once により skip するが **warning を出す**（「target に既存ファイルがあり copy をスキップした」）。symlink の foreign 警告（→ ADR-0015）と対称化し、「nput が中身を置いた」と誤認する masking を防ぐ。上書きはせず apply 全体も止めない（→ ADR-0022）。「自分が置いたか」は前世代 manifest の entry 有無で判別し、内容は判別しない。
+- **foreign 実ファイルの skip は warning で可視化する**: target が存在し**かつ前世代 manifest にこの copy entry が無い**（= nput が置いていない foreign ファイル）のとき、place-once により skip するが **warning を出す**（「target に既存ファイルがあり copy をスキップした」）。symlink の foreign 警告（→ ADR-0015）と対称化し、「nput が中身を置いた」と誤認する masking を防ぐ。上書きはせず apply 全体も止めない（→ ADR-0022）。「自分が置いたか」は前世代 manifest の entry 有無で判別し、内容は判別しない。**`apply --backup` 有効時はこの skip + warning の代わりに、target を `<target>.<suffix>` へ退避してから copy を新規配置する**（→ ADR-0045）。
+- `subpath` がディレクトリのとき `target` に通常ファイルが存在する場合、または `subpath` がファイルのとき `target` がディレクトリの場合は構造不一致でエラーで停止するが、**`apply --backup` 有効時は退避してから copy を新規配置する**（→ ADR-0045）。
 - **place-once**: 初回マテリアライズ後、target が在れば触らない。ストア更新の反映は **`apply --recopy`（全 copy target を src から無条件上書き）**、または `reset <name> [target]` で撤去後に再 apply で行う（→ ADR-0020）。
 - **mode は保存しつつ owner-write を付与する**（例: `0444 → 0644` / `0555 → 0755`・→ ADR-0016）。store パスは read-only（0444 / 0555）のため、そのまま保存すると編集できない。copy は「store から切り離してユーザーが所有・編集する」用途なので、perm の相対構造（実行ビット・group/other）は保ちつつ所有者が編集できる状態にする。
 - **src ツリー内の symlink は symlink のまま複製する**（deref しない。循環・サイズ膨張回避・→ ADR-0016）。ただし store 内への絶対 symlink を複製すると **store 依存（read-only / GC 後 dangling）が残る**点に注意。相対 symlink はそのまま保つ。
 - 世代管理の対象外。ロールバックされない。
-- `subpath` がディレクトリのとき `target` に通常ファイルが存在する場合、または `subpath` がファイルのとき `target` がディレクトリの場合は、構造の不一致としてエラーで停止。
 
 ### out-of-store symlink
 
@@ -830,9 +841,13 @@ FS を自動収束させる（nput profile は前進のみ＝旧内容の新世�
 ```
 nput.enable  :: bool          # デフォルト: false
 nput.entries :: attrsOf entry # デフォルト: {}（属性キー = target・→ ADR-0014）
+nput.backup.enable :: bool    # デフォルト: false（→ ADR-0045）
+nput.backup.suffix :: str     # デフォルト: "nput-backup"（→ ADR-0045）
 ```
 
 モジュールは自分の性質で root を pin する（HM → `homeRoot` / devShell → `projectRoot`）ため、モジュール利用者は `root` を再指定しない（→ ADR-0003, ADR-0007）。
+
+`nput.backup`（submodule・全モジュール共通）は activation の `nput apply --manifest` 起動へ `--backup=<suffix>` を配線する（→ ADR-0045, issue #169）。`enable = true` かつ `suffix` 省略で既定 `nput-backup` が使われる。`entries`（manifest v1 契約・`lib/types.nix`）とは独立な起動配線レイヤーのオプションで、manifest 自体には影響しない。
 
 > **HM モジュールの profile 粒度（MVP）**（→ ADR-0024, ADR-0025）: `nput.entries` は**単一 attrset = 単一 manifest = 1 profile（固定名 `default`）**で、`<name>` 次元を持たない。**standalone / CLI が entrypoint の `nput.<name>` で複数の独立 profile（役割分離・個別 rollback）を持てるのに対し、HM モジュール経由では役割分離はできない**。役割ごとに分けたいユーザーは standalone CLI 経路を使う。HM の複数 profile 化（`nput.configs.<name>.entries` 等）は将来拡張の seam として残す（HM の低い positioning〔ADR-0007〕に鑑み MVP では背負わない）。
 
@@ -985,21 +1000,23 @@ devShells.default = pkgs.mkShell {
 | `src` が存在しないストアパス（path / set）| Nix 評価時にエラー |
 | `src` が marker でローカルパスが存在しない | engine 実行時にエラーで停止 |
 | `subpath` が `src` 内に存在しないパス | engine 実行時にエラーで停止 |
-| `target` に通常ファイルが既存（symlink モード）| conflict。全件を stderr へ列挙して停止（上書きしない・→ 後述「conflict の全件報告」）|
+| `target` に通常ファイルが既存（symlink モード）| conflict。全件を stderr へ列挙して停止（上書きしない・→ 後述「conflict の全件報告」）。`apply --backup` 有効時は `<target>.<suffix>` へ退避してから新規配置（→ ADR-0045）|
 | `target` が実 dir で既存（symlink モード）、配下（任意深さ）の全 leaf が recorded∧stale な symlink または空 sub dir（由来問わず）| dir 全体を配置前に除去（PreRemove: leaf は Unlink・dir は子から親へ Rmdir）し新規配置（silent・`-v` で可視・`--dryrun` は非 conflict の remove・→ ADR-0047）|
-| `target` が実 dir で既存（symlink モード）、配下に中身のある実 file/dir・foreign symlink・次世代にも残る自己矛盾 symlink が 1 つでもある | conflict。dir 全体を停止し全件を stderr へ列挙（部分除去はしない・`--dryrun` も conflict・→ ADR-0047, 後述「conflict の全件報告」）|
+| `target` が実 dir で既存（symlink モード）、配下に中身のある実 file/dir・foreign symlink・次世代にも残る自己矛盾 symlink が 1 つでもある | conflict。dir 全体を停止し全件を stderr へ列挙（部分除去はしない・`--dryrun` も conflict・→ ADR-0047, 後述「conflict の全件報告」）。`apply --backup` 有効時は dir 全体を `<target>.<suffix>` へ 1 回で退避してから新規配置（部分退避はしない・→ ADR-0045）|
 | `target` の祖先 component が foreign symlink（記録なし / 記録 dest と不一致 / 前世代なし）、または次世代にも祖先が残る自己矛盾 | conflict。engine 実行時に全件を stderr へ列挙して停止（lstat walk・`--dryrun` も conflict・→ ADR-0015 §4, ADR-0046, 後述「conflict の全件報告」）|
 | `target` の祖先 component が自己記録 stale symlink（前世代 manifest が記録・on-disk 一致・次世代に無い）| 祖先を配置前に除去（PreRemove）し配下子を新規配置してネスト移行（silent・`-v` で可視・`--dryrun` は非 conflict の remove・→ ADR-0046）|
 | `target` に foreign symlink が既存（自身の前世代 manifest に記録なし・別 config / 別ツール / 手動）| warning を出して後勝ちで置き換える（→ ADR-0015）|
 | 同一 `target` で method が symlink→copy に変更、前世代が記録した symlink で on-disk が記録通り | 配置前に除去（PreRemove）し copy を新規配置（silent・`-v` で可視・readlink drift 時は通常の foreign 判定へフォールバック・→ ADR-0047 D5）|
 | 同一 `target` で method が copy→symlink に変更 | 自動移行しない。エラーで停止（`target` に既存ファイルとして扱う・`--backup` が脱出ハッチ・→ ADR-0047 D5）|
 | PreRemove 対象（祖先 symlink / 実 dir 配下 leaf・dir / method 変更 symlink）が計画後に drift（記録不一致・ENOTEMPTY 等）| skip せずエラーで停止（冪等再実行で収束・→ ADR-0046 §3, ADR-0047 D3）|
-| apply / rollback が PreRemove・配置・stale 除去のいずれかの段で途中失敗（`--set` 到達前）| この run が行った FS 変更を全てインメモリ undo ジャーナルで巻き戻し pre-apply 状態へ復元してから停止（exit 1・フラグなし常時有効・→ ADR-0044, 前述「途中失敗時の巻き戻し」）|
+| `apply --backup` 有効時、退避先 `<target>.<suffix>` が既に存在（前回の退避物が残っている）| conflict。全件を stderr へ列挙して停止（黙って上書きしない・→ ADR-0045, 後述「conflict の全件報告」）|
+| `apply --backup` は祖先 symlink conflict（foreign / 自己矛盾）には適用されない | 従来通り conflict のまま（構造問題であり退避では解消しない・→ ADR-0015, ADR-0046, ADR-0045）|
+| apply / rollback が PreRemove・Backup（`--backup`）・配置・stale 除去のいずれかの段で途中失敗（`--set` 到達前）| この run が行った FS 変更を全てインメモリ undo ジャーナルで巻き戻し pre-apply 状態へ復元してから停止（exit 1・フラグなし常時有効・→ ADR-0044, 前述「途中失敗時の巻き戻し」）|
 | 巻き戻し（undo）自体が一部失敗（対象が既に他プロセスに変更された等）| 失敗項目はスキップして残りの巻き戻しを続行（best-effort）。元の apply エラー + 未復元項目一覧を stderr に全報告して停止（→ ADR-0044）|
-| `subpath` がディレクトリのとき `target` に通常ファイルが既存（copy モード）| conflict。全件を stderr へ列挙して停止（→ 後述「conflict の全件報告」）|
-| `subpath` がファイルのとき `target` がディレクトリとして既存（copy モード）| conflict。全件を stderr へ列挙して停止（→ 後述「conflict の全件報告」）|
+| `subpath` がディレクトリのとき `target` に通常ファイルが既存（copy モード）| conflict。全件を stderr へ列挙して停止（→ 後述「conflict の全件報告」）。`apply --backup` 有効時は退避してから copy を新規配置（→ ADR-0045）|
+| `subpath` がファイルのとき `target` がディレクトリとして既存（copy モード）| conflict。全件を stderr へ列挙して停止（→ 後述「conflict の全件報告」）。`apply --backup` 有効時は退避してから copy を新規配置（→ ADR-0045）|
 | copy モードで `target` が既存（前世代 manifest に entry あり = nput 配置済み）| place-once により何もしない（上書きしない）。`apply --recopy` 時のみ無条件上書き（→ ADR-0020）|
-| copy モードで `target` に foreign 実ファイルが既存（前世代 manifest に entry なし）| place-once で skip しつつ **warning** で可視化（masking 防止・symlink の foreign 警告と対称・apply は止めない・→ ADR-0022）|
+| copy モードで `target` に foreign 実ファイルが既存（前世代 manifest に entry なし）| place-once で skip しつつ **warning** で可視化（masking 防止・symlink の foreign 警告と対称・apply は止めない・→ ADR-0022）。`apply --backup` 有効時は skip の代わりに退避してから copy を新規配置（warning は出さない・→ ADR-0045）|
 | 世代スキップ時に copy `target` が不在（project mode）| lstat ドリフト修復で place-once 再マテリアライズ。内容が異なるだけ（編集済み）の場合は不可触（→ ADR-0022）|
 | stale 除去で copy entry が消えた | copy target は削除せず、orphan を警告で通知。明示撤去は `reset`（→ ADR-0020）|
 | `reset` で対象 entry の配置物が既に無い | no-op（既に無い状態・エラーにしない・→ ADR-0020）|
@@ -1027,10 +1044,11 @@ devShells.default = pkgs.mkShell {
 
 `apply` / `rollback` が conflict で停止するとき、`planner.Compute` が収集した **`plan.Conflicts` の全件**を stderr へ列挙してから停止する（`--dryrun` の `Result.Conflicts` と同じ集合。HM の `checkLinkTargets` と対称）。1 件ずつ「修正 → 再実行 → 次の 1 件…」を強いられないよう、1 回の実行で全ての衝突箇所を可視化する。各行には conflict 種別に応じた 1 行の対処ガイダンスが付く：
 
-- foreign 実体（`target` に記録外の通常ファイル・ディレクトリ）→ 手動で退避・削除してから再実行
+- foreign 実体（`target` に記録外の通常ファイル・ディレクトリ）→ 手動で退避・削除してから再実行（または `apply --backup` で自動退避・→ ADR-0045）
 - foreign 祖先 symlink（記録なし / 記録 dest と不一致 / 前世代なし）→ そのリンクを作った主体（別 config / 別ツール / 手動操作）を確認
 - 自己矛盾 manifest（次世代にも祖先 symlink が残ったまま配下 target を定義）→ entry 定義を見直す（祖先と配下のどちらかに一本化）
-- copy 構造不一致（`subpath` の dir/file 種別と既存 `target` の種別が食い違う）→ entry 定義を見直す
+- copy 構造不一致（`subpath` の dir/file 種別と既存 `target` の種別が食い違う）→ entry 定義を見直す（または `apply --backup` で自動退避）
+- backup 退避先が既存（`apply --backup` 有効時、`<target>.<suffix>` に前回の退避物が残っている）→ 手動で退避物を移動・削除してから再実行（→ ADR-0045）
 
 停止時の `error` は列挙の後に返す**件数付き集約メッセージ 1 本**（例: `nput: N conflict(s) detected; stopped without placing (see above)`）で、個別 conflict の詳細は本文ではなく直前の stderr 列挙が担う。終了コードは不変（`apply` 非 dryrun は `1`・`--dryrun` は `2`）。`--json`（epic #126）の `Conflicts` 配列も同じ全件集合と整合させる。
 

--- a/flake.nix
+++ b/flake.nix
@@ -249,6 +249,9 @@
                       src = fakeSrc;
                       subpath = "skills/nix";
                     };
+                    # nput.backup.enable の wiring 確認（→ ADR-0045, issue #169）。suffix 省略時は
+                    # submodule 既定値 "nput-backup" が activation に渡ることを検証する。
+                    nput.backup.enable = true;
                   }
                 ];
               };
@@ -272,6 +275,11 @@
               # (3) nput.entries が manifest に流れていること（target = 属性キー）。
               grep -q '".claude/skills/nix"' "$manifest/manifest.json" \
                 || { echo "FAIL: nput.entries が manifest に反映されていません"; cat "$manifest/manifest.json"; exit 1; }
+
+              # (4) nput.backup.enable が --backup=<既定 suffix> として同じ apply 起動に配線されること
+              #     （→ ADR-0045, issue #169）。
+              grep -q -- '--backup=nput-backup' "$script" \
+                || { echo "FAIL: activation が --backup=<suffix> を配線していません"; cat "$script"; exit 1; }
 
               touch "$out"
             '';

--- a/internal/engine/backup.go
+++ b/internal/engine/backup.go
@@ -1,0 +1,43 @@
+package engine
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/yasunori0418/nput/internal/planner"
+)
+
+// backup applies the planner's Backup actions: rename each occupying foreign filesystem object
+// aside (TargetAbs → BackupAbs = "<target>.<suffix>") so the placement stage that follows lands
+// on an absent target (→ ADR-0045, issue #169). It runs after PreRemove and before Place /
+// materializeCopies, mirroring recopyAll's rename-aside (asidePath / journalRenamedAside): the
+// rename is a same-parent-directory metadata-only operation that cannot fail partway under
+// ENOSPC. Undo restores it with the undoRestoreBackup inverse (remove whatever this run placed at
+// TargetAbs, then rename BackupAbs back) — unlike recopy's aside, a successful commit does NOT
+// clean up BackupAbs; it is the user's backup and stays on disk (→ ADR-0044, ADR-0045).
+//
+// The backup destination's absence was already checked at plan time (→ planner.appendBackup), but
+// a re-check immediately before the rename guards the same plan/execute TOCTOU window PreRemove's
+// reverifyStale guards for stale removal: a concurrent writer could have created BackupAbs between
+// planning and this run reaching it. Unlike PreRemove's drift handling, there is nothing here to
+// "keep as-is" on drift — the destination existing at all means a prior backup would be silently
+// clobbered, so this aborts loudly (→ ADR-0017 idempotent re-run convergence).
+func (a *applier) backup(actions []planner.BackupAction) error {
+	for _, act := range actions {
+		if _, err := os.Lstat(act.BackupAbs); err == nil {
+			return fmt.Errorf("nput: backup destination already exists (%s); cannot safely back up %s; re-run apply to converge", act.BackupAbs, act.TargetAbs)
+		} else if !os.IsNotExist(err) {
+			return fmt.Errorf("nput: cannot lstat backup destination (%s): %w", act.BackupAbs, err)
+		}
+		if err := os.Rename(act.TargetAbs, act.BackupAbs); err != nil {
+			return fmt.Errorf("nput: cannot rename aside for backup (%s -> %s): %w", act.TargetAbs, act.BackupAbs, err)
+		}
+		// Journaled immediately after the rename, before placement lands: if a later stage fails,
+		// undoRestoreBackup's os.RemoveAll tolerates TargetAbs being absent/partial and still
+		// renames BackupAbs back, restoring the pre-apply content (→ ADR-0044).
+		a.journalBackedUp(act.TargetAbs, act.BackupAbs)
+		a.result.BackedUp = append(a.result.BackedUp, act.Entry.Target)
+		a.opts.Warnf("nput: backed up existing target before placement: %s -> %s", act.TargetAbs, act.BackupAbs)
+	}
+	return nil
+}

--- a/internal/engine/backup_test.go
+++ b/internal/engine/backup_test.go
@@ -1,0 +1,230 @@
+package engine
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// Tests for apply --backup (→ ADR-0045, issue #169): renaming an occupying foreign filesystem
+// object aside to "<target>.<suffix>" before placement, instead of stopping on conflict.
+
+// TestApplyBackupRenamesForeignFileAndPlaces verifies the basic flow: a regular file occupying a
+// symlink placement target is renamed aside to "<target>.nput-backup" (the default suffix) and the
+// entry is placed fresh, with the target reported in Result.BackedUp.
+func TestApplyBackupRenamesForeignFileAndPlaces(t *testing.T) {
+	root := realTempDir(t)
+	state := realTempDir(t)
+	src := makeSrc(t, "foo")
+
+	target := filepath.Join(root, "foo")
+	if err := os.WriteFile(target, []byte("pre-existing"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	lf := writeLinkFarm(t, projectManifest(storeEntry(src, "foo", "foo")))
+	res, err := Apply(Options{
+		LinkFarm: lf, Name: "c", RootOverride: root, StateDir: state, Commit: fakeCommit(nil), Backup: true,
+	})
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	got, rerr := os.Readlink(target)
+	if rerr != nil || got != filepath.Join(src, "foo") {
+		t.Errorf("readlink(foo) = %q, err %v; want %q", got, rerr, filepath.Join(src, "foo"))
+	}
+	backupPath := target + ".nput-backup"
+	data, berr := os.ReadFile(backupPath)
+	if berr != nil || string(data) != "pre-existing" {
+		t.Errorf("backup file content = %q, err = %v; want %q", data, berr, "pre-existing")
+	}
+	if len(res.BackedUp) != 1 || res.BackedUp[0] != "foo" {
+		t.Errorf("Result.BackedUp = %v, want [foo]", res.BackedUp)
+	}
+}
+
+// TestApplyBackupCustomSuffix verifies apply --backup=<suffix> uses the given suffix instead of
+// the default "nput-backup".
+func TestApplyBackupCustomSuffix(t *testing.T) {
+	root := realTempDir(t)
+	state := realTempDir(t)
+	src := makeSrc(t, "foo")
+
+	target := filepath.Join(root, "foo")
+	if err := os.WriteFile(target, []byte("pre-existing"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	lf := writeLinkFarm(t, projectManifest(storeEntry(src, "foo", "foo")))
+	if _, err := Apply(Options{
+		LinkFarm: lf, Name: "c", RootOverride: root, StateDir: state, Commit: fakeCommit(nil),
+		Backup: true, BackupSuffix: "bak",
+	}); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	if _, err := os.Lstat(target + ".bak"); err != nil {
+		t.Errorf("backup with custom suffix must exist at foo.bak: %v", err)
+	}
+	if _, err := os.Lstat(target + ".nput-backup"); !os.IsNotExist(err) {
+		t.Errorf("default-suffix path must not exist when a custom suffix is given, lstat err = %v", err)
+	}
+}
+
+// TestApplyBackupSurvivesCommit verifies that unlike --recopy's rename-aside (cleaned up on
+// success), a --backup aside is never removed once the run commits — it is the user's backup, kept
+// indefinitely (→ ADR-0045 "reset は復元しない").
+func TestApplyBackupSurvivesCommit(t *testing.T) {
+	root := realTempDir(t)
+	state := realTempDir(t)
+	src := makeSrc(t, "foo")
+
+	target := filepath.Join(root, "foo")
+	if err := os.WriteFile(target, []byte("pre-existing"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	lf := writeLinkFarm(t, projectManifest(storeEntry(src, "foo", "foo")))
+	if _, err := Apply(Options{
+		LinkFarm: lf, Name: "c", RootOverride: root, StateDir: state, Commit: fakeCommit(nil), Backup: true,
+	}); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	if _, err := os.Lstat(target + ".nput-backup"); err != nil {
+		t.Errorf("backup file must survive a successful commit: %v", err)
+	}
+}
+
+// TestApplyBackupMidBatchFailureRestoresBackup verifies that a later placement failure in the same
+// batch rolls the backup back: the target is restored to its pre-apply content and the aside path
+// is gone, mirroring --recopy's rollback shape but keeping the destination on rollback failure too
+// (→ ADR-0044, ADR-0045).
+func TestApplyBackupMidBatchFailureRestoresBackup(t *testing.T) {
+	root := realTempDir(t)
+	state := realTempDir(t)
+	src := makeSrc(t, "foo")
+
+	target := filepath.Join(root, "foo")
+	if err := os.WriteFile(target, []byte("pre-existing"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	blockWrite(t, filepath.Join(root, "ro"))
+
+	lf := writeLinkFarm(t, projectManifest(
+		storeEntry(src, "foo", "foo"),
+		storeEntry(realTempDir(t), ".", "ro/leaf"),
+	))
+	_, err := Apply(Options{
+		LinkFarm: lf, Name: "c", RootOverride: root, StateDir: state, Commit: fakeCommit(nil), Backup: true,
+	})
+	if err == nil {
+		t.Fatal("expected an error from the blocked mid-batch placement, got nil")
+	}
+
+	data, rerr := os.ReadFile(target)
+	if rerr != nil || string(data) != "pre-existing" {
+		t.Errorf("target must be restored to its pre-apply content: data=%q, err=%v", data, rerr)
+	}
+	if _, lerr := os.Lstat(target + ".nput-backup"); !os.IsNotExist(lerr) {
+		t.Errorf("backup aside path must not be left behind after a rolled-back backup, lstat err = %v", lerr)
+	}
+}
+
+// TestApplyBackupDestinationExistsConflict verifies that a pre-existing "<target>.<suffix>" (a
+// leftover from an earlier backup) stops apply with a conflict instead of being silently
+// overwritten (→ ADR-0045).
+func TestApplyBackupDestinationExistsConflict(t *testing.T) {
+	root := realTempDir(t)
+	state := realTempDir(t)
+	src := makeSrc(t, "foo")
+
+	target := filepath.Join(root, "foo")
+	if err := os.WriteFile(target, []byte("pre-existing"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(target+".nput-backup", []byte("earlier backup"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	lf := writeLinkFarm(t, projectManifest(storeEntry(src, "foo", "foo")))
+	_, err := Apply(Options{
+		LinkFarm: lf, Name: "c", RootOverride: root, StateDir: state, Commit: fakeCommit(nil), Backup: true,
+	})
+	if err == nil {
+		t.Fatal("expected a conflict error when the backup destination already exists, got nil")
+	}
+
+	data, rerr := os.ReadFile(target)
+	if rerr != nil || string(data) != "pre-existing" {
+		t.Errorf("target must be untouched on conflict: data=%q, err=%v", data, rerr)
+	}
+	data, rerr = os.ReadFile(target + ".nput-backup")
+	if rerr != nil || string(data) != "earlier backup" {
+		t.Errorf("earlier backup must be untouched on conflict: data=%q, err=%v", data, rerr)
+	}
+}
+
+// TestApplyDryRunBackupNoConflictNoSideEffects verifies apply --dryrun --backup reports the
+// occupying target as a planned backup (not a conflict) with zero exit-2-worthy conflicts and
+// leaves the FS untouched (→ ADR-0045 "--dryrun --backup は conflict ではなく backup + 配置予定").
+func TestApplyDryRunBackupNoConflictNoSideEffects(t *testing.T) {
+	root := realTempDir(t)
+	state := realTempDir(t)
+	src := makeSrc(t, "foo")
+
+	target := filepath.Join(root, "foo")
+	if err := os.WriteFile(target, []byte("pre-existing"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	lf := writeLinkFarm(t, projectManifest(storeEntry(src, "foo", "foo")))
+	res, err := Apply(Options{
+		LinkFarm: lf, Name: "c", RootOverride: root, StateDir: state, DryRun: true, Backup: true,
+	})
+	if err != nil {
+		t.Fatalf("Apply dryrun: %v", err)
+	}
+	if len(res.Conflicts) != 0 {
+		t.Errorf("Conflicts = %v, want none (--backup turns this into a planned backup)", res.Conflicts)
+	}
+	if len(res.BackedUp) != 1 || res.BackedUp[0] != "foo" {
+		t.Errorf("Result.BackedUp = %v, want [foo]", res.BackedUp)
+	}
+	if len(res.Placed) != 1 || res.Placed[0] != "foo" {
+		t.Errorf("Result.Placed = %v, want [foo]", res.Placed)
+	}
+	// dryrun must not touch the FS at all.
+	data, rerr := os.ReadFile(target)
+	if rerr != nil || string(data) != "pre-existing" {
+		t.Errorf("target must be untouched by dryrun: data=%q, err=%v", data, rerr)
+	}
+	if _, lerr := os.Lstat(target + ".nput-backup"); !os.IsNotExist(lerr) {
+		t.Errorf("no backup file must be created by dryrun, lstat err = %v", lerr)
+	}
+}
+
+// TestApplyWithoutBackupStillConflicts verifies the default (Backup: false) behavior is unchanged:
+// a foreign regular file at a placement target still stops apply with a conflict, not a backup.
+func TestApplyWithoutBackupStillConflicts(t *testing.T) {
+	root := realTempDir(t)
+	state := realTempDir(t)
+	src := makeSrc(t, "foo")
+
+	target := filepath.Join(root, "foo")
+	if err := os.WriteFile(target, []byte("pre-existing"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	lf := writeLinkFarm(t, projectManifest(storeEntry(src, "foo", "foo")))
+	_, err := Apply(Options{
+		LinkFarm: lf, Name: "c", RootOverride: root, StateDir: state, Commit: fakeCommit(nil),
+	})
+	if err == nil {
+		t.Fatal("expected a conflict error without --backup, got nil")
+	}
+	if _, lerr := os.Lstat(target + ".nput-backup"); !os.IsNotExist(lerr) {
+		t.Errorf("no backup file must be created without --backup, lstat err = %v", lerr)
+	}
+}

--- a/internal/engine/backup_test.go
+++ b/internal/engine/backup_test.go
@@ -3,7 +3,10 @@ package engine
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+
+	"github.com/yasunori0418/nput/internal/planner"
 )
 
 // Tests for apply --backup (→ ADR-0045, issue #169): renaming an occupying foreign filesystem
@@ -205,6 +208,119 @@ func TestApplyDryRunBackupNoConflictNoSideEffects(t *testing.T) {
 	}
 }
 
+// TestApplyBackupDirTargetDoesNotWarnAboutSiblingRecordedLeaf verifies that when a real-dir target
+// migration fails (a foreign leaf mixed in) and --backup renames the whole directory aside, a
+// sibling leaf that prev recorded as its own stale symlink is NOT also reported by removeStale as
+// "drifted after planning" — it left with the directory in the single rename, which is expected,
+// not drift (→ ADR-0045, planner.markDirEntriesPreRemoved). Regression test for a diff-review
+// finding: the remove-side loop used to independently schedule such a leaf as a Remove candidate
+// (never marked preRemoved), so at execution time removeStale's reverifyStale would find it already
+// gone (renamed away with the parent) and misreport a drift warning.
+func TestApplyBackupDirTargetDoesNotWarnAboutSiblingRecordedLeaf(t *testing.T) {
+	root := realTempDir(t)
+	state := realTempDir(t)
+	srcOld := makeSrc(t, "x")
+
+	// First apply: place a per-file symlink at .claude/hooks/safe.sh (this generation's own record).
+	lf1 := writeLinkFarm(t, projectManifest(storeEntry(srcOld, ".", ".claude/hooks/safe.sh")))
+	if _, err := Apply(Options{
+		LinkFarm: lf1, Name: "c", RootOverride: root, StateDir: state, Commit: fakeCommit(nil),
+	}); err != nil {
+		t.Fatalf("first Apply: %v", err)
+	}
+
+	// A foreign tool drops a real file next to it, occupying .claude/hooks as a real dir with a
+	// foreign leaf — a whole-dir migration that would normally fail (foo.txt is not
+	// recorded/migratable), forcing the --backup whole-dir rename path.
+	if err := os.WriteFile(filepath.Join(root, ".claude", "hooks", "foo.txt"), []byte("foreign"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Second apply: new generation wants .claude/hooks as a single dir symlink (drops safe.sh's
+	// entry). Without --backup this would conflict; with --backup the whole dir is renamed aside.
+	srcNew := realTempDir(t)
+	lf2 := writeLinkFarm(t, projectManifest(storeEntry(srcNew, ".", ".claude/hooks")))
+	var warns []string
+	res, err := Apply(Options{
+		LinkFarm: lf2, Name: "c", RootOverride: root, StateDir: state, Commit: fakeCommit(nil),
+		Backup: true, Warnf: collectFormatted(&warns),
+	})
+	if err != nil {
+		t.Fatalf("second Apply (dir backup): %v", err)
+	}
+	if len(res.Conflicts) != 0 {
+		t.Errorf("Conflicts = %v, want none", res.Conflicts)
+	}
+	if len(res.BackedUp) != 1 || res.BackedUp[0] != ".claude/hooks" {
+		t.Errorf("Result.BackedUp = %v, want [.claude/hooks]", res.BackedUp)
+	}
+	if len(res.Removed) != 0 {
+		t.Errorf("Result.Removed = %v, want none (safe.sh left with the whole-dir rename, not independently removed)", res.Removed)
+	}
+	for _, w := range warns {
+		if strings.Contains(w, "drifted after planning") {
+			t.Errorf("unexpected drift warning for a leaf that was backed up with its parent dir, not drifted: %q (all warnings: %v)", w, warns)
+		}
+	}
+
+	got, rerr := os.Readlink(filepath.Join(root, ".claude", "hooks"))
+	if rerr != nil || got != srcNew {
+		t.Errorf("readlink(.claude/hooks) = %q, err %v; want %q", got, rerr, srcNew)
+	}
+	if _, lerr := os.Lstat(filepath.Join(root, ".claude", "hooks.nput-backup", "safe.sh")); lerr != nil {
+		t.Errorf("backed-up dir must retain safe.sh: %v", lerr)
+	}
+}
+
+// TestApplyGenerationSkipBackupRepairsForeignFile verifies that apply --backup also fires on the
+// project-mode generation-skip (drift repair) path, not just normal apply: unlike PreRemove, Backup
+// has no "derivation unchanged ⇒ never fires" invariant, since a foreign entity can appear at a
+// target purely from an FS-level event between shell re-entries, independent of config content
+// (→ ADR-0045, docs/spec.md "途中失敗時の巻き戻し" drift 修復の扱い).
+func TestApplyGenerationSkipBackupRepairsForeignFile(t *testing.T) {
+	root := realTempDir(t)
+	state := realTempDir(t)
+	src := makeSrc(t, "x")
+	lf := writeLinkFarm(t, projectManifest(storeEntry(src, ".", ".config/foo")))
+
+	var commits [][2]string
+	applyOnce(t, lf, "c", root, state, &commits, nil)
+
+	// foreign tool replaces the target with a regular file between shell re-entries.
+	tgt := filepath.Join(root, ".config", "foo")
+	if err := os.Remove(tgt); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(tgt, []byte("foreign content"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Second apply: same link-farm (generation skip candidate) with --backup enabled.
+	res, err := Apply(Options{
+		LinkFarm: lf, Name: "c", RootOverride: root, StateDir: state, Commit: fakeCommit(&commits), Backup: true,
+	})
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if !res.GenerationSkipped {
+		t.Errorf("GenerationSkipped = false, want true (same derivation)")
+	}
+	if len(commits) != 1 {
+		t.Errorf("commit calls = %d, want 1 (no new generation)", len(commits))
+	}
+	if len(res.BackedUp) != 1 || res.BackedUp[0] != ".config/foo" {
+		t.Errorf("Result.BackedUp = %v, want [.config/foo]", res.BackedUp)
+	}
+	got, rerr := os.Readlink(tgt)
+	if rerr != nil || got != src {
+		t.Errorf("readlink(.config/foo) = %q, err %v; want %q", got, rerr, src)
+	}
+	data, berr := os.ReadFile(tgt + ".nput-backup")
+	if berr != nil || string(data) != "foreign content" {
+		t.Errorf("backup file content = %q, err = %v; want %q", data, berr, "foreign content")
+	}
+}
+
 // TestApplyWithoutBackupStillConflicts verifies the default (Backup: false) behavior is unchanged:
 // a foreign regular file at a placement target still stops apply with a conflict, not a backup.
 func TestApplyWithoutBackupStillConflicts(t *testing.T) {
@@ -226,5 +342,48 @@ func TestApplyWithoutBackupStillConflicts(t *testing.T) {
 	}
 	if _, lerr := os.Lstat(target + ".nput-backup"); !os.IsNotExist(lerr) {
 		t.Errorf("no backup file must be created without --backup, lstat err = %v", lerr)
+	}
+}
+
+// TestApplierBackupReverifiesDestinationImmediatelyBeforeRename directly exercises applier.backup
+// with a BackupAction whose destination did NOT exist when the plan was computed but exists by the
+// time backup() executes (simulating the plan/execute TOCTOU window backup.go's doc comment
+// describes) — mirroring TestPreRemoveJournalRmdirThenUnlinkOrder's pattern of driving an applier
+// stage directly, without a full Apply. backup() must abort loudly rather than clobber the
+// concurrently-created destination (→ ADR-0045, ADR-0017).
+func TestApplierBackupReverifiesDestinationImmediatelyBeforeRename(t *testing.T) {
+	root := realTempDir(t)
+	target := filepath.Join(root, "foo")
+	backupAbs := target + ".nput-backup"
+	if err := os.WriteFile(target, []byte("pre-existing"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Simulates a concurrent writer creating the destination after Compute planned this
+	// BackupAction (which found it absent) but before backup() reached it.
+	if err := os.WriteFile(backupAbs, []byte("concurrently created"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var warns []string
+	a := &applier{opts: Options{Warnf: collectWarnings(&warns)}, result: &Result{}}
+	a.root = root
+	actions := []planner.BackupAction{
+		{Entry: storeEntry(root, ".", "foo"), TargetAbs: target, BackupAbs: backupAbs},
+	}
+	err := a.backup(actions)
+	if err == nil {
+		t.Fatal("expected an error when the backup destination appears between planning and execution, got nil")
+	}
+
+	data, rerr := os.ReadFile(target)
+	if rerr != nil || string(data) != "pre-existing" {
+		t.Errorf("target must be untouched: data=%q, err=%v", data, rerr)
+	}
+	data, rerr = os.ReadFile(backupAbs)
+	if rerr != nil || string(data) != "concurrently created" {
+		t.Errorf("concurrently-created destination must not be clobbered: data=%q, err=%v", data, rerr)
+	}
+	if len(a.result.BackedUp) != 0 {
+		t.Errorf("Result.BackedUp = %v, want none (nothing was actually backed up)", a.result.BackedUp)
 	}
 }

--- a/internal/engine/drift.go
+++ b/internal/engine/drift.go
@@ -53,6 +53,11 @@ func generationUnchanged(profileLink, newLinkFarm string) (bool, error) {
 // affected target, which changes the link-farm derivation. So generationUnchanged is never true
 // for a plan with a non-empty PreRemove, and the gen-skip branch above is not taken. The drift
 // repair therefore has no pre-removal to run.
+//
+// plan.Backup has no such invariant: apply --backup's rename-aside fires on a foreign occupant at
+// a target, which can appear at any time regardless of whether the manifest/derivation changed (a
+// foreign tool can drop a file at the target between shell re-entries). So a gen-skip run backs up
+// and places fresh exactly like normal apply, instead of asserting Backup is empty (→ ADR-0045, issue #169).
 func (a *applier) repairDrift(plan planner.Plan, recopy bool) error {
 	// Defensive guard for the invariant the doc comment relies on: any PreRemove source changes the
 	// manifest (hence the derivation) at its target, so it can never reach the gen-skip path with a
@@ -60,6 +65,9 @@ func (a *applier) repairDrift(plan planner.Plan, recopy bool) error {
 	// nest/place through stale content still occupying the target — fail loudly instead (→ ADR-0046, ADR-0047).
 	if len(plan.PreRemove) > 0 {
 		return fmt.Errorf("nput: internal invariant violated: generation-skip drift repair received %d pre-removal(s) (→ ADR-0046, ADR-0047)", len(plan.PreRemove))
+	}
+	if err := a.backup(plan.Backup); err != nil {
+		return err
 	}
 	drifted := make([]planner.PlaceAction, 0, len(plan.Place))
 	for _, act := range plan.Place {

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -63,6 +63,12 @@ type Options struct {
 	// Recopy is the apply --recopy modifier (unconditionally overwrite/re-copy all copy targets in the config from src · → ADR-0020).
 	// An opt-in path that breaks place-once. The normal apply of the symlink part (stale removal + generation commit) is unchanged.
 	Recopy bool
+	// Backup is the apply --backup modifier: a foreign occupant that would otherwise be a conflict
+	// (or a copy foreign skip) is renamed aside to "<target>.<BackupSuffix>" and the entry placed
+	// fresh, instead of stopping (→ ADR-0045, issue #169).
+	Backup bool
+	// BackupSuffix is the apply --backup rename suffix. Empty defaults to "nput-backup" (→ ADR-0045).
+	BackupSuffix string
 	// DryRun is a side-effect-free read-only preview (apply --dryrun · → ADR-0006, ADR-0023).
 	// When true it runs the planner read-only, packs the plan into Result and returns,
 	// taking none of FS writes / --set / flock / pending gcroot. It builds (src resolution) but does not place.
@@ -88,6 +94,7 @@ type Result struct {
 	Recopied   []string // existing copy targets overwritten/re-copied by --recopy (→ ADR-0020)
 	Removed    []string // stale-removed targets
 	Pruned     []string // empty ancestor directories rmdir-ed after a removal (→ Issue #174, #172 (D4))
+	BackedUp   []string // targets renamed aside to "<target>.<suffix>" under apply --backup (→ ADR-0045)
 	Skipped    bool     // skipped on try-lock contention (NoWait path)
 	DryRun     bool     // read-only preview (Placed etc. are "to be placed" plans · → ADR-0023)
 	Conflicts  []string // conflicts detected in dryrun ("target: reason" · used by the CLI to decide exit 2 · → ADR-0006)
@@ -199,7 +206,7 @@ func Apply(opts Options) (*Result, error) {
 	prev := a.loadPrevManifest()
 
 	// 6. compute the place/replace/remove plan with the planner (pure logic · → internal/planner).
-	plan, err := planner.Compute(prev, a.manifest, a.root, planner.OSFS)
+	plan, err := planner.Compute(prev, a.manifest, a.root, planner.OSFS, a.plannerOptions())
 	if err != nil {
 		return nil, err
 	}
@@ -241,11 +248,16 @@ func Apply(opts Options) (*Result, error) {
 	//    filesystem object occupies a placement target — an ancestor symlink, a real directory
 	//    fully migratable, or a symlink replaced by a symlink→copy method change — so placement
 	//    lands on an empty/absent target · local exception to ADR-0006 · → ADR-0046, ADR-0047),
-	//    then new / re-link, then stale removal last (→ ADR-0006). copy branches: on --recopy overwrite
-	//    all copy targets unconditionally, normally place-once (new copy only when target is absent) (→ ADR-0020).
-	//    Each stage journals its own FS writes; a failure in any of the four unwinds everything this
-	//    run has done so far (across all four, not just the failing stage) before returning (→ ADR-0044).
+	//    then Backup (apply --backup: rename a foreign occupant aside so placement lands on an
+	//    absent target · → ADR-0045), then new / re-link, then stale removal last (→ ADR-0006).
+	//    copy branches: on --recopy overwrite all copy targets unconditionally, normally
+	//    place-once (new copy only when target is absent) (→ ADR-0020).
+	//    Each stage journals its own FS writes; a failure in any of the five unwinds everything this
+	//    run has done so far (across all five, not just the failing stage) before returning (→ ADR-0044).
 	if err := a.runJournaled(func() error { return a.preRemove(plan.PreRemove) }); err != nil {
+		return nil, err
+	}
+	if err := a.runJournaled(func() error { return a.backup(plan.Backup) }); err != nil {
 		return nil, err
 	}
 	if err := a.runJournaled(func() error { return a.place(plan.Place) }); err != nil {
@@ -297,6 +309,12 @@ type applier struct {
 	journal  []undoOp
 }
 
+// plannerOptions translates the apply --backup modifier (opts.Backup / opts.BackupSuffix) into
+// planner.Options for planner.Compute (→ ADR-0045, issue #169).
+func (a *applier) plannerOptions() planner.Options {
+	return planner.Options{Backup: a.opts.Backup, Suffix: a.opts.BackupSuffix}
+}
+
 // runJournaled runs an FS-mutating stage and unwinds the journal recorded so far — by this
 // stage and any earlier ones in the same Apply/Rollback call — if it fails (→ ADR-0044). Stages
 // covered: preRemove, place, materializeCopies, removeStale, repairDrift. A stage succeeding
@@ -334,7 +352,7 @@ func (a *applier) dryRun() (*Result, error) {
 	}
 
 	prev := a.loadPrevManifest()
-	plan, err := planner.Compute(prev, a.manifest, a.root, planner.OSFS)
+	plan, err := planner.Compute(prev, a.manifest, a.root, planner.OSFS, a.plannerOptions())
 	if err != nil {
 		return nil, err
 	}
@@ -364,6 +382,9 @@ func (a *applier) dryRun() (*Result, error) {
 	}
 	for _, r := range plan.Remove {
 		a.result.Removed = append(a.result.Removed, r.Entry.Target)
+	}
+	for _, b := range plan.Backup {
+		a.result.BackedUp = append(a.result.BackedUp, b.Entry.Target)
 	}
 	for _, c := range plan.Conflicts {
 		a.result.Conflicts = append(a.result.Conflicts, fmt.Sprintf("%s: %s", c.Entry.Target, c.Reason))
@@ -469,6 +490,8 @@ func conflictGuidance(kind planner.ConflictKind) string {
 		return "the manifest keeps both this ancestor and an entry nested beneath it; fix the entry definitions"
 	case planner.ConflictCopyStructureMismatch:
 		return "the copy entry's structure no longer matches the existing target; fix the entry definition"
+	case planner.ConflictBackupTargetExists:
+		return "a previous --backup was left at \"<target>.<suffix>\"; move or remove it manually, then re-run --backup"
 	default:
 		return "review the entry definition and the existing target"
 	}

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -490,6 +490,8 @@ func conflictGuidance(kind planner.ConflictKind) string {
 		return "the manifest keeps both this ancestor and an entry nested beneath it; fix the entry definitions"
 	case planner.ConflictCopyStructureMismatch:
 		return "the copy entry's structure no longer matches the existing target; fix the entry definition"
+	case planner.ConflictDirMigrationFailed:
+		return "move or remove the directory's non-migratable contents manually (or use --backup to back up the whole directory), then re-apply"
 	case planner.ConflictBackupTargetExists:
 		return "a previous --backup was left at \"<target>.<suffix>\"; move or remove it manually, then re-run --backup"
 	default:

--- a/internal/engine/generations.go
+++ b/internal/engine/generations.go
@@ -165,7 +165,7 @@ func Rollback(opts RollbackOptions) (*RollbackResult, error) {
 	}
 
 	// 5. compute the plan for N∖N-1 stale removal · N-1 entry re-placement with the planner (reusing the apply engine with (baseline, target) substituted).
-	plan, err := planner.Compute(baseline, target, root, planner.OSFS)
+	plan, err := planner.Compute(baseline, target, root, planner.OSFS, planner.Options{})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/engine/preremove_generalization_test.go
+++ b/internal/engine/preremove_generalization_test.go
@@ -422,7 +422,7 @@ func TestApplyDirMigrationInterruptedAfterPreRemoveReRunConverges(t *testing.T) 
 	srcNew := realTempDir(t)
 	next := projectManifest(storeEntry(srcNew, ".", ".claude/hooks"))
 	prev := projectManifest(storeEntry(srcOld, ".", ".claude/hooks/foo"))
-	plan, err := planner.Compute(&prev, &next, root, planner.OSFS)
+	plan, err := planner.Compute(&prev, &next, root, planner.OSFS, planner.Options{})
 	if err != nil {
 		t.Fatalf("planner.Compute: %v", err)
 	}

--- a/internal/engine/reset.go
+++ b/internal/engine/reset.go
@@ -124,7 +124,7 @@ func Reset(opts ResetOptions) (*ResetResult, error) {
 		}
 	}
 	symManifest := &manifest.Manifest{SchemaVersion: prev.SchemaVersion, Root: prev.Root, Entries: symEntries}
-	plan, err := planner.Compute(symManifest, nil, root, planner.OSFS)
+	plan, err := planner.Compute(symManifest, nil, root, planner.OSFS, planner.Options{})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/engine/undo.go
+++ b/internal/engine/undo.go
@@ -33,6 +33,11 @@ const (
 	// undoRestoreRename renames tmpPath back to path (recopyAll's rename-aside of an existing
 	// copy target before overwriting it — → ADR-0044 §1, ADR-0047 D5 boundary).
 	undoRestoreRename
+	// undoRestoreBackup renames tmpPath (the apply --backup aside) back to path, identically to
+	// undoRestoreRename's inverse. Kept as a distinct kind solely so discardJournal does not sweep
+	// it up on success: a backup aside is user-owned, kept as-is, not transient overwrite debris
+	// (→ ADR-0045, issue #169).
+	undoRestoreBackup
 	// undoMkdir recreates the empty directory removed at path (PreRemove's RemoveRmdir → ADR-0047).
 	undoMkdir
 )
@@ -71,6 +76,14 @@ func (a *applier) journalRenamedAside(path, tmpPath string) {
 	a.journal = append(a.journal, undoOp{kind: undoRestoreRename, path: path, tmpPath: tmpPath})
 }
 
+// journalBackedUp records an apply --backup rename-aside: path's pre-placement occupant was moved
+// to tmpPath (= "<path>.<suffix>") before the fresh placement landed at path (→ ADR-0045, issue
+// #169). Unlike journalRenamedAside, the aside is never cleaned up on success — it is the user's
+// backup, not overwrite debris (→ discardJournal).
+func (a *applier) journalBackedUp(path, tmpPath string) {
+	a.journal = append(a.journal, undoOp{kind: undoRestoreBackup, path: path, tmpPath: tmpPath})
+}
+
 // journalRemovedEmptyDir records an empty directory this run rmdir-ed (PreRemove's RemoveRmdir →
 // ADR-0047), capturing its mode so undo recreates it identically rather than with a fixed default.
 func (a *applier) journalRemovedEmptyDir(path string, mode os.FileMode) {
@@ -82,7 +95,10 @@ func (a *applier) journalRemovedEmptyDir(path string, mode os.FileMode) {
 // rollback's job, not this run's · → ADR-0044 §2). A recopy rename-aside entry's tmpPath still
 // holds the pre-overwrite content at this point (undo was never triggered), so it is cleaned up
 // here rather than left to linger — a warning-only best-effort, since the fresh copy already
-// landed successfully and a leftover aside file is cosmetic, not a correctness issue.
+// landed successfully and a leftover aside file is cosmetic, not a correctness issue. An
+// apply --backup aside (undoRestoreBackup) is deliberately excluded from this sweep: the backup is
+// user-owned and stays on disk indefinitely, not cleaned up by nput (reset does not restore it
+// either · → ADR-0045, issue #169).
 func (a *applier) discardJournal() {
 	for _, op := range a.journal {
 		if op.kind != undoRestoreRename {
@@ -143,7 +159,7 @@ func undoOne(op undoOp) error {
 		return os.Symlink(op.prevDest, op.path)
 	case undoRemoveCopy:
 		return os.RemoveAll(op.path)
-	case undoRestoreRename:
+	case undoRestoreRename, undoRestoreBackup:
 		if err := os.RemoveAll(op.path); err != nil {
 			return err
 		}

--- a/internal/planner/planner.go
+++ b/internal/planner/planner.go
@@ -143,6 +143,10 @@ const (
 	// ConflictCopyStructureMismatch is a copy entry whose src structure (dir/file) mismatches the
 	// existing target kind (→ ADR-0020).
 	ConflictCopyStructureMismatch
+	// ConflictDirMigrationFailed is a real directory occupying a symlink target where at least one
+	// leaf beneath it (any depth) is not safely migratable — a regular file, a foreign or
+	// record-mismatched symlink, or a self-contradictory kept symlink (→ ADR-0047 D2, issue #175).
+	ConflictDirMigrationFailed
 	// ConflictBackupTargetExists is apply --backup's rename-aside destination (<target>.<suffix>)
 	// already occupied by a leftover from a previous backup (→ ADR-0045). Stops rather than
 	// silently overwriting a prior backup, so the user notices before it is lost.
@@ -542,7 +546,21 @@ func classifyRealDirTarget(plan *Plan, e manifest.Entry, targetAbs string, prevB
 		return err
 	}
 	if reason != "" {
-		return appendBackupOrConflict(plan, e, targetAbs, fmt.Sprintf("target directory cannot be fully migrated: %s (→ ADR-0047)", reason), ConflictUnspecified, fs, opts)
+		// Under apply --backup the whole occupying directory is renamed aside as one unit (§ doc
+		// comment above), so every prev entry recorded beneath it — safe or foreign alike — leaves
+		// with it. Mark them preRemoved *before* delegating so the remove-side loop below does not
+		// also try to stale-remove them: at execution time the dir is already gone (renamed), so
+		// removeStale's reverifyStale would see ENOENT and misreport a "drifted after planning"
+		// warning for something that was actually backed up, not drifted (→ ADR-0045). Gated on
+		// opts.Backup: on the plain-conflict path (--backup disabled) a recorded-stale leaf under the
+		// failed dir is deliberately left as an ordinary Remove candidate — harmless since
+		// engine.Apply stops before removeStale on any conflict — and marking it preRemoved here
+		// would incorrectly suppress that existing, tested behavior (→ TestComputeTableDriven "real
+		// dir target, one real file mixed in → conflict").
+		if opts.Backup {
+			markDirEntriesPreRemoved(filepath.Clean(e.Target), prevByTarget, preRemoved)
+		}
+		return appendBackupOrConflict(plan, e, targetAbs, fmt.Sprintf("target directory cannot be fully migrated: %s (→ ADR-0047)", reason), ConflictDirMigrationFailed, fs, opts)
 	}
 	plan.PreRemove = append(plan.PreRemove, dirActions...)
 	plan.PreRemove = append(plan.PreRemove, RemoveAction{Kind: RemoveRmdir, TargetAbs: targetAbs})
@@ -553,6 +571,22 @@ func classifyRealDirTarget(plan *Plan, e manifest.Entry, targetAbs string, prevB
 	}
 	plan.Place = append(plan.Place, PlaceAction{Entry: e, TargetAbs: targetAbs, Dest: LinkDest(e), Kind: PlaceNew})
 	return nil
+}
+
+// markDirEntriesPreRemoved marks every prevByTarget entry whose target lies beneath dirRel (any
+// depth) as preRemoved, without emitting any RemoveAction for them. Used when apply --backup is
+// about to rename a whole occupying directory aside as one unit (→ classifyRealDirTarget, ADR-0045):
+// every recorded entry beneath it — the ones classifyDirMigration would have deemed safe to unlink,
+// and the ones that made the migration fail — leaves with the directory in a single rename, so none
+// of them should also be scheduled (or left unscheduled but re-verified) by the remove-side loop.
+func markDirEntriesPreRemoved(dirRel string, prevByTarget map[string]manifest.Entry, preRemoved map[string]bool) {
+	for target := range prevByTarget {
+		rel, err := filepath.Rel(dirRel, target)
+		if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			continue
+		}
+		preRemoved[target] = true
+	}
 }
 
 // classifyDirMigration walks an occupying real directory (dirAbs, root-relative dirRel) that a

--- a/internal/planner/planner.go
+++ b/internal/planner/planner.go
@@ -102,6 +102,17 @@ type RemoveAction struct {
 	TargetAbs string
 }
 
+// BackupAction renames an occupying foreign filesystem object aside (TargetAbs →
+// BackupAbs = <target>.<suffix>) before placement, when apply --backup is enabled
+// (→ ADR-0045, issue #169). It runs after PreRemove and before Place/Copies: once the
+// rename lands, TargetAbs is absent, so the entry's placement follows the ordinary
+// "target absent" arm (PlaceNew / a new CopyAction) without further special-casing.
+type BackupAction struct {
+	Entry     manifest.Entry
+	TargetAbs string
+	BackupAbs string // <target>.<suffix>
+}
+
 // Conflict is a placement target the engine must stop on: occupied by a non-symlink
 // (regular file / directory) or nested under a symlinked ancestor (→ ADR-0015).
 type Conflict struct {
@@ -132,6 +143,10 @@ const (
 	// ConflictCopyStructureMismatch is a copy entry whose src structure (dir/file) mismatches the
 	// existing target kind (→ ADR-0020).
 	ConflictCopyStructureMismatch
+	// ConflictBackupTargetExists is apply --backup's rename-aside destination (<target>.<suffix>)
+	// already occupied by a leftover from a previous backup (→ ADR-0045). Stops rather than
+	// silently overwriting a prior backup, so the user notices before it is lost.
+	ConflictBackupTargetExists
 )
 
 // WarnKind enumerates non-fatal conditions the planner surfaces to the user.
@@ -158,10 +173,12 @@ type Warning struct {
 }
 
 // Plan is the computed place/replace/remove plan plus non-fatal warnings and
-// fatal conflicts. The engine executes PreRemove → Place / Copies → Remove
+// fatal conflicts. The engine executes PreRemove → Backup → Place / Copies → Remove
 // ("new/re-link first, stale removal last"; PreRemove is a local ordering exception
 // that unlinks self-recorded stale ancestor symlinks *before* placement so children
-// nest into a real directory; → ADR-0006, ADR-0046); a non-empty Conflicts means apply must stop.
+// nest into a real directory; Backup is a further exception under apply --backup that
+// renames a foreign occupant aside so placement lands on an absent target;
+// → ADR-0006, ADR-0044, ADR-0045, ADR-0046); a non-empty Conflicts means apply must stop.
 type Plan struct {
 	Place  []PlaceAction
 	Copies []CopyAction
@@ -171,8 +188,35 @@ type Plan struct {
 	// manual rm. Populated only for ancestors the previous generation recorded and the new
 	// generation drops (recorded ∧ stale); foreign or still-kept ancestors stay Conflicts (→ ADR-0046).
 	PreRemove []RemoveAction
+	// Backup renames a foreign occupant aside (<target>.<suffix>) before placement, only when
+	// apply --backup is enabled (→ ADR-0045). Populated instead of the Conflict/skip that would
+	// otherwise be emitted for a foreign regular file/directory, a fully-foreign real dir target,
+	// a copy structure mismatch, a copy foreign skip, or a copy→symlink method change. Ancestor
+	// symlink conflicts stay out of scope regardless of --backup (→ issue #169).
+	Backup    []BackupAction
 	Conflicts []Conflict
 	Warnings  []Warning
+}
+
+// Options configures Compute's optional behaviors. The zero value is normal apply
+// (backup disabled) (→ ADR-0045, issue #169).
+type Options struct {
+	// Backup enables apply --backup: a foreign occupant that would otherwise be a Conflict
+	// (or, for a copy target, a skip+WarnCopyForeign) is instead renamed aside to
+	// "<target>.<Suffix>" and the entry is placed fresh. Ancestor-symlink conflicts are
+	// unaffected regardless of this flag (→ ADR-0045).
+	Backup bool
+	// Suffix is the backup rename suffix (Backup's target becomes "<target>.<Suffix>").
+	// Empty defaults to "nput-backup" (→ ADR-0045).
+	Suffix string
+}
+
+// backupSuffix returns opts.Suffix, defaulting to "nput-backup" when empty (→ ADR-0045).
+func backupSuffix(opts Options) string {
+	if opts.Suffix == "" {
+		return "nput-backup"
+	}
+	return opts.Suffix
 }
 
 // LinkDest returns the destination the entry's symlink should point to (<src>/<subpath>).
@@ -186,8 +230,9 @@ func LinkDest(e manifest.Entry) string {
 // Compute diffs the previous-generation manifest (prev; nil means first apply)
 // against the new manifest (next), relative to root and FS state, and computes
 // the place/replace/remove plan as pure logic. It has no side effects; the FS
-// changes are applied by the engine (place + stale-remover).
-func Compute(prev, next *manifest.Manifest, root string, fs FS) (Plan, error) {
+// changes are applied by the engine (place + stale-remover). opts configures
+// optional behaviors (apply --backup; the zero Options is normal apply · → ADR-0045).
+func Compute(prev, next *manifest.Manifest, root string, fs FS, opts Options) (Plan, error) {
 	var plan Plan
 
 	// --- place / replace side: classify each new-generation entry against the current FS ---
@@ -245,7 +290,7 @@ func Compute(prev, next *manifest.Manifest, root string, fs FS) (Plan, error) {
 
 		// Branch the place-once / re-link classification per method.
 		if e.Method == manifest.MethodCopy {
-			if err := classifyCopy(&plan, e, targetAbs, prevByTarget, preRemoved, fs); err != nil {
+			if err := classifyCopy(&plan, e, targetAbs, prevByTarget, preRemoved, fs, opts); err != nil {
 				return Plan{}, err
 			}
 			continue
@@ -269,17 +314,15 @@ func Compute(prev, next *manifest.Manifest, root string, fs FS) (Plan, error) {
 			// it is a self-recorded stale symlink or an empty subdirectory (→ ADR-0047, issue #175).
 			// A copy-placed target is out of scope (copy targets never appear here — this arm only
 			// runs for the symlink-method branch).
-			if err := classifyRealDirTarget(&plan, e, targetAbs, prevByTarget, nextByTarget, preRemoved, fs); err != nil {
+			if err := classifyRealDirTarget(&plan, e, targetAbs, prevByTarget, nextByTarget, preRemoved, fs, opts); err != nil {
 				return Plan{}, err
 			}
 		case err == nil:
-			// A regular file is not overwritten (→ docs/spec.md error spec).
-			plan.Conflicts = append(plan.Conflicts, Conflict{
-				Entry:     e,
-				TargetAbs: targetAbs,
-				Reason:    "target already has an existing file/directory (will not overwrite)",
-				Kind:      ConflictForeignEntity,
-			})
+			// A regular file is not overwritten (→ docs/spec.md error spec), unless apply --backup
+			// is enabled, in which case it is renamed aside and the entry placed fresh (→ ADR-0045).
+			if err := appendBackupOrConflict(&plan, e, targetAbs, "target already has an existing file/directory (will not overwrite)", ConflictForeignEntity, fs, opts); err != nil {
+				return Plan{}, err
+			}
 		case os.IsNotExist(err):
 			plan.Place = append(plan.Place, PlaceAction{Entry: e, TargetAbs: targetAbs, Dest: LinkDest(e), Kind: PlaceNew})
 		default:
@@ -369,14 +412,14 @@ func recordedLink(target, targetAbs string, prevByTarget map[string]manifest.Ent
 //
 //	target absent                     → CopyAction (new place-once copy)
 //	target is a self-recorded stale symlink (method changed symlink→copy) → PreRemove(Unlink) + CopyAction (→ ADR-0047 D5)
-//	target exists, structure mismatch → conflict (subpath dir × target file / subpath file × target dir)
+//	target exists, structure mismatch → conflict, or backup + CopyAction under apply --backup (→ ADR-0045)
 //	target exists, recorded           → no-op (placed by nput in a previous generation; place-once leaves it untouched)
-//	target exists, foreign            → skip + WarnCopyForeign (unrecorded real file; masking prevention)
+//	target exists, foreign            → skip + WarnCopyForeign, or backup + CopyAction under apply --backup (→ ADR-0045)
 //
 // recopy (apply --recopy) is a separate path that breaks place-once: the engine
 // overwrites the manifest's copy entry directly. The planner only does the
 // normal place-once classification (→ ADR-0020).
-func classifyCopy(plan *Plan, e manifest.Entry, targetAbs string, prevByTarget map[string]manifest.Entry, preRemoved map[string]bool, fs FS) error {
+func classifyCopy(plan *Plan, e manifest.Entry, targetAbs string, prevByTarget map[string]manifest.Entry, preRemoved map[string]bool, fs FS, opts Options) error {
 	info, err := fs.Lstat(targetAbs)
 	switch {
 	case err == nil && info.Mode()&os.ModeSymlink != 0 && prevByTarget[e.Target].Method == manifest.MethodSymlink && recordedLink(e.Target, targetAbs, prevByTarget, fs):
@@ -402,17 +445,14 @@ func classifyCopy(plan *Plan, e manifest.Entry, targetAbs string, prevByTarget m
 			return err
 		}
 		if mismatch {
-			plan.Conflicts = append(plan.Conflicts, Conflict{
-				Entry:     e,
-				TargetAbs: targetAbs,
-				Reason:    "copy src structure and target kind mismatch (dir↔file; will not overwrite)",
-				Kind:      ConflictCopyStructureMismatch,
-			})
-			return nil
+			return appendBackupOrConflict(plan, e, targetAbs, "copy src structure and target kind mismatch (dir↔file; will not overwrite)", ConflictCopyStructureMismatch, fs, opts)
 		}
 		// place-once: leave a copy recorded by the previous generation untouched. An unrecorded real file gets a foreign warning.
 		if pe, ok := prevByTarget[e.Target]; ok && pe.Method == manifest.MethodCopy {
 			return nil
+		}
+		if opts.Backup {
+			return appendBackup(plan, e, targetAbs, fs, opts)
 		}
 		plan.Warnings = append(plan.Warnings, Warning{Kind: WarnCopyForeign, Target: e.Target})
 		return nil
@@ -422,6 +462,40 @@ func classifyCopy(plan *Plan, e manifest.Entry, targetAbs string, prevByTarget m
 	default:
 		return fmt.Errorf("nput: cannot lstat copy target (%s): %w", targetAbs, err)
 	}
+}
+
+// appendBackupOrConflict is the shared decision point for every foreign-occupant conflict site
+// (symlink method's foreign regular file, copy method's structure mismatch): under normal apply
+// it appends the Conflict the caller describes; under apply --backup it instead schedules a
+// rename-aside of targetAbs and places the entry fresh (→ ADR-0045, issue #169).
+func appendBackupOrConflict(plan *Plan, e manifest.Entry, targetAbs, reason string, kind ConflictKind, fs FS, opts Options) error {
+	if !opts.Backup {
+		plan.Conflicts = append(plan.Conflicts, Conflict{Entry: e, TargetAbs: targetAbs, Reason: reason, Kind: kind})
+		return nil
+	}
+	return appendBackup(plan, e, targetAbs, fs, opts)
+}
+
+// appendBackup schedules targetAbs to be renamed aside to "<targetAbs>.<suffix>" and appends the
+// entry's fresh placement (as if the target had always been absent), under apply --backup
+// (→ ADR-0045, issue #169). It conflicts instead (ConflictBackupTargetExists) when the rename
+// destination is itself already occupied — by a leftover from an earlier backup, most likely —
+// rather than silently clobbering it.
+func appendBackup(plan *Plan, e manifest.Entry, targetAbs string, fs FS, opts Options) error {
+	backupAbs := targetAbs + "." + backupSuffix(opts)
+	if _, err := fs.Lstat(backupAbs); err == nil {
+		plan.Conflicts = append(plan.Conflicts, Conflict{
+			Entry:     e,
+			TargetAbs: targetAbs,
+			Reason:    fmt.Sprintf("backup destination already exists (%s); remove or move it manually before re-running --backup", backupAbs),
+			Kind:      ConflictBackupTargetExists,
+		})
+		return nil
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("nput: cannot lstat backup destination (%s): %w", backupAbs, err)
+	}
+	plan.Backup = append(plan.Backup, BackupAction{Entry: e, TargetAbs: targetAbs, BackupAbs: backupAbs})
+	return appendAbsentPlacement(plan, e, targetAbs)
 }
 
 // appendAbsentPlacement records the placement for an entry whose target is known to be absent
@@ -456,22 +530,19 @@ func copyStructureMismatch(e manifest.Entry, targetInfo os.FileInfo, fs FS) (boo
 // classifyRealDirTarget classifies a symlink-method entry whose target is occupied by a real
 // directory (→ ADR-0047, issue #175). Mirrors classifyCopy's role for the copy-method branch:
 // it owns the full decision — walk the tree via classifyDirMigration, emit a Conflict on
-// failure, or on success append the PreRemove actions (children before the target itself),
-// dedup the unlinked children against the remove-side loop's preRemoved map (→ ADR-0046 dedup
-// convention: each unlinked child is also a stale entry in prev.Entries and must not be
-// scheduled there a second time), and append the new-symlink Place action.
-func classifyRealDirTarget(plan *Plan, e manifest.Entry, targetAbs string, prevByTarget, nextByTarget map[string]manifest.Entry, preRemoved map[string]bool, fs FS) error {
+// failure (or, under apply --backup, rename the whole occupying directory aside in one piece
+// rather than partially migrating it — consistent with ADR-0047's "no partial removal" stance
+// · → ADR-0045, issue #169), or on success append the PreRemove actions (children before the
+// target itself), dedup the unlinked children against the remove-side loop's preRemoved map
+// (→ ADR-0046 dedup convention: each unlinked child is also a stale entry in prev.Entries and
+// must not be scheduled there a second time), and append the new-symlink Place action.
+func classifyRealDirTarget(plan *Plan, e manifest.Entry, targetAbs string, prevByTarget, nextByTarget map[string]manifest.Entry, preRemoved map[string]bool, fs FS, opts Options) error {
 	dirActions, reason, err := classifyDirMigration(filepath.Clean(e.Target), targetAbs, prevByTarget, nextByTarget, fs)
 	if err != nil {
 		return err
 	}
 	if reason != "" {
-		plan.Conflicts = append(plan.Conflicts, Conflict{
-			Entry:     e,
-			TargetAbs: targetAbs,
-			Reason:    fmt.Sprintf("target directory cannot be fully migrated: %s (→ ADR-0047)", reason),
-		})
-		return nil
+		return appendBackupOrConflict(plan, e, targetAbs, fmt.Sprintf("target directory cannot be fully migrated: %s (→ ADR-0047)", reason), ConflictUnspecified, fs, opts)
 	}
 	plan.PreRemove = append(plan.PreRemove, dirActions...)
 	plan.PreRemove = append(plan.PreRemove, RemoveAction{Kind: RemoveRmdir, TargetAbs: targetAbs})

--- a/internal/planner/planner_test.go
+++ b/internal/planner/planner_test.go
@@ -576,8 +576,13 @@ func TestComputeTableDriven(t *testing.T) {
 			// independently a stale entry in prev.Entries under the ordinary remove-side loop (it
 			// was never added to preRemoved, since the dir classification failed before dedup-ing
 			// it). This is harmless: engine.Apply stops before removeStale on any conflict, so this
-			// planned removal never executes (→ ADR-0047).
-			want: want{conflicts: 1, remove: []string{".claude/hooks/foo/main.sh"}},
+			// planned removal never executes (→ ADR-0047). --backup is disabled in this case, so
+			// markDirEntriesPreRemoved is not invoked either (→ ADR-0045).
+			want: want{
+				conflicts:     1,
+				conflictKinds: []ConflictKind{ConflictDirMigrationFailed},
+				remove:        []string{".claude/hooks/foo/main.sh"},
+			},
 		},
 		{
 			// Real directory whose new generation still records a nested child at the same relative
@@ -662,18 +667,6 @@ func TestComputeTableDriven(t *testing.T) {
 			want: want{placeNew: []string{".config/foo"}, backup: []string{".config/foo"}},
 		},
 		{
-			// apply --backup with no --backup=<suffix> uses the default "nput-backup" suffix; the
-			// backup destination check reads "<target>.nput-backup" (verified indirectly by NOT
-			// pre-populating that path — if the code used a different default this would conflict
-			// instead of placing cleanly, and want would need conflicts:1).
-			name: "backup enabled, default suffix (no custom Suffix given)",
-			prev: nil,
-			next: mani(sl(srcB, ".config/foo")),
-			fs:   fakeFS{abs(".config/foo"): reg()},
-			opts: Options{Backup: true},
-			want: want{placeNew: []string{".config/foo"}, backup: []string{".config/foo"}},
-		},
-		{
 			// apply --backup with a custom suffix: the backup destination is "<target>.<suffix>", not
 			// the default "<target>.nput-backup" — proven by pre-populating the DEFAULT-suffix path
 			// with a foreign entity the plan must never touch, while the custom-suffix path stays free.
@@ -740,6 +733,26 @@ func TestComputeTableDriven(t *testing.T) {
 				abs(".claude"):               dir(),
 				abs(".claude/hooks"):         dir(),
 				abs(".claude/hooks/foo.txt"): reg(), // foreign regular file leaf → normally makes the whole dir conflict
+			},
+			opts: Options{Backup: true},
+			want: want{placeNew: []string{".claude/hooks"}, backup: []string{".claude/hooks"}},
+		},
+		{
+			// apply --backup on a dir migration failure must not also schedule the dir's safe
+			// (recorded ∧ stale) leaves on the remove-side: the whole dir is renamed aside as one
+			// unit, so a leaf recorded by prev is neither a lingering Remove candidate nor a
+			// "drifted after planning" false warning at execution time (→ ADR-0045). "safe.sh" alone
+			// would normally be a clean RemoveUnlink candidate (classifyDirMigration would accept it
+			// individually), but "foo.txt" forces the whole-dir backup path, which must also absorb
+			// "safe.sh" out of the remove side rather than leaving it stranded there.
+			name: "backup enabled, real dir target with foreign leaf: sibling recorded-stale leaf must not linger on remove side",
+			prev: mani(sl(srcA, ".claude/hooks/safe.sh")),
+			next: mani(sl(srcB, ".claude/hooks")),
+			fs: fakeFS{
+				abs(".claude"):               dir(),
+				abs(".claude/hooks"):         dir(),
+				abs(".claude/hooks/foo.txt"): reg(),     // foreign regular file leaf → forces whole-dir backup
+				abs(".claude/hooks/safe.sh"): sym(srcA), // recorded ∧ stale on its own, but dropped by next
 			},
 			opts: Options{Backup: true},
 			want: want{placeNew: []string{".claude/hooks"}, backup: []string{".claude/hooks"}},

--- a/internal/planner/planner_test.go
+++ b/internal/planner/planner_test.go
@@ -130,6 +130,7 @@ type want struct {
 	remove       []string
 	preRemove    []string // RemoveUnlink actions, by Entry.Target
 	preRemoveDir []string // RemoveRmdir actions, by root-relative TargetAbs
+	backup       []string // BackupAction entries, by Entry.Target (→ ADR-0045)
 	warns        []WarnKind
 	conflicts    int
 	// conflictKinds asserts plan.Conflicts[i].Kind in order (nil = skip; the conflicts count
@@ -188,6 +189,14 @@ func copyTargets(p Plan) []string {
 	return out
 }
 
+func backupTargets(p Plan) []string {
+	var out []string
+	for _, a := range p.Backup {
+		out = append(out, a.Entry.Target)
+	}
+	return out
+}
+
 func warnKinds(p Plan) []WarnKind {
 	var out []WarnKind
 	for _, w := range p.Warnings {
@@ -240,6 +249,7 @@ func TestComputeTableDriven(t *testing.T) {
 		prev *manifest.Manifest
 		next *manifest.Manifest
 		fs   fakeFS
+		opts Options // zero value = normal apply (backup disabled)
 		want want
 	}{
 		{
@@ -642,6 +652,109 @@ func TestComputeTableDriven(t *testing.T) {
 			want: want{conflicts: 1},
 		},
 		{
+			// apply --backup: a regular file occupying a symlink target is backed up instead of
+			// conflicting, and the entry places fresh (→ ADR-0045, issue #169).
+			name: "backup enabled, regular file at symlink target → backup + placeNew",
+			prev: nil,
+			next: mani(sl(srcB, ".config/foo")),
+			fs:   fakeFS{abs(".config/foo"): reg()},
+			opts: Options{Backup: true},
+			want: want{placeNew: []string{".config/foo"}, backup: []string{".config/foo"}},
+		},
+		{
+			// apply --backup with no --backup=<suffix> uses the default "nput-backup" suffix; the
+			// backup destination check reads "<target>.nput-backup" (verified indirectly by NOT
+			// pre-populating that path — if the code used a different default this would conflict
+			// instead of placing cleanly, and want would need conflicts:1).
+			name: "backup enabled, default suffix (no custom Suffix given)",
+			prev: nil,
+			next: mani(sl(srcB, ".config/foo")),
+			fs:   fakeFS{abs(".config/foo"): reg()},
+			opts: Options{Backup: true},
+			want: want{placeNew: []string{".config/foo"}, backup: []string{".config/foo"}},
+		},
+		{
+			// apply --backup with a custom suffix: the backup destination is "<target>.<suffix>", not
+			// the default "<target>.nput-backup" — proven by pre-populating the DEFAULT-suffix path
+			// with a foreign entity the plan must never touch, while the custom-suffix path stays free.
+			name: "backup enabled, custom suffix",
+			prev: nil,
+			next: mani(sl(srcB, ".config/foo")),
+			fs: fakeFS{
+				abs(".config/foo"):             reg(),
+				abs(".config/foo.nput-backup"): reg(), // must be left alone; custom suffix is used instead
+			},
+			opts: Options{Backup: true, Suffix: "bak"},
+			want: want{placeNew: []string{".config/foo"}, backup: []string{".config/foo"}},
+		},
+		{
+			// apply --backup: the backup destination itself already exists (a leftover from an
+			// earlier backup) → conflict rather than silently clobbering it (→ ADR-0045).
+			name: "backup enabled, backup destination already exists → conflict",
+			prev: nil,
+			next: mani(sl(srcB, ".config/foo")),
+			fs: fakeFS{
+				abs(".config/foo"):             reg(),
+				abs(".config/foo.nput-backup"): reg(),
+			},
+			opts: Options{Backup: true},
+			want: want{conflicts: 1, conflictKinds: []ConflictKind{ConflictBackupTargetExists}},
+		},
+		{
+			// apply --backup: a copy structure mismatch is backed up instead of conflicting.
+			name: "backup enabled, copy structure mismatch → backup + copy",
+			prev: nil,
+			next: mani(cp(srcA, ".config/foo")),
+			fs:   fakeFS{srcA: dir(), abs(".config/foo"): reg()},
+			opts: Options{Backup: true},
+			want: want{copies: []string{".config/foo"}, backup: []string{".config/foo"}},
+		},
+		{
+			// apply --backup: a copy target occupied by a foreign real file is backed up and a fresh
+			// copy placed, instead of the usual skip+WarnCopyForeign (→ ADR-0045).
+			name: "backup enabled, copy foreign file → backup + copy (no WarnCopyForeign)",
+			prev: nil,
+			next: mani(cp(srcA, ".config/foo")),
+			fs:   fakeFS{srcA: reg(), abs(".config/foo"): reg()},
+			opts: Options{Backup: true},
+			want: want{copies: []string{".config/foo"}, backup: []string{".config/foo"}},
+		},
+		{
+			// apply --backup: method changed copy→symlink is backed up instead of the usual
+			// non-migrated conflict — --backup is the escape hatch ADR-0047 D5 promised.
+			name: "backup enabled, method change copy→symlink → backup + placeNew",
+			prev: mani(cp(srcA, ".config/tool.conf")),
+			next: mani(sl(srcB, ".config/tool.conf")),
+			fs:   fakeFS{abs(".config/tool.conf"): reg()},
+			opts: Options{Backup: true},
+			want: want{placeNew: []string{".config/tool.conf"}, backup: []string{".config/tool.conf"}},
+		},
+		{
+			// apply --backup: a real directory target that fails full migration (a foreign leaf
+			// mixed in) is backed up whole rather than partially migrated — consistent with
+			// ADR-0047's "no partial removal" stance (→ ADR-0045, issue #169).
+			name: "backup enabled, real dir target with foreign leaf → backup whole dir + placeNew",
+			prev: nil,
+			next: mani(sl(srcB, ".claude/hooks")),
+			fs: fakeFS{
+				abs(".claude"):               dir(),
+				abs(".claude/hooks"):         dir(),
+				abs(".claude/hooks/foo.txt"): reg(), // foreign regular file leaf → normally makes the whole dir conflict
+			},
+			opts: Options{Backup: true},
+			want: want{placeNew: []string{".claude/hooks"}, backup: []string{".claude/hooks"}},
+		},
+		{
+			// apply --backup does NOT extend to ancestor-symlink conflicts (out of scope per issue
+			// #169 / ADR-0045): a foreign ancestor symlink still stops the world even with --backup.
+			name: "backup enabled, foreign ancestor symlink → still conflict (out of scope)",
+			prev: nil,
+			next: mani(sl(srcB, ".claude/skills/nix")),
+			fs:   fakeFS{abs(".claude"): sym("/some/store")},
+			opts: Options{Backup: true},
+			want: want{conflicts: 1, conflictKinds: []ConflictKind{ConflictForeignAncestor}},
+		},
+		{
 			// mixed: new + silent re-link + foreign warning + stale removal + mismatch kept.
 			name: "mixed plan",
 			prev: mani(sl(srcA, "keep"), sl(srcA, "drop"), sl(srcA, "mism")),
@@ -665,7 +778,7 @@ func TestComputeTableDriven(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			plan, err := Compute(tt.prev, tt.next, root, tt.fs)
+			plan, err := Compute(tt.prev, tt.next, root, tt.fs, tt.opts)
 			if err != nil {
 				t.Fatalf("Compute: unexpected error: %v", err)
 			}
@@ -676,6 +789,7 @@ func TestComputeTableDriven(t *testing.T) {
 			sortedEq(t, "remove", removeTargets(plan), tt.want.remove)
 			sortedEq(t, "preRemove", preRemoveTargets(plan), tt.want.preRemove)
 			sortedEq(t, "preRemoveDir", preRemoveDirTargets(plan), tt.want.preRemoveDir)
+			sortedEq(t, "backup", backupTargets(plan), tt.want.backup)
 			warnEq(t, warnKinds(plan), tt.want.warns)
 			if len(plan.Conflicts) != tt.want.conflicts {
 				t.Errorf("conflicts = %d, want %d (%v)", len(plan.Conflicts), tt.want.conflicts, plan.Conflicts)
@@ -725,7 +839,7 @@ func TestComputeDirMigrationPreRemoveOrderIsBottomUp(t *testing.T) {
 		abs(".claude/hooks/foo/sub/leaf.sh"): sym(src),
 	}
 
-	plan, err := Compute(prev, next, root, fs)
+	plan, err := Compute(prev, next, root, fs, Options{})
 	if err != nil {
 		t.Fatalf("Compute: unexpected error: %v", err)
 	}
@@ -777,7 +891,7 @@ func TestComputeDirMigrationPreRemoveOrderIsBottomUp(t *testing.T) {
 func TestComputeUnknownMethodErrors(t *testing.T) {
 	e := sl("/nix/store/x", ".config/foo")
 	e.Method = "bogus"
-	_, err := Compute(nil, mani(e), root, fakeFS{})
+	_, err := Compute(nil, mani(e), root, fakeFS{}, Options{})
 	if err == nil {
 		t.Fatal("expected error for unknown method, got nil")
 	}
@@ -786,7 +900,7 @@ func TestComputeUnknownMethodErrors(t *testing.T) {
 // TestComputeAncestorDirNotSymlink confirms that no conflict arises when the ancestor is a regular directory.
 func TestComputeAncestorDirNotSymlink(t *testing.T) {
 	plan, err := Compute(nil, mani(sl("/nix/store/x", ".config/foo")), root,
-		fakeFS{abs(".config"): dir()})
+		fakeFS{abs(".config"): dir()}, Options{})
 	if err != nil {
 		t.Fatalf("Compute: %v", err)
 	}

--- a/modules/common.nix
+++ b/modules/common.nix
@@ -38,5 +38,31 @@ in
         error (→ docs/spec.md "entries schema").
       '';
     };
+
+    backup = lib.mkOption {
+      type = lib.types.submodule {
+        options = {
+          enable = lib.mkEnableOption ''
+            back up an occupying foreign entity to "<target>.<suffix>" before placing it,
+            instead of stopping on conflict (wires activation's apply --backup; → ADR-0045)
+          '';
+          suffix = lib.mkOption {
+            type = lib.types.str;
+            default = "nput-backup";
+            description = ''
+              The backup rename suffix (activation wires apply --backup=<suffix>). The
+              backup destination becomes "<target>.<suffix>" (→ ADR-0045).
+            '';
+          };
+        };
+      };
+      default = { };
+      description = ''
+        apply --backup wiring: renames an occupying foreign entity aside instead of
+        conflicting (→ ADR-0045). This is a placement modifier orthogonal to `entries`
+        and does not touch the manifest v1 contract (lib/types.nix) — activation only
+        adds `--backup=<suffix>` to the `nput apply --manifest` invocation when enabled.
+      '';
+    };
   };
 }

--- a/modules/home-manager.nix
+++ b/modules/home-manager.nix
@@ -42,9 +42,12 @@ in
     # Kick the engine from home.activation. Since the pre-built link-farm is passed via --manifest,
     # no nix eval/build is done inside activation (this is not the entrypoint path). Run it after
     # writeBoundary so it does not collide in ordering with home.file's symlink placement. `run` is home-manager's
-    # activation helper and honors --dry-run (DRY_RUN_CMD).
+    # activation helper and honors --dry-run (DRY_RUN_CMD). nput.backup.enable wires --backup=<suffix>
+    # onto the same invocation (→ ADR-0045); the suffix is shell-quoted since it is user-supplied.
     home.activation.nput = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
-      run ${lib.getExe nputPackage} apply --manifest ${manifest}
+      run ${lib.getExe nputPackage} apply --manifest ${manifest}${
+        lib.optionalString cfg.backup.enable " --backup=${lib.escapeShellArg cfg.backup.suffix}"
+      }
     '';
   };
 }

--- a/modules/home-manager.nix
+++ b/modules/home-manager.nix
@@ -45,9 +45,7 @@ in
     # activation helper and honors --dry-run (DRY_RUN_CMD). nput.backup.enable wires --backup=<suffix>
     # onto the same invocation (→ ADR-0045); the suffix is shell-quoted since it is user-supplied.
     home.activation.nput = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
-      run ${lib.getExe nputPackage} apply --manifest ${manifest}${
-        lib.optionalString cfg.backup.enable " --backup=${lib.escapeShellArg cfg.backup.suffix}"
-      }
+      run ${lib.getExe nputPackage} apply --manifest ${manifest}${lib.optionalString cfg.backup.enable " --backup=${lib.escapeShellArg cfg.backup.suffix}"}
     '';
   };
 }


### PR DESCRIPTION
## 概要

<!-- なぜ・何を変えるか。Conventional Commits のタイトルだけでは残らない背景を書く。 -->

`apply --backup[=suffix]` を実装する。配置先に既存の**記録外（foreign）**実体があるとき、`<target>.<suffix>` へ rename 退避してから配置する opt-in の脱出ハッチ（既定 suffix `nput-backup`）。

対象は symlink モードの foreign 実 file/dir・実 dir target の migration 失敗（ADR-0047）・copy 構造不一致・copy foreign skip・method 変更 copy→symlink（ADR-0047 D5 が自動移行しないと決めたケース）。**祖先 symlink conflict は対象外**（構造問題であり退避では解消しない）。退避先が既に存在する場合は黙って上書きせず conflict にする。退避操作は #168（ADR-0044 の undo ジャーナル）にそのまま乗り、途中失敗時は rename back で巻き戻される。成功時は `--recopy` の一時退避と異なり退避物を残置する（reset も復元しない・ユーザー所有物として引き渡す）。

HM モジュールには `nput.backup.enable` / `nput.backup.suffix`（submodule）を追加し、activation の `nput apply --manifest` 起動へ `--backup=<suffix>` を配線する（manifest v1 契約には触れない起動配線レイヤーのみの変更）。

diff-review（design / test レンズ、2 巡）で検出された指摘は全て修正済み: dir 丸ごと backup 退避時に配下の recorded-stale symlink が remove-side へ二重計上され誤った drift warning を出す不具合、`repairDrift`（世代スキップ経路）での backup 未検証、engine 側 rename 直前の TOCTOU 再検証未検証、CLI 出力の no-op 判定漏れ。

## 関連 issue

<!-- 例: Closes #N / Refs #N。なければ「なし」。 -->

Closes #169
Refs #172

## docs / ADR 影響

<!--
このリポジトリはドキュメント主導。配置動作・API・方針に触れる変更は docs の更新がセットになる。
- concept / design / spec の更新有無
- 方針転換や trade-off を伴うなら ADR を追加したか（docs/adr/）
影響がなければ「なし」と明記する。
-->

- `docs/adr/0045-backup-flag-for-foreign-entity-rename-aside.md` を新規起票
- `docs/adr/0044-undo-journal-for-partial-apply-failure.md` / `docs/adr/0047-preremove-generalization.md` に、それぞれが予告していた `--backup` 連携の実装完了を示す改訂注記を追記
- `docs/spec.md` を更新: CLI リファレンス・グローバルフラグ・配置動作仕様（symlink/copy モードの backup 分岐・実行順序）・途中失敗時の巻き戻し・エラー仕様表・conflict の全件報告ガイダンス・モジュールオプション仕様
