### PR TITLE
ci(bump): workflow_dispatch で VERSION を bot 名義 bump する workflow を追加

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,0 +1,59 @@
+name: Bump Version
+
+# バージョン bump を省力化する workflow（ADR-0042 §2）。VERSION を書き換えて
+# `chore: bump version to X` を bot 名義でコミット・push し、通常の PR フローで
+# マージする（マージが release.yml を駆動する）。
+#
+# これは唯一の経路ではない: 手元で VERSION を直接編集して PR を作る手動経路も
+# 同格に有効。この workflow はその手作業を肩代わりするだけで、bump の正規手段を
+# 独占しない（ADR-0042 §2）。
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "New version (semver, e.g. 0.2.0)"
+        required: true
+        type: string
+
+# git commit / push しか行わないので書き込み権限は contents のみに絞る。
+permissions:
+  contents: write
+
+jobs:
+  bump:
+    # 非 main ブランチ上でのみ実行する（cryoflow 同型）。bump コミットは branch
+    # 上で積み、マージは人間の PR 操作という ADR-0025（main 直コミット禁止）の
+    # 動線に乗せる。main 上で誤起動しても no-op で終わる。
+    if: github.ref_name != 'main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Bump VERSION and commit
+        env:
+          VERSION_INPUT: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+
+          # semver（X.Y.Z）以外は受け付けない。不正入力で VERSION を壊さない。
+          if ! printf '%s' "$VERSION_INPUT" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::invalid version '$VERSION_INPUT' (expected semver X.Y.Z)"
+            exit 1
+          fi
+
+          printf '%s\n' "$VERSION_INPUT" > VERSION
+
+          # bot 名義でコミットする（github-actions[bot]）。
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          # 入力が現在の VERSION と同一なら差分が無く commit できないので早期終了する。
+          if git diff --quiet -- VERSION; then
+            echo "VERSION is already '$VERSION_INPUT'; nothing to commit."
+            exit 0
+          fi
+
+          git add VERSION
+          git commit -m "chore: bump version to $VERSION_INPUT"
+          git push origin "HEAD:$GITHUB_REF_NAME"

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -56,4 +56,11 @@ jobs:
 
           git add VERSION
           git commit -m "chore: bump version to $VERSION_INPUT"
-          git push origin "HEAD:$GITHUB_REF_NAME"
+
+          # push が non-fast-forward で reject される（dispatch 後にブランチが
+          # 進んだ場合など）と git の生メッセージしか残らず、運用者に次の一手が
+          # 伝わらない。失敗を捕捉して ::error:: で対処方針を明示し fail-fast する。
+          if ! git push origin "HEAD:$GITHUB_REF_NAME"; then
+            echo "::error::push to '$GITHUB_REF_NAME' failed (likely non-fast-forward). ブランチをリモート最新へ更新（git pull --rebase 等）してから、この workflow を再度 dispatch してください。"
+            exit 1
+          fi


### PR DESCRIPTION
## 概要

ADR-0042 §2 のリリース自動化のうち `bump-version.yml`（workflow_dispatch でバージョン bump をコミット）を追加する。cryoflow 同型で、`inputs.version`（semver）を入力に取り非 main ブランチ上で `VERSION` を書き換え、`chore: bump version to X` を bot 名義（`github-actions[bot]`）でコミット・push する。マージは通常の PR フローに乗せる（bump PR のマージが後続の release.yml を駆動する設計）。

主な設計点:

- **非 main 限定**: ジョブに `if: github.ref_name != 'main'` を付け、main 上で誤起動しても no-op で終わる。bump コミットは branch 上で積み、マージは人間の PR 操作という ADR-0025（main 直コミット禁止）の動線に合わせる。
- **semver バリデーション**: 実行 step 内で `inputs.version` を `^[0-9]+\.[0-9]+\.[0-9]+$` で検証し、不正なら `exit 1`。不正入力で `VERSION` を壊さない。
- **冪等**: 入力が現在の `VERSION` と同一なら差分が無く commit できないため早期 `exit 0`。
- **push 失敗の可観測性**: 最終 push が non-fast-forward で reject されたとき、git の生メッセージだけでなく `::error::` アノテーションで対処方針（ブランチをリモート最新へ更新のうえ workflow を再 dispatch）を示し `exit 1` で fail-fast する。
- **権限最小化**: git commit / push しか行わないので `permissions: contents: write` のみ。
- **外部 action 非依存**: bump は git 操作で完結するため checkout 以外の外部 action は使わない。checkout は既存 workflow と同じ pin 済み SHA（`actions/checkout@9c091bb...  # v7.0.0`、ADR-0027）を流用。
- 「手元で `VERSION` を編集して PR を作る手動経路も同格に有効」旨は workflow ファイル冒頭の YAML コメントに注記（design.md への追記は別 sub-issue #160 の担当のため本 PR では触れない）。

`nix run nixpkgs#actionlint` で構文チェック済み（指摘なし）。

## 関連 issue

Closes #159
Refs #151

## docs / ADR 影響

なし。本 PR は `.github/workflows/bump-version.yml` の新規追加のみで、design.md / spec.md / concept.md や ADR には触れない（design.md への追記は sub-issue #160 が担当、衝突回避のため本 PR の範囲外）。設計判断の根拠は既存の ADR-0042 §2 に記載済み。
