### PR TITLE
docs(concept): 配置を塞ぐ空 dir の由来問わず自動除去を HM 超え観点へ追記

### DIFF
--- a/docs/concept.md
+++ b/docs/concept.md
@@ -339,10 +339,11 @@ home-manager の `home.file`（`files.nix`）と nput はどちらも「symlink 
 
 1. **同名 leaf を含む per-file → dir symlink 遷移の自動移行**: `foo/main.sh`（per-file 配置）を `foo`（dir symlink）へ定義変更したとき、home-manager は cleanup の存在判定が新世代の dir symlink を辿って旧 leaf の残存を誤認し、部分適用で失敗しうる。nput は manifest 記録との一致判定（recorded ∧ stale）で安全に自動移行する（→ ADR-0046, ADR-0047）。
 2. **所有判定の厳密さ**: home-manager は readlink の glob パターンマッチ（`*-home-manager-files/*` 相当）で「自分が置いたものか」を判定する。nput は「記録した配置先 + on-disk の readlink が記録 dest と完全一致」で判定する。この厳密さが、実 dir target 配下の recorded ∧ stale leaf を漏れなく検出する自動移行の土台になっている。
-3. **祖先 symlink の安全性**: home-manager は配置先の祖先 component が symlink でも無検査で辿る（`os.MkdirAll` 相当が書込可能な先なら無警告で汚染し、read-only な先なら部分適用停止になりうる）。nput は foreign な祖先 symlink を conflict で停止し、自己記録の stale 祖先symlink のみ配置前除去（PreRemove）で migration する（→ ADR-0046）。
-4. **rename 可用性 + fail-fast drift**: home-manager は cleanup（除去）を配置より先に行うため、rename 相当（旧 target 削除 + 新 target 追加）の適用中にクラッシュすると、新旧どちらのパスにも実体が無い瞬間が生じうる。nput は「配置を塞ぐ依存除去のみ」を前段化し、独立した stale 除去は本流どおり最後に行う（ADR-0006 の「新規・張替を先に、stale 除去を最後に」は不変）。前段化した除去が drift（記録との不一致）を検出した場合は skip せず error で停止し、握りつぶさない（→ ADR-0047）。
+3. **配置を塞ぐ空 dir の由来を問わない自動除去**: 配置先に空のディレクトリが既存のとき、home-manager は所有判定が readlink 依存で実 dir に効かないため collision として停止する（バックアップ指定や手動除去をユーザーに求める）。nput は rmdir が空 dir にしか成功しない＝損失ゼロであることを利用し、由来を問わず配置前除去（PreRemove）の対象に含めて自動で配置を通す。実 dir target 配下の空 sub dir も同様（→ ADR-0047、`docs/spec.md`「配置動作仕様」0.5）。
+4. **祖先 symlink の安全性**: home-manager は配置先の祖先 component が symlink でも無検査で辿る（`os.MkdirAll` 相当が書込可能な先なら無警告で汚染し、read-only な先なら部分適用停止になりうる）。nput は foreign な祖先 symlink を conflict で停止し、自己記録の stale 祖先symlink のみ配置前除去（PreRemove）で migration する（→ ADR-0046）。
+5. **rename 可用性 + fail-fast drift**: home-manager は cleanup（除去）を配置より先に行うため、rename 相当（旧 target 削除 + 新 target 追加）の適用中にクラッシュすると、新旧どちらのパスにも実体が無い瞬間が生じうる。nput は「配置を塞ぐ依存除去のみ」を前段化し、独立した stale 除去は本流どおり最後に行う（ADR-0006 の「新規・張替を先に、stale 除去を最後に」は不変）。前段化した除去が drift（記録との不一致）を検出した場合は skip せず error で停止し、握りつぶさない（→ ADR-0047）。
 
-home-manager の空 dir 剪定・conflict 全件報告は nput も同等の挙動を持つ（パリティ項目・HM 超えではない。→ `docs/spec.md`「空親ディレクトリ剪定」「conflict の全件報告」）。method 変更（symlink → copy）を跨ぐ自動移行や、copy を含めた `reset` によるロールバックは copy という概念自体が home-manager に存在しないカテゴリであり、比較の対象外である。
+stale 除去後に残った空親ディレクトリの剪定（cleanup 後の掃除。観点 3 の「配置を塞ぐ空 dir の除去」とは別物）・conflict 全件報告は nput も同等の挙動を持つ（パリティ項目・HM 超えではない。→ `docs/spec.md`「空親ディレクトリ剪定」「conflict の全件報告」）。method 変更（symlink → copy）を跨ぐ自動移行や、copy を含めた `reset` によるロールバックは copy という概念自体が home-manager に存在しないカテゴリであり、比較の対象外である。
 
 特に **system-manager** とは、パッケージ / systemd / `/etc` というドメインこそ重なるが、
 「モジュールで隠す」か「純粋関数でユーザーが握る」かというアプローチが思想レベルで異なるため競合しない。


### PR DESCRIPTION
<!--
PR テンプレート（ソロ運用・最小構成）。
チェックリストは置かない。形骸化を避け、このリポジトリで実際に意味のある 3 点だけ書く。
-->

## 概要

<!-- なぜ・何を変えるか。Conventional Commits のタイトルだけでは残らない背景を書く。 -->

#177 の followup。PR #183 で追加した `docs/concept.md`「home-manager `home.file` との配置意味論の差」を issue #177 の骨子(HM 超えの 6 観点)と突合したところ、観点 3「**空 dir の由来問わず除去**」が欠落していた(マージ済みの文は空親 dir の**剪定**〔#174・パリティ項目〕のみに触れ、「配置を塞ぐ空 dir を由来問わず PreRemove で自動除去する〔HM は collision 停止〕」という HM 超えの観点が書かれていなかった)。

比較リストへ観点 3 として追記し(既存の祖先 symlink・rename 可用性は 4・5 へ繰り下げ)、パリティ項目の段落は「stale 除去後に残った空親ディレクトリの剪定(cleanup 後の掃除)」と明示して観点 3 との混同を避けた。記述は `docs/spec.md`「配置動作仕様」0.5 / ADR-0047 の実装済み意味論に基づく。

なお PR #183 はマージ時点の本文が `Closes #173` のままだったため #177 が auto-close されていない。本 PR のマージで #177 を close する。

## 関連 issue

<!-- 例: Closes #N / Refs #N。なければ「なし」。 -->

Closes #177
Refs #172

## docs / ADR 影響

<!--
このリポジトリはドキュメント主導。配置動作・API・方針に触れる変更は docs の更新がセットになる。
- concept / design / spec の更新有無
- 方針転換や trade-off を伴うなら ADR を追加したか（docs/adr/）
影響がなければ「なし」と明記する。
-->

- `docs/concept.md` のみ更新(本 PR の本体)。
- 新規 ADR は無し。ADR-0047 / `docs/spec.md` で確定済みの意味論をコンセプト文書へ転記するのみで、方針転換は含まない。
