### PR TITLE
docs: --version を global flags 一覧に追記（spec / README×2）

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -358,6 +358,7 @@ nput init <template>           # `nix flake init -t github:yasunori0418/nput#<te
 --root <path>       # 任意モードで解決済み root を上書き
 --no-wait           # ロック競合時に待たずスキップ(shellHook 用。明示 apply は既定でブロック)
 -v, --verbose       # 配置レポートを出力(サマリ＋target ごとの行)。既定は成功時サイレント
+--version           # 埋め込みバージョンを表示して終了(cobra 既定書式 `nput version X.Y.Z`。-v は --verbose 割当済みのため短縮形なし)
 --debug             # 内部 nix コマンドを stderr に出す(トラブルシュート用)
 --project-root      # --all の限定子: projectRoot config のみ(--home-root / --system-root も同様)
 --recopy            # apply の限定子: 全 copy target を src から上書き

--- a/README.md
+++ b/README.md
@@ -436,6 +436,7 @@ nput init <template>           # wrapper over `nix flake init -t github:yasunori
 --root <path>       # override the resolved root in any mode
 --no-wait           # on lock contention, skip instead of waiting (for shellHook; explicit apply blocks by default)
 -v, --verbose       # print the placement report (summary + per-target lines); default is silent on success
+--version           # print the embedded version and exit (cobra default format `nput version X.Y.Z`; no short flag, since -v is --verbose)
 --debug             # reveal the internal nix commands on stderr (for troubleshooting)
 --project-root      # --all qualifier: only projectRoot configs (also --home-root / --system-root)
 --recopy            # apply qualifier: overwrite every copy target from src

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -223,6 +223,8 @@ nput init <template>           # nix flake init -t <nput>#<template> のラッ�
                     # 明示時は全モードで profileDir を上書き後 root の <roothash> でキー（→ ADR-0023）
 --no-wait           # flock 競合時に待たず skip（shellHook 用。既定は明示 apply=blocking wait・→ ADR-0013）
 -v, --verbose       # 配置レポート（サマリ + per-target 行）を出力（既定は成功時沈黙・→ ADR-0031）
+--version           # 埋め込みバージョンを表示して終了（cobra 既定書式 `nput version X.Y.Z`。
+                    # -v は --verbose に割当済みのため短縮形なし・→ ADR-0042）
 --debug             # 内部実行する nix コマンドを stderr に開示（troubleshooting 用・→ ADR-0031）
 --project-root      # --all の修飾。nput.* のうち projectRoot の config のみ適用（→ ADR-0017）
 --home-root         # --all の修飾。homeRoot の config のみ適用


### PR DESCRIPTION
## 概要

#158（VERSION 導入・`nput --version` 新設）はマージ済みだが、`--version` フラグが global flags を列挙する 3 箇所（`docs/spec.md` / `README.md` / `README.ja.md`）に未反映だった。実装済みの CLI 表面をドキュメントへ書き戻す。

各ファイルの global flags 一覧に 1 行ずつ追記する（言語・体裁は各ファイル準拠）。記述内容は、埋め込みバージョンを表示して終了（cobra 既定書式 `nput version X.Y.Z`）・`-v` は `--verbose` に割当済みのため `--version` の短縮形はなし（→ ADR-0042）。

`version` サブコマンドは存在しないため、**サブコマンド一覧には追記していない**（`cmd/nput/version_test.go` の `TestVersionSubcommandAbsent` と整合）。

## 関連 issue

Closes #189
Refs #151

## docs / ADR 影響

- spec 更新: あり（`docs/spec.md` のグローバルフラグ一覧に `--version` を追記）。
- README 更新: あり（`README.md` / `README.ja.md` の Global flags / グローバルフラグ一覧に追記）。
- concept / design 更新: なし（version 導出の design 追記は #160 が担当のため対象外）。
- ADR 追加: なし（実装済み CLI 表面のドキュメント書き戻しのみ。ADR-0042 本文への書き戻しは新 ADR とセット運用のため対象外）。
