### PR TITLE
refactor(cli): niface エンベロープの TInfo / TEnvInfo を具象型へ移行（出力不変）

### DIFF
--- a/cmd/nput/apply.go
+++ b/cmd/nput/apply.go
@@ -15,6 +15,21 @@ import (
 
 var flagApplyAll bool // --all: apply all of nput.* in lexical order (narrowable by root filter)
 
+// applyResultInfo / applyEnvInfo are apply's niface info slots (→ issue #196). apply's record
+// lives entirely in items / changes, so both are empty seat types held as nil pointers: the
+// omitempty on result.info / the envelope's info keeps them out of the document (an
+// unparameterized struct{} would emit "info":{} and change the output). They exist so a later
+// issue can put mutation run facts (profile / trunk root / retention ...) on them by adding
+// fields alone, without touching the run's type arguments or any RunE instantiation.
+type (
+	applyResultInfo struct{}
+	applyEnvInfo    struct{}
+)
+
+// applyRun is apply's concrete run instantiation, threaded from RunE through the run functions
+// (the info-typed setters cannot cross the emitter interface · → issue #196).
+type applyRun = nifaceRun[*applyResultInfo, *applyEnvInfo]
+
 func newApplyCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "apply [name]",
@@ -24,7 +39,9 @@ func newApplyCmd() *cobra.Command {
 			"--all applies all of nput.* in lexical order; --project-root / --home-root / --system-root narrow by root mode.",
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			nifaceReport.begin(cmd.Name())
+			run := newNifaceRun[*applyResultInfo, *applyEnvInfo]()
+			run.begin(cmd.Name())
+			nifaceReport = run
 			flagBackupEnabled = cmd.Flags().Changed("backup")
 			if flagApplyAll {
 				if len(args) > 0 {
@@ -39,7 +56,7 @@ func newApplyCmd() *cobra.Command {
 			if len(args) == 1 {
 				name = args[0]
 			}
-			return runApply(name)
+			return runApply(run, name)
 		},
 	}
 	cmd.Flags().BoolVar(&flagApplyAll, "all", false, "Apply all of nput.* in lexical order (continues on partial failure; exits non-zero if any fails)")
@@ -59,7 +76,7 @@ func newApplyCmd() *cobra.Command {
 // (the module activation path). It does no entrypoint discovery, no rootKind pre-resolution eval,
 // and no nix build; the engine reads rootKind from manifest.json (an HM module pins homeRoot, so home).
 // It drives engine.Apply's Build=nil path (a pre-built LinkFarm) from the CLI (→ engine.Options).
-func runApplyManifest(name string) error {
+func runApplyManifest(run *applyRun, name string) error {
 	linkFarm, err := filepath.Abs(flagManifest)
 	if err != nil {
 		return fmt.Errorf("nput: cannot resolve the --manifest path (%s): %w", flagManifest, err)
@@ -77,7 +94,7 @@ func runApplyManifest(name string) error {
 	if res != nil {
 		// Also on failure: a partial result carries the reached/unreached item partition and
 		// the changes that actually happened before the stop (→ issue #131, niface ADR-0020).
-		attachMutationPayload(res, err)
+		attachMutationPayload(run, res, err)
 	}
 	if err != nil {
 		if errors.Is(err, engine.ErrSkipped) {
@@ -99,16 +116,16 @@ func runApplyManifest(name string) error {
 // entrypoint discovery → rootKind pre-resolution eval → engine.Apply (flock → in-lock build → place → --set → remove .pending).
 // When --manifest is given it does no entrypoint discovery and no nix eval/build, passing the pre-built link-farm
 // directly to the engine (the module activation path; → docs/spec.md "per-module behavior spec", ADR-0003, ADR-0007).
-func runApply(name string) error {
+func runApply(run *applyRun, name string) error {
 	// The config name is the niface subject; errors from here on are subject-borne (→ issue #130).
-	nifaceReport.beginSubject(name)
+	run.beginSubject(name)
 	if flagManifest != "" {
 		// --manifest fixes the source to a link-farm, so it conflicts in meaning with the
 		// entrypoint discovery flags (the positional name is orthogonal as a profile selector and coexists; → ADR-0026).
 		if flagFile != "" {
 			return errors.New("nput: --manifest cannot be combined with -f (--manifest fixes the source to a pre-built link-farm)")
 		}
-		return runApplyManifest(name)
+		return runApplyManifest(run, name)
 	}
 
 	ep, err := discoverEntrypoint(flagFile)
@@ -147,7 +164,7 @@ func runApply(name string) error {
 		// (→ issue #132). cmdErr is nil here: a conflict is item-borne (failed item +
 		// E_NPUT_COLLISION inside the payload) and the exit-2 decision comes below,
 		// after the plan is printed — the envelope still carries the payload alongside.
-		attachMutationPayload(res, nil)
+		attachMutationPayload(run, res, nil)
 		printApplyPlan(res)
 		// exit 2 if there are conflicts (a pre-gate for CI; → docs/spec.md exit code table).
 		if len(res.Conflicts) > 0 {
@@ -161,7 +178,7 @@ func runApply(name string) error {
 	if res != nil {
 		// Also on failure: a partial result carries the reached/unreached item partition and
 		// the changes that actually happened before the stop (→ issue #131, niface ADR-0020).
-		attachMutationPayload(res, err)
+		attachMutationPayload(run, res, err)
 	}
 	if err != nil {
 		if errors.Is(err, engine.ErrSkipped) {

--- a/cmd/nput/apply.go
+++ b/cmd/nput/apply.go
@@ -17,10 +17,17 @@ var flagApplyAll bool // --all: apply all of nput.* in lexical order (narrowable
 
 // applyResultInfo / applyEnvInfo are apply's niface info slots (→ issue #196). apply's record
 // lives entirely in items / changes, so both are empty seat types held as nil pointers: the
-// omitempty on result.info / the envelope's info keeps them out of the document (an
-// unparameterized struct{} would emit "info":{} and change the output). They exist so a later
-// issue can put mutation run facts (profile / trunk root / retention ...) on them by adding
-// fields alone, without touching the run's type arguments or any RunE instantiation.
+// omitempty on result.info / the envelope's info keeps them out of the document (a non-pointer
+// struct{} would emit "info":{} and change the output). They exist so a later issue can put
+// mutation run facts (profile / trunk root / retention ...) on them by adding fields alone,
+// without touching the run's type arguments or any RunE instantiation.
+//
+// The asymmetry against the read commands is deliberate, not an oversight (→ issue #196 §5):
+// unused slots get a named seat only where information is expected to land later, which is the
+// mutation commands' two slots (ncompose reconstructs "what this run did" from them · niface
+// ADR-0018). Read commands record no run-scoped state and init registers no subject, so their
+// unused slots stay anonymous *struct{} — a named seat there would promise a future that is
+// not planned. Read "named seat" as "reserved", "*struct{}" as "nothing goes here".
 type (
 	applyResultInfo struct{}
 	applyEnvInfo    struct{}
@@ -39,9 +46,7 @@ func newApplyCmd() *cobra.Command {
 			"--all applies all of nput.* in lexical order; --project-root / --home-root / --system-root narrow by root mode.",
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			run := newNifaceRun[*applyResultInfo, *applyEnvInfo]()
-			run.begin(cmd.Name())
-			nifaceReport = run
+			run := beginNifaceRun[*applyResultInfo, *applyEnvInfo](cmd.Name())
 			flagBackupEnabled = cmd.Flags().Changed("backup")
 			if flagApplyAll {
 				if len(args) > 0 {

--- a/cmd/nput/apply.go
+++ b/cmd/nput/apply.go
@@ -33,9 +33,15 @@ type (
 	applyEnvInfo    struct{}
 )
 
-// applyRun is apply's concrete run instantiation, threaded from RunE through the run functions
-// (the info-typed setters cannot cross the emitter interface · → issue #196).
+// applyRun is apply's concrete run instantiation, threaded from RunE into the run functions.
 type applyRun = nifaceRun[*applyResultInfo, *applyEnvInfo]
+
+// beginApplyRun starts apply's run (→ beginNifaceRun). It is the only place apply's info type
+// pair is spelled outside the alias, so changing applyRun's parameters cannot leave a stale
+// instantiation behind.
+func beginApplyRun(command string) *applyRun {
+	return beginNifaceRun[*applyResultInfo, *applyEnvInfo](command)
+}
 
 func newApplyCmd() *cobra.Command {
 	cmd := &cobra.Command{
@@ -46,7 +52,7 @@ func newApplyCmd() *cobra.Command {
 			"--all applies all of nput.* in lexical order; --project-root / --home-root / --system-root narrow by root mode.",
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			run := beginNifaceRun[*applyResultInfo, *applyEnvInfo](cmd.Name())
+			run := beginApplyRun(cmd.Name())
 			flagBackupEnabled = cmd.Flags().Changed("backup")
 			if flagApplyAll {
 				if len(args) > 0 {

--- a/cmd/nput/apply.go
+++ b/cmd/nput/apply.go
@@ -36,9 +36,10 @@ type (
 // applyRun is apply's concrete run instantiation, threaded from RunE into the run functions.
 type applyRun = nifaceRun[*applyResultInfo, *applyEnvInfo]
 
-// beginApplyRun starts apply's run (→ beginNifaceRun). It is the only place apply's info type
-// pair is spelled outside the alias, so changing applyRun's parameters cannot leave a stale
-// instantiation behind.
+// beginApplyRun starts apply's run (→ beginNifaceRun). It is the only production site that
+// spells apply's info type pair outside the alias (the tests have one more, newApplyTestRun),
+// and because it returns the alias type, changing applyRun's parameters without updating it is
+// a compile error rather than a stale instantiation.
 func beginApplyRun(command string) *applyRun {
 	return beginNifaceRun[*applyResultInfo, *applyEnvInfo](command)
 }
@@ -52,6 +53,8 @@ func newApplyCmd() *cobra.Command {
 			"--all applies all of nput.* in lexical order; --project-root / --home-root / --system-root narrow by root mode.",
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			// beginApplyRun also publishes the run to nifaceReport, so --all still emits its
+			// (subject-less) envelope even though it never touches the run value below.
 			run := beginApplyRun(cmd.Name())
 			flagBackupEnabled = cmd.Flags().Changed("backup")
 			if flagApplyAll {

--- a/cmd/nput/gitignore.go
+++ b/cmd/nput/gitignore.go
@@ -35,9 +35,7 @@ func newGitignoreCmd() *cobra.Command {
 			"--all sorts and de-duplicates the targets of all projectRoot configs.",
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			run := newNifaceRun[*gitignoreInfo, *struct{}]()
-			run.begin(cmd.Name())
-			nifaceReport = run
+			run := beginNifaceRun[*gitignoreInfo, *struct{}](cmd.Name())
 			if all {
 				if len(args) > 0 {
 					return fmt.Errorf("nput: gitignore cannot combine <name> with --all")

--- a/cmd/nput/gitignore.go
+++ b/cmd/nput/gitignore.go
@@ -40,6 +40,8 @@ func newGitignoreCmd() *cobra.Command {
 			"--all sorts and de-duplicates the targets of all projectRoot configs.",
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			// beginGitignoreRun also publishes the run to nifaceReport, so --all still emits its
+			// (subject-less) envelope even though it never touches the run value below.
 			run := beginGitignoreRun(cmd.Name())
 			if all {
 				if len(args) > 0 {

--- a/cmd/nput/gitignore.go
+++ b/cmd/nput/gitignore.go
@@ -24,6 +24,11 @@ type gitignoreInfo struct {
 // gitignoreRun is gitignore's concrete run instantiation, threaded from RunE.
 type gitignoreRun = nifaceRun[*gitignoreInfo, *struct{}]
 
+// beginGitignoreRun starts gitignore's run (→ beginNifaceRun, beginApplyRun).
+func beginGitignoreRun(command string) *gitignoreRun {
+	return beginNifaceRun[*gitignoreInfo, *struct{}](command)
+}
+
 func newGitignoreCmd() *cobra.Command {
 	var all bool
 	cmd := &cobra.Command{
@@ -35,7 +40,7 @@ func newGitignoreCmd() *cobra.Command {
 			"--all sorts and de-duplicates the targets of all projectRoot configs.",
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			run := beginNifaceRun[*gitignoreInfo, *struct{}](cmd.Name())
+			run := beginGitignoreRun(cmd.Name())
 			if all {
 				if len(args) > 0 {
 					return fmt.Errorf("nput: gitignore cannot combine <name> with --all")

--- a/cmd/nput/gitignore.go
+++ b/cmd/nput/gitignore.go
@@ -10,6 +10,20 @@ import (
 	"github.com/yasunori0418/nput/internal/manifest"
 )
 
+// gitignoreInfo is gitignore's result.info: the anchor-form target enumeration (→ issue #132,
+// ADR-0043 §5; typed by #196). The envelope-wide slot stays unused (read-only command), so it is
+// an anonymous *struct{} left nil.
+//
+// Carried as a pointer for the same reason as generationsInfo: gitignore can fail after the
+// subject is registered but before the enumeration exists (eval / project-mode rejection /
+// build), and only a nil pointer keeps result.info omitted there (→ issue #196 §4).
+type gitignoreInfo struct {
+	Paths []string `json:"paths"`
+}
+
+// gitignoreRun is gitignore's concrete run instantiation, threaded from RunE.
+type gitignoreRun = nifaceRun[*gitignoreInfo, *struct{}]
+
 func newGitignoreCmd() *cobra.Command {
 	var all bool
 	cmd := &cobra.Command{
@@ -21,7 +35,9 @@ func newGitignoreCmd() *cobra.Command {
 			"--all sorts and de-duplicates the targets of all projectRoot configs.",
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			nifaceReport.begin(cmd.Name())
+			run := newNifaceRun[*gitignoreInfo, *struct{}]()
+			run.begin(cmd.Name())
+			nifaceReport = run
 			if all {
 				if len(args) > 0 {
 					return fmt.Errorf("nput: gitignore cannot combine <name> with --all")
@@ -31,7 +47,7 @@ func newGitignoreCmd() *cobra.Command {
 			if len(args) != 1 {
 				return fmt.Errorf("nput: gitignore requires <name> or --all")
 			}
-			return runGitignore(args[0])
+			return runGitignore(run, args[0])
 		},
 	}
 	cmd.Flags().BoolVar(&all, "all", false, "Sort and de-duplicate the targets of all projectRoot configs")
@@ -40,9 +56,9 @@ func newGitignoreCmd() *cobra.Command {
 
 // runGitignore lists a single config's placement targets. project mode only;
 // it errors out if a non-project config (home / fixed) is given (because the anchor form presupposes the git toplevel; → ADR-0023).
-func runGitignore(name string) error {
+func runGitignore(run *gitignoreRun, name string) error {
 	// The config name is the niface subject; errors from here on are subject-borne (→ issue #130).
-	nifaceReport.beginSubject(name)
+	run.beginSubject(name)
 	ep, err := discoverEntrypoint(flagFile)
 	if err != nil {
 		return err
@@ -68,7 +84,7 @@ func runGitignore(name string) error {
 	// A read-only enumeration rides in result.info as the anchor-form paths (items stays [] —
 	// the listing is not an execution record · → issue #132, ADR-0043 §5). The line-oriented
 	// default stdout below is untouched (--json is the opt-in second contract).
-	nifaceReport.setPayload(&nifacePayload{info: map[string]any{"paths": gitignoreAnchors(targets)}})
+	run.setPayload(&nifacePayload[*gitignoreInfo]{info: &gitignoreInfo{Paths: gitignoreAnchors(targets)}})
 	printGitignore(targets)
 	return nil
 }

--- a/cmd/nput/gitignore_test.go
+++ b/cmd/nput/gitignore_test.go
@@ -43,10 +43,10 @@ func TestGitignoreJSONInfoPaths(t *testing.T) {
 		t.Fatalf("conformance.NewDefaultChecker: %v", err)
 	}
 
-	r, buf := newTestRun("gitignore")
+	r, buf := newTestRun[*gitignoreInfo, *struct{}]("gitignore")
 	r.beginSubject("docs")
-	r.setPayload(&nifacePayload{info: map[string]any{
-		"paths": gitignoreAnchors([]string{".claude/skills/nix", ".nput-out/docs"}),
+	r.setPayload(&nifacePayload[*gitignoreInfo]{info: &gitignoreInfo{
+		Paths: gitignoreAnchors([]string{".claude/skills/nix", ".nput-out/docs"}),
 	}})
 	if err := r.emit(nil); err != nil {
 		t.Fatalf("emit: %v", err)
@@ -77,9 +77,9 @@ func TestGitignoreJSONInfoPaths(t *testing.T) {
 // (spec: entry 0 件でも "paths": [] を明示): the emitted document must carry the paths key as
 // an empty array — a nil slice would marshal the key away.
 func TestGitignoreJSONEmptyPathsStaysArray(t *testing.T) {
-	r, buf := newTestRun("gitignore")
+	r, buf := newTestRun[*gitignoreInfo, *struct{}]("gitignore")
 	r.beginSubject("empty")
-	r.setPayload(&nifacePayload{info: map[string]any{"paths": gitignoreAnchors(nil)}})
+	r.setPayload(&nifacePayload[*gitignoreInfo]{info: &gitignoreInfo{Paths: gitignoreAnchors(nil)}})
 	if err := r.emit(nil); err != nil {
 		t.Fatalf("emit: %v", err)
 	}

--- a/cmd/nput/gitignore_test.go
+++ b/cmd/nput/gitignore_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"reflect"
 	"testing"
 
@@ -71,6 +72,21 @@ func TestGitignoreJSONInfoPaths(t *testing.T) {
 	if len(paths) != 2 || paths[0] != "/.claude/skills/nix" || paths[1] != "/.nput-out/docs" {
 		t.Errorf("info.paths = %v, want the anchor-form targets", paths)
 	}
+}
+
+// TestGitignoreJSONInfoAbsentWithoutEnumeration pins the failure boundary that forced
+// gitignoreInfo to be carried as a pointer (→ issue #196 §4): gitignore can fail after the
+// subject is registered but before the enumeration exists (entrypoint discovery, the
+// project-mode rejection, the manifest build), and result.info must stay absent there — as it
+// did while the slot was a nil map. A value-struct TInfo would emit "info":{"paths":null},
+// which the conformance checker would still accept.
+func TestGitignoreJSONInfoAbsentWithoutEnumeration(t *testing.T) {
+	r, buf := newTestRun[*gitignoreInfo, *struct{}]("gitignore")
+	r.beginSubject("docs")
+	if err := r.emit(errors.New("nput: gitignore is project mode only")); err != nil {
+		t.Fatalf("emit: %v", err)
+	}
+	assertNoInfoKeys(t, decodeEnvelope(t, buf))
 }
 
 // TestGitignoreJSONEmptyPathsStaysArray pins the zero-entry boundary at the emit level

--- a/cmd/nput/gitignore_test.go
+++ b/cmd/nput/gitignore_test.go
@@ -44,7 +44,7 @@ func TestGitignoreJSONInfoPaths(t *testing.T) {
 		t.Fatalf("conformance.NewDefaultChecker: %v", err)
 	}
 
-	r, buf := newTestRun[*gitignoreInfo, *struct{}]("gitignore")
+	r, buf := newGitignoreTestRun()
 	r.beginSubject("docs")
 	r.setPayload(&nifacePayload[*gitignoreInfo]{info: &gitignoreInfo{
 		Paths: gitignoreAnchors([]string{".claude/skills/nix", ".nput-out/docs"}),
@@ -81,7 +81,7 @@ func TestGitignoreJSONInfoPaths(t *testing.T) {
 // did while the slot was a nil map. A value-struct TInfo would emit "info":{"paths":null},
 // which the conformance checker would still accept.
 func TestGitignoreJSONInfoAbsentWithoutEnumeration(t *testing.T) {
-	r, buf := newTestRun[*gitignoreInfo, *struct{}]("gitignore")
+	r, buf := newGitignoreTestRun()
 	r.beginSubject("docs")
 	if err := r.emit(errors.New("nput: gitignore is project mode only")); err != nil {
 		t.Fatalf("emit: %v", err)
@@ -93,7 +93,7 @@ func TestGitignoreJSONInfoAbsentWithoutEnumeration(t *testing.T) {
 // (spec: entry 0 件でも "paths": [] を明示): the emitted document must carry the paths key as
 // an empty array — a nil slice would marshal the key away.
 func TestGitignoreJSONEmptyPathsStaysArray(t *testing.T) {
-	r, buf := newTestRun[*gitignoreInfo, *struct{}]("gitignore")
+	r, buf := newGitignoreTestRun()
 	r.beginSubject("empty")
 	r.setPayload(&nifacePayload[*gitignoreInfo]{info: &gitignoreInfo{Paths: gitignoreAnchors(nil)}})
 	if err := r.emit(nil); err != nil {

--- a/cmd/nput/init.go
+++ b/cmd/nput/init.go
@@ -18,6 +18,21 @@ const defaultTemplateRef = "github:yasunori0418/nput"
 // initTemplates is the template names that init accepts (matching the output names in flake.templates).
 var initTemplates = []string{"standalone", "project"}
 
+// initInfo is init's envelope-wide info: the run facts of the template expansion (→ issue #132,
+// niface ADR-0018; typed by #196). init registers no subject, so its result.info slot is unused
+// and stays an anonymous *struct{} left nil.
+//
+// Carried as a pointer: an unknown template name fails before setEnvelopeInfo, and only a nil
+// pointer keeps the envelope's info omitted there (a value struct would newly emit
+// "info":{"template":"","ref":""} · → issue #196 §4).
+type initInfo struct {
+	Template string `json:"template"`
+	Ref      string `json:"ref"`
+}
+
+// initRun is init's concrete run instantiation, threaded from RunE into runInit.
+type initRun = nifaceRun[*struct{}, *initInfo]
+
 func newInitCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "init <template>",
@@ -31,15 +46,17 @@ func newInitCmd() *cobra.Command {
 			"Existing files are not overwritten (inherits nix flake init's behavior).",
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			nifaceReport.begin(cmd.Name())
-			return runInit(args[0])
+			run := newNifaceRun[*struct{}, *initInfo]()
+			run.begin(cmd.Name())
+			nifaceReport = run
+			return runInit(run, args[0])
 		},
 	}
 }
 
 // runInit validates the template name and runs `nix flake init -t <ref>#<template>` in the CWD.
 // Because it generates a new flake, it does not go through entrypoint discovery (discoverEntrypoint; → plan 8).
-func runInit(template string) error {
+func runInit(run *initRun, template string) error {
 	if !isValidTemplate(template) {
 		return fmt.Errorf("nput: unknown template: %q (valid values: %s)", template, strings.Join(initTemplates, " / "))
 	}
@@ -52,7 +69,7 @@ func runInit(template string) error {
 	// init has no subject (no config), so the run facts ride in the envelope-wide info while
 	// results stays [] (niface ADR-0018 · → issue #132). Registered before the expansion so a
 	// failed init still reports what it attempted alongside the top-level error.
-	nifaceReport.setEnvelopeInfo(map[string]any{"template": template, "ref": ref})
+	run.setEnvelopeInfo(&initInfo{Template: template, Ref: ref})
 
 	args := flakeInitArgs(template, ref)
 	if flagDebug {

--- a/cmd/nput/init.go
+++ b/cmd/nput/init.go
@@ -33,6 +33,11 @@ type initInfo struct {
 // initRun is init's concrete run instantiation, threaded from RunE into runInit.
 type initRun = nifaceRun[*struct{}, *initInfo]
 
+// beginInitRun starts init's run (→ beginNifaceRun, beginApplyRun).
+func beginInitRun(command string) *initRun {
+	return beginNifaceRun[*struct{}, *initInfo](command)
+}
+
 func newInitCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "init <template>",
@@ -46,7 +51,7 @@ func newInitCmd() *cobra.Command {
 			"Existing files are not overwritten (inherits nix flake init's behavior).",
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			run := beginNifaceRun[*struct{}, *initInfo](cmd.Name())
+			run := beginInitRun(cmd.Name())
 			return runInit(run, args[0])
 		},
 	}

--- a/cmd/nput/init.go
+++ b/cmd/nput/init.go
@@ -46,9 +46,7 @@ func newInitCmd() *cobra.Command {
 			"Existing files are not overwritten (inherits nix flake init's behavior).",
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			run := newNifaceRun[*struct{}, *initInfo]()
-			run.begin(cmd.Name())
-			nifaceReport = run
+			run := beginNifaceRun[*struct{}, *initInfo](cmd.Name())
 			return runInit(run, args[0])
 		},
 	}

--- a/cmd/nput/init_test.go
+++ b/cmd/nput/init_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"reflect"
 	"testing"
 
@@ -57,6 +58,19 @@ func TestIsValidTemplate(t *testing.T) {
 			t.Errorf("isValidTemplate(%q) = true, want false", v)
 		}
 	}
+}
+
+// TestInitJSONEnvelopeInfoAbsentOnRejectedTemplate pins the failure boundary that forced
+// initInfo to be carried as a pointer (→ issue #196 §4): an unknown template name fails before
+// setEnvelopeInfo runs, so the envelope's info must stay absent — as it did while the slot was
+// a nil map. A value-struct TEnvInfo would emit "info":{"template":"","ref":""}, which the
+// conformance checker would still accept.
+func TestInitJSONEnvelopeInfoAbsentOnRejectedTemplate(t *testing.T) {
+	r, buf := newTestRun[*struct{}, *initInfo]("init")
+	if err := r.emit(errors.New(`nput: unknown template: "nosuch"`)); err != nil {
+		t.Fatalf("emit: %v", err)
+	}
+	assertNoInfoKeys(t, decodeEnvelope(t, buf))
 }
 
 // TestInitJSONEnvelopeInfo pins init's --json shape (niface ADR-0018 · → issue #132): init has

--- a/cmd/nput/init_test.go
+++ b/cmd/nput/init_test.go
@@ -68,8 +68,8 @@ func TestInitJSONEnvelopeInfo(t *testing.T) {
 		t.Fatalf("conformance.NewDefaultChecker: %v", err)
 	}
 
-	r, buf := newTestRun("init")
-	r.setEnvelopeInfo(map[string]any{"template": "standalone", "ref": defaultTemplateRef})
+	r, buf := newTestRun[*struct{}, *initInfo]("init")
+	r.setEnvelopeInfo(&initInfo{Template: "standalone", Ref: defaultTemplateRef})
 	if err := r.emit(nil); err != nil {
 		t.Fatalf("emit: %v", err)
 	}

--- a/cmd/nput/init_test.go
+++ b/cmd/nput/init_test.go
@@ -66,7 +66,7 @@ func TestIsValidTemplate(t *testing.T) {
 // a nil map. A value-struct TEnvInfo would emit "info":{"template":"","ref":""}, which the
 // conformance checker would still accept.
 func TestInitJSONEnvelopeInfoAbsentOnRejectedTemplate(t *testing.T) {
-	r, buf := newTestRun[*struct{}, *initInfo]("init")
+	r, buf := newInitTestRun()
 	if err := r.emit(errors.New(`nput: unknown template: "nosuch"`)); err != nil {
 		t.Fatalf("emit: %v", err)
 	}
@@ -82,7 +82,7 @@ func TestInitJSONEnvelopeInfo(t *testing.T) {
 		t.Fatalf("conformance.NewDefaultChecker: %v", err)
 	}
 
-	r, buf := newTestRun[*struct{}, *initInfo]("init")
+	r, buf := newInitTestRun()
 	r.setEnvelopeInfo(&initInfo{Template: "standalone", Ref: defaultTemplateRef})
 	if err := r.emit(nil); err != nil {
 		t.Fatalf("emit: %v", err)

--- a/cmd/nput/list-generations.go
+++ b/cmd/nput/list-generations.go
@@ -42,6 +42,8 @@ func newListGenerationsCmd() *cobra.Command {
 			"Pass <name> for that config, or --all to list every home mode config.",
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			// beginListGenerationsRun also publishes the run to nifaceReport, so --all still emits
+			// its (subject-less) envelope even though it never touches the run value below.
 			run := beginListGenerationsRun(cmd.Name())
 			if all {
 				if len(args) > 0 {

--- a/cmd/nput/list-generations.go
+++ b/cmd/nput/list-generations.go
@@ -12,6 +12,22 @@ import (
 	"github.com/yasunori0418/nput/internal/paths"
 )
 
+// generationsInfo is list-generations' result.info: the read-only generation inventory
+// (→ issue #132, ADR-0043 §5; typed by #196). The envelope-wide slot stays unused — a read-only
+// command records no run-scoped state — so it is an anonymous *struct{} left nil (omitted).
+//
+// It is carried as a *generationsInfo, not a value: the run can fail after the subject is
+// registered but before the listing exists (eval / rootKind rejection / profile resolution),
+// and only a nil pointer keeps omitempty effective there. A value struct would newly emit
+// "info":{"generations":null} on those paths — the same output-invariance trap as the mutation
+// seats (→ issue #196 §4).
+type generationsInfo struct {
+	Generations []generationRow `json:"generations"`
+}
+
+// listGenerationsRun is list-generations' concrete run instantiation, threaded from RunE.
+type listGenerationsRun = nifaceRun[*generationsInfo, *struct{}]
+
 func newListGenerationsCmd() *cobra.Command {
 	var all bool
 	cmd := &cobra.Command{
@@ -21,7 +37,9 @@ func newListGenerationsCmd() *cobra.Command {
 			"Pass <name> for that config, or --all to list every home mode config.",
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			nifaceReport.begin(cmd.Name())
+			run := newNifaceRun[*generationsInfo, *struct{}]()
+			run.begin(cmd.Name())
+			nifaceReport = run
 			if all {
 				if len(args) > 0 {
 					return fmt.Errorf("nput: list-generations cannot combine <name> with --all")
@@ -31,7 +49,7 @@ func newListGenerationsCmd() *cobra.Command {
 			if len(args) != 1 {
 				return fmt.Errorf("nput: list-generations requires <name> or --all")
 			}
-			return runListGenerations(args[0])
+			return runListGenerations(run, args[0])
 		},
 	}
 	cmd.Flags().BoolVar(&all, "all", false, "List generations for every home mode config")
@@ -39,9 +57,9 @@ func newListGenerationsCmd() *cobra.Command {
 }
 
 // runListGenerations confirms rootKind via eval pre-resolution (home mode only), resolves profileDir, and lists generations.
-func runListGenerations(name string) error {
+func runListGenerations(run *listGenerationsRun, name string) error {
 	// The config name is the niface subject; errors from here on are subject-borne (→ issue #130).
-	nifaceReport.beginSubject(name)
+	run.beginSubject(name)
 	ep, err := discoverEntrypoint(flagFile)
 	if err != nil {
 		return err
@@ -75,7 +93,7 @@ func runListGenerations(name string) error {
 	// A read-only enumeration rides in result.info (items stays [] — generations are not
 	// id-derived items, and the SubjectResult.generation slot stays absent to avoid encoding
 	// the same numbers twice · → issue #132, ADR-0043 §5).
-	nifaceReport.setPayload(&nifacePayload{info: map[string]any{"generations": generationRows(gens)}})
+	run.setPayload(&nifacePayload[*generationsInfo]{info: &generationsInfo{Generations: generationRows(gens)}})
 	printGenerations(gens)
 	return nil
 }

--- a/cmd/nput/list-generations.go
+++ b/cmd/nput/list-generations.go
@@ -37,9 +37,7 @@ func newListGenerationsCmd() *cobra.Command {
 			"Pass <name> for that config, or --all to list every home mode config.",
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			run := newNifaceRun[*generationsInfo, *struct{}]()
-			run.begin(cmd.Name())
-			nifaceReport = run
+			run := beginNifaceRun[*generationsInfo, *struct{}](cmd.Name())
 			if all {
 				if len(args) > 0 {
 					return fmt.Errorf("nput: list-generations cannot combine <name> with --all")

--- a/cmd/nput/list-generations.go
+++ b/cmd/nput/list-generations.go
@@ -28,6 +28,11 @@ type generationsInfo struct {
 // listGenerationsRun is list-generations' concrete run instantiation, threaded from RunE.
 type listGenerationsRun = nifaceRun[*generationsInfo, *struct{}]
 
+// beginListGenerationsRun starts list-generations' run (→ beginNifaceRun, beginApplyRun).
+func beginListGenerationsRun(command string) *listGenerationsRun {
+	return beginNifaceRun[*generationsInfo, *struct{}](command)
+}
+
 func newListGenerationsCmd() *cobra.Command {
 	var all bool
 	cmd := &cobra.Command{
@@ -37,7 +42,7 @@ func newListGenerationsCmd() *cobra.Command {
 			"Pass <name> for that config, or --all to list every home mode config.",
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			run := beginNifaceRun[*generationsInfo, *struct{}](cmd.Name())
+			run := beginListGenerationsRun(cmd.Name())
 			if all {
 				if len(args) > 0 {
 					return fmt.Errorf("nput: list-generations cannot combine <name> with --all")

--- a/cmd/nput/list-generations_test.go
+++ b/cmd/nput/list-generations_test.go
@@ -24,7 +24,7 @@ func TestListGenerationsJSONInfoGenerations(t *testing.T) {
 		{Number: 1, Date: "2026-07-18 09:00:00"},
 		{Number: 2, Date: "2026-07-19 12:00:00", Current: true},
 	}
-	r, buf := newTestRun[*generationsInfo, *struct{}]("list-generations")
+	r, buf := newListGenerationsTestRun()
 	r.beginSubject("home")
 	r.setPayload(&nifacePayload[*generationsInfo]{info: &generationsInfo{Generations: generationRows(gens)}})
 	if err := r.emit(nil); err != nil {
@@ -66,7 +66,7 @@ func TestListGenerationsJSONInfoGenerations(t *testing.T) {
 // it did while the slot was a nil map. A value-struct TInfo would emit
 // "info":{"generations":null}, which the conformance checker would still accept.
 func TestListGenerationsJSONInfoAbsentWithoutListing(t *testing.T) {
-	r, buf := newTestRun[*generationsInfo, *struct{}]("list-generations")
+	r, buf := newListGenerationsTestRun()
 	r.beginSubject("home")
 	if err := r.emit(errors.New("nput: list-generations is home mode only")); err != nil {
 		t.Fatalf("emit: %v", err)
@@ -78,7 +78,7 @@ func TestListGenerationsJSONInfoAbsentWithoutListing(t *testing.T) {
 // (spec: 空 profile でも "generations": [] を明示): the emitted document must carry the
 // generations key as an empty array — a nil slice would marshal the key away.
 func TestListGenerationsJSONEmptyStaysArray(t *testing.T) {
-	r, buf := newTestRun[*generationsInfo, *struct{}]("list-generations")
+	r, buf := newListGenerationsTestRun()
 	r.beginSubject("empty")
 	r.setPayload(&nifacePayload[*generationsInfo]{info: &generationsInfo{Generations: generationRows(nil)}})
 	if err := r.emit(nil); err != nil {

--- a/cmd/nput/list-generations_test.go
+++ b/cmd/nput/list-generations_test.go
@@ -23,9 +23,9 @@ func TestListGenerationsJSONInfoGenerations(t *testing.T) {
 		{Number: 1, Date: "2026-07-18 09:00:00"},
 		{Number: 2, Date: "2026-07-19 12:00:00", Current: true},
 	}
-	r, buf := newTestRun("list-generations")
+	r, buf := newTestRun[*generationsInfo, *struct{}]("list-generations")
 	r.beginSubject("home")
-	r.setPayload(&nifacePayload{info: map[string]any{"generations": generationRows(gens)}})
+	r.setPayload(&nifacePayload[*generationsInfo]{info: &generationsInfo{Generations: generationRows(gens)}})
 	if err := r.emit(nil); err != nil {
 		t.Fatalf("emit: %v", err)
 	}
@@ -62,9 +62,9 @@ func TestListGenerationsJSONInfoGenerations(t *testing.T) {
 // (spec: 空 profile でも "generations": [] を明示): the emitted document must carry the
 // generations key as an empty array — a nil slice would marshal the key away.
 func TestListGenerationsJSONEmptyStaysArray(t *testing.T) {
-	r, buf := newTestRun("list-generations")
+	r, buf := newTestRun[*generationsInfo, *struct{}]("list-generations")
 	r.beginSubject("empty")
-	r.setPayload(&nifacePayload{info: map[string]any{"generations": generationRows(nil)}})
+	r.setPayload(&nifacePayload[*generationsInfo]{info: &generationsInfo{Generations: generationRows(nil)}})
 	if err := r.emit(nil); err != nil {
 		t.Fatalf("emit: %v", err)
 	}

--- a/cmd/nput/list-generations_test.go
+++ b/cmd/nput/list-generations_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"testing"
 
 	"github.com/yasunori0418/niface/go/conformance"
@@ -56,6 +57,21 @@ func TestListGenerationsJSONInfoGenerations(t *testing.T) {
 	if first := rows[0].(map[string]any); first["current"] != false {
 		t.Errorf("rows[0].current = %v, want false (the key is always present)", first["current"])
 	}
+}
+
+// TestListGenerationsJSONInfoAbsentWithoutListing pins the failure boundary that forced
+// generationsInfo to be carried as a pointer (→ issue #196 §4): list-generations can fail after
+// the subject is registered but before any listing exists (entrypoint discovery, the home-mode
+// rootKind rejection, profile resolution), and result.info must stay absent there — exactly as
+// it did while the slot was a nil map. A value-struct TInfo would emit
+// "info":{"generations":null}, which the conformance checker would still accept.
+func TestListGenerationsJSONInfoAbsentWithoutListing(t *testing.T) {
+	r, buf := newTestRun[*generationsInfo, *struct{}]("list-generations")
+	r.beginSubject("home")
+	if err := r.emit(errors.New("nput: list-generations is home mode only")); err != nil {
+		t.Fatalf("emit: %v", err)
+	}
+	assertNoInfoKeys(t, decodeEnvelope(t, buf))
 }
 
 // TestListGenerationsJSONEmptyStaysArray pins the zero-generation boundary at the emit level

--- a/cmd/nput/main.go
+++ b/cmd/nput/main.go
@@ -94,7 +94,8 @@ func newRootCmd() *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
-	// The niface run is begun at each subcommand's RunE top (nifaceReport.begin), not via a
+	// The niface run is built, begun, and published to nifaceReport at each subcommand's RunE
+	// top (→ issue #196: the run is typed by that command's info pair), not via a
 	// PersistentPreRun: cobra's auto-added utility commands (help / completion / __complete)
 	// own stdout with their own text and must never emit an envelope, and PersistentPreRun
 	// cannot tell them apart robustly (→ issue #130, docs/spec.md).

--- a/cmd/nput/niface.go
+++ b/cmd/nput/niface.go
@@ -122,10 +122,16 @@ func (noopEmitter) emit(error) error { return nil }
 // concrete run here so main can emit it after Execute returns (tests build their own runs).
 var nifaceReport emitter = noopEmitter{}
 
-// newNifaceRun builds a command's concrete run against the real clock and stdout. RunE calls it,
-// begins it, and publishes it to nifaceReport (→ issue #196).
-func newNifaceRun[TInfo, TEnvInfo any]() *nifaceRun[TInfo, TEnvInfo] {
-	return &nifaceRun[TInfo, TEnvInfo]{now: time.Now, out: os.Stdout}
+// beginNifaceRun starts a command's run: it builds the concrete instantiation against the real
+// clock and stdout, begins it for command, and publishes it to nifaceReport so main can emit it
+// after Execute returns. Every subcommand's RunE calls exactly this — keeping build / begin /
+// publish in one place, because a run that is begun but never published emits no envelope at
+// all (main's gate reads nifaceReport, not the command's local variable · → issue #196).
+func beginNifaceRun[TInfo, TEnvInfo any](command string) *nifaceRun[TInfo, TEnvInfo] {
+	r := &nifaceRun[TInfo, TEnvInfo]{now: time.Now, out: os.Stdout}
+	r.begin(command)
+	nifaceReport = r
+	return r
 }
 
 // begin records the executed subcommand, the run start time, and the parsed --dryrun value

--- a/cmd/nput/niface.go
+++ b/cmd/nput/niface.go
@@ -124,9 +124,13 @@ var nifaceReport emitter = noopEmitter{}
 
 // beginNifaceRun starts a command's run: it builds the concrete instantiation against the real
 // clock and stdout, begins it for command, and publishes it to nifaceReport so main can emit it
-// after Execute returns. Every subcommand's RunE calls exactly this — keeping build / begin /
-// publish in one place, because a run that is begun but never published emits no envelope at
-// all (main's gate reads nifaceReport, not the command's local variable · → issue #196).
+// after Execute returns — keeping build / begin / publish in one place, because a run that is
+// begun but never published emits no envelope at all (main's gate reads nifaceReport, not the
+// command's local variable · → issue #196).
+//
+// Commands do not call this directly with their type arguments; each one wraps it in a
+// begin<Command>Run helper declared next to its run alias, so the command's (TInfo, TEnvInfo)
+// pair is spelled exactly once per command and the alias stays the single source of truth.
 func beginNifaceRun[TInfo, TEnvInfo any](command string) *nifaceRun[TInfo, TEnvInfo] {
 	r := &nifaceRun[TInfo, TEnvInfo]{now: time.Now, out: os.Stdout}
 	r.begin(command)

--- a/cmd/nput/niface.go
+++ b/cmd/nput/niface.go
@@ -71,7 +71,7 @@ func nifaceTimestamp(t time.Time) string { return t.Format(time.RFC3339) }
 type nifaceRun[TInfo, TEnvInfo any] struct {
 	now     func() time.Time // injectable clock; tests pin it to a fixed time
 	out     io.Writer        // envelope sink (os.Stdout; tests substitute a buffer)
-	command string           // executed subcommand name ("" until begin — no envelope for --help / --version)
+	command string           // executed subcommand name ("" until begin · → began)
 	dryRun  bool             // envelope dryRun field, captured from flagDryrun at begin (tests set it directly)
 	started time.Time
 	subject *nifaceSubject[TInfo] // the single subject #130 wires (nil = none; #164 generalizes to N)
@@ -146,9 +146,11 @@ func (r *nifaceRun[TInfo, TEnvInfo]) begin(command string) {
 	r.started = r.now()
 }
 
-// began reports whether an nput subcommand's RunE actually started (false on the --help /
-// --version / help / completion paths and on flag or argument validation failures — none of
-// those emit an envelope; exit code + stderr are the only signals there).
+// began satisfies emitter. A published run is always a begun one — beginNifaceRun is the only
+// production constructor and it begins before publishing — so this is true for anything main
+// finds in nifaceReport; the not-started state is noopEmitter's, which owns the list of paths
+// that never reach a RunE. It still reads the field rather than returning true, because tests
+// build runs directly and main's gate must stay honest for them too.
 func (r *nifaceRun[TInfo, TEnvInfo]) began() bool { return r.command != "" }
 
 // beginSubject registers the command's subject (config name) once it is known. From then on a

--- a/cmd/nput/niface.go
+++ b/cmd/nput/niface.go
@@ -27,16 +27,20 @@ import (
 const nifaceSpecVersion = 1
 
 // The nput instantiation of the niface generic envelope. The four type parameters are the
-// tool-specific info slots (item / change / per-subject result / envelope-wide). #131 pins
-// the item / change slots to the concrete mutation DTOs (pointers, so an absent info is
-// omitted); the per-subject result / envelope-wide slots stay open JSON objects until #132
-// populates them (read-only inventories / init) — nil maps marshal as omitted.
+// tool-specific info slots (item / change / per-subject result / envelope-wide). The item /
+// change slots are pinned to the concrete mutation DTOs shared by every command (pointers, so
+// an absent info is omitted · #131); the per-subject result (TInfo) and envelope-wide
+// (TEnvInfo) slots vary per command, so they stay type parameters here and each command
+// instantiates them with its own info type (→ issue #196, niface ADR-0018).
+//
+// These stay aliases (parameterized aliases, Go 1.24+), so the emitted values remain niface's
+// own types and keep niface's MarshalJSON — the required-array normalization must not be lost.
 type (
-	nputEnvelope      = niface.Envelope[*nifaceEntryInfo, *nifaceChangeInfo, map[string]any, map[string]any]
-	nputSubjectResult = niface.SubjectResult[*nifaceEntryInfo, *nifaceChangeInfo, map[string]any]
-	nputResult        = niface.Result[*nifaceEntryInfo, *nifaceChangeInfo, map[string]any]
-	nputItem          = niface.Item[*nifaceEntryInfo]
-	nputChange        = niface.Change[*nifaceChangeInfo]
+	nputEnvelope[TInfo, TEnvInfo any] = niface.Envelope[*nifaceEntryInfo, *nifaceChangeInfo, TInfo, TEnvInfo]
+	nputSubjectResult[TInfo any]      = niface.SubjectResult[*nifaceEntryInfo, *nifaceChangeInfo, TInfo]
+	nputResult[TInfo any]             = niface.Result[*nifaceEntryInfo, *nifaceChangeInfo, TInfo]
+	nputItem                          = niface.Item[*nifaceEntryInfo]
+	nputChange                        = niface.Change[*nifaceChangeInfo]
 )
 
 // entryItemID derives the niface item id for a placement entry: identity kind="entry",
@@ -54,34 +58,39 @@ func entryItemID(target string) (string, error) {
 func nifaceTimestamp(t time.Time) string { return t.Format(time.RFC3339) }
 
 // nifaceRun accumulates what the --json envelope needs across one command invocation. Each nput
-// subcommand's RunE begins it first thing (command name + start time — flag parsing and cobra's
-// argument validation have succeeded by then, and cobra's utility commands help / completion /
-// __complete never reach a RunE of ours, so they keep stdout for their own text), commands
-// register their subject as it becomes known, and main emits once after Execute returns: the
-// single stdout write point (→ issue #130, ADR-0043 §2).
-type nifaceRun struct {
+// subcommand's RunE builds it first thing and begins it (command name + start time — flag parsing
+// and cobra's argument validation have succeeded by then, and cobra's utility commands help /
+// completion / __complete never reach a RunE of ours, so they keep stdout for their own text),
+// commands register their subject as it becomes known, and main emits once after Execute
+// returns: the single stdout write point (→ issue #130, ADR-0043 §2).
+//
+// TInfo / TEnvInfo are the command's own result.info / envelope-info types (→ issue #196): each
+// command instantiates the run with its concrete pair in RunE and threads that concrete value
+// through its run functions, because the info-typed setters cannot cross the emitter interface
+// (Go forbids generic methods).
+type nifaceRun[TInfo, TEnvInfo any] struct {
 	now     func() time.Time // injectable clock; tests pin it to a fixed time
 	out     io.Writer        // envelope sink (os.Stdout; tests substitute a buffer)
 	command string           // executed subcommand name ("" until begin — no envelope for --help / --version)
 	dryRun  bool             // envelope dryRun field, captured from flagDryrun at begin (tests set it directly)
 	started time.Time
-	subject *nifaceSubject // the single subject #130 wires (nil = none; #164 generalizes to N)
-	info    map[string]any // envelope-wide tool info (init's run info · niface ADR-0018, issue #132)
+	subject *nifaceSubject[TInfo] // the single subject #130 wires (nil = none; #164 generalizes to N)
+	info    TEnvInfo              // envelope-wide tool info (init's run info · niface ADR-0018, issue #132)
 }
 
 // nifaceSubject is one subject's (config's) accumulation for its SubjectResult.
-type nifaceSubject struct {
+type nifaceSubject[TInfo any] struct {
 	name    string
 	started time.Time
 	// payload is the command-built items/changes/generation/warnings mapping (→ #131's
 	// niface_payload.go builders). nil keeps the minimal #130 shape (empty items) — the
 	// read-only commands until #132, and failures before any engine result exists.
-	payload *nifacePayload
+	payload *nifacePayload[TInfo]
 }
 
 // setPayload attaches the command's result payload to the registered subject (a no-op
 // without one — payloads only exist for subject-scoped commands).
-func (r *nifaceRun) setPayload(p *nifacePayload) {
+func (r *nifaceRun[TInfo, TEnvInfo]) setPayload(p *nifacePayload[TInfo]) {
 	if r.subject != nil {
 		r.subject.payload = p
 	}
@@ -89,14 +98,39 @@ func (r *nifaceRun) setPayload(p *nifacePayload) {
 
 // setEnvelopeInfo registers the envelope-wide tool info (top-level info — run-scoped facts not
 // tied to any subject; init's template expansion · niface ADR-0018, issue #132).
-func (r *nifaceRun) setEnvelopeInfo(info map[string]any) { r.info = info }
+func (r *nifaceRun[TInfo, TEnvInfo]) setEnvelopeInfo(info TEnvInfo) { r.info = info }
 
-// nifaceReport is the process-wide run the CLI wires (tests build their own nifaceRun instances).
-var nifaceReport = &nifaceRun{now: time.Now, out: os.Stdout}
+// emitter is the type-erased face of a run: the two methods main needs after Execute returns,
+// neither of which mentions the info types. Which subcommand runs is unknown before cobra
+// dispatches, so the process-wide report cannot be a single static instantiation; the
+// info-typed operations (begin / beginSubject / setPayload / setEnvelopeInfo) stay on the
+// concrete run each command holds (→ issue #196).
+type emitter interface {
+	began() bool
+	emit(error) error
+}
+
+// noopEmitter is nifaceReport's initial value: no RunE has run, so no envelope exists. It keeps
+// main's emit gate total without a nil check on the paths that never reach a RunE (--help /
+// --version / help / completion / flag- and argument-validation failures).
+type noopEmitter struct{}
+
+func (noopEmitter) began() bool      { return false }
+func (noopEmitter) emit(error) error { return nil }
+
+// nifaceReport is the process-wide run the CLI wires: each subcommand's RunE assigns its own
+// concrete run here so main can emit it after Execute returns (tests build their own runs).
+var nifaceReport emitter = noopEmitter{}
+
+// newNifaceRun builds a command's concrete run against the real clock and stdout. RunE calls it,
+// begins it, and publishes it to nifaceReport (→ issue #196).
+func newNifaceRun[TInfo, TEnvInfo any]() *nifaceRun[TInfo, TEnvInfo] {
+	return &nifaceRun[TInfo, TEnvInfo]{now: time.Now, out: os.Stdout}
+}
 
 // begin records the executed subcommand, the run start time, and the parsed --dryrun value
 // (cobra has finished flag parsing by RunE, where begin is called).
-func (r *nifaceRun) begin(command string) {
+func (r *nifaceRun[TInfo, TEnvInfo]) begin(command string) {
 	r.command = command
 	r.dryRun = flagDryrun
 	r.started = r.now()
@@ -105,28 +139,28 @@ func (r *nifaceRun) begin(command string) {
 // began reports whether an nput subcommand's RunE actually started (false on the --help /
 // --version / help / completion paths and on flag or argument validation failures — none of
 // those emit an envelope; exit code + stderr are the only signals there).
-func (r *nifaceRun) began() bool { return r.command != "" }
+func (r *nifaceRun[TInfo, TEnvInfo]) began() bool { return r.command != "" }
 
 // beginSubject registers the command's subject (config name) once it is known. From then on a
 // command failure attaches to this subject's SubjectResult.errors[] rather than the top-level
 // errors[] (top level = failures before/outside subject resolution only · → ADR-0043 §6).
 // #130 wires the single-config commands; --all / init leave no subject (results stays []).
-func (r *nifaceRun) beginSubject(name string) {
-	r.subject = &nifaceSubject{name: name, started: r.now()}
+func (r *nifaceRun[TInfo, TEnvInfo]) beginSubject(name string) {
+	r.subject = &nifaceSubject[TInfo]{name: name, started: r.now()}
 }
 
 // emit writes the niface envelope — exactly one JSON document, trailing newline, nothing else —
 // to r.out. cmdErr is the command's overall error: nil ⇔ exit 0 ⇔ status "success" (the only
 // status contract consumers may rely on · → ADR-0043 §6). The #130 envelope is minimal: the
 // registered subject yields one SubjectResult with empty items; payload population is #131 / #132.
-func (r *nifaceRun) emit(cmdErr error) error {
+func (r *nifaceRun[TInfo, TEnvInfo]) emit(cmdErr error) error {
 	finished := nifaceTimestamp(r.now())
 	status := niface.StatusSuccess
 	if cmdErr != nil {
 		status = niface.StatusError
 	}
 
-	env := nputEnvelope{
+	env := nputEnvelope[TInfo, TEnvInfo]{
 		SpecVersion: nifaceSpecVersion,
 		Tool:        niface.Tool{Name: "nput", Version: version},
 		Command:     r.command,
@@ -137,7 +171,7 @@ func (r *nifaceRun) emit(cmdErr error) error {
 		Info:        r.info,
 	}
 	if r.subject != nil {
-		sr := nputSubjectResult{
+		sr := nputSubjectResult[TInfo]{
 			Subject:    niface.Subject{Name: r.subject.name},
 			Status:     status,
 			StartedAt:  nifaceTimestamp(r.subject.started),
@@ -146,7 +180,7 @@ func (r *nifaceRun) emit(cmdErr error) error {
 		if p := r.subject.payload; p != nil {
 			sr.Generation = p.generation
 			sr.Warnings = p.warnings
-			sr.Result = nputResult{Items: p.items, Changes: p.changes, Info: p.info}
+			sr.Result = nputResult[TInfo]{Items: p.items, Changes: p.changes, Info: p.info}
 		}
 		env.Results = append(env.Results, sr)
 	}

--- a/cmd/nput/niface_payload.go
+++ b/cmd/nput/niface_payload.go
@@ -38,15 +38,17 @@ type nifaceChangeInfo struct {
 
 // nifacePayload is one subject's accumulated result payload, attached to the run by the
 // mutation commands and folded into the SubjectResult at emit time (→ nifaceRun.emit).
-type nifacePayload struct {
+// TInfo is the owning command's result.info type (→ issue #196).
+type nifacePayload[TInfo any] struct {
 	items      []nputItem
 	changes    []nputChange
 	generation *niface.Generation
 	warnings   []niface.Warning // subject-level (not item-borne) warnings
 	// info is the per-subject tool info (result.info): the read-only enumeration inventories
 	// (list-generations の generations / gitignore の paths · → issue #132, ADR-0043 §5).
-	// nil for the mutation commands — their record lives in items / changes.
-	info map[string]any
+	// The mutation commands leave it at its zero value (a nil seat pointer, omitted from the
+	// document) — their record lives in items / changes.
+	info TInfo
 	// itemBorne marks that the command error is already represented by a failed item
 	// (entry failure / conflict), so emit must not duplicate it into subjectResult.errors[]
 	// (niface §2: item 起因のエラーを errors[] に置いてはならない).
@@ -54,26 +56,26 @@ type nifacePayload struct {
 }
 
 // attachMutationPayload builds the apply / rollback payload from res and registers it on the
-// run. A payload-build failure (id derivation — practically impossible for string targets) is
-// reported to stderr and the envelope falls back to the minimal #130 shape rather than
-// emitting a half-mapped document.
-func attachMutationPayload(res *engine.Result, cmdErr error) {
-	p, err := mutationPayload(res, cmdErr)
+// command's run. A payload-build failure (id derivation — practically impossible for string
+// targets) is reported to stderr and the envelope falls back to the minimal #130 shape rather
+// than emitting a half-mapped document.
+func attachMutationPayload[TInfo, TEnvInfo any](run *nifaceRun[TInfo, TEnvInfo], res *engine.Result, cmdErr error) {
+	p, err := mutationPayload[TInfo](res, cmdErr)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "nput: could not build the --json payload: %v\n", err)
 		return
 	}
-	nifaceReport.setPayload(p)
+	run.setPayload(p)
 }
 
 // attachResetPayload is attachMutationPayload's reset counterpart.
-func attachResetPayload(res *engine.ResetResult, cmdErr error) {
-	p, err := resetPayload(res, cmdErr)
+func attachResetPayload[TInfo, TEnvInfo any](run *nifaceRun[TInfo, TEnvInfo], res *engine.ResetResult, cmdErr error) {
+	p, err := resetPayload[TInfo](res, cmdErr)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "nput: could not build the --json payload: %v\n", err)
 		return
 	}
-	nifaceReport.setPayload(p)
+	run.setPayload(p)
 }
 
 // itemStatuses is the reached-state partition shared by the builders (→ niface ADR-0016 /
@@ -173,9 +175,9 @@ func changeInfoOrNil(old, new string) *nifaceChangeInfo {
 //     (→ ADR-0044) additionally carries W_NPUT_UNWOUND at the subject level: the changes list
 //     stays the record of what happened up to the failure, and the warning tells consumers
 //     those diffs were rolled back rather than left on disk.
-func mutationPayload(res *engine.Result, cmdErr error) (*nifacePayload, error) {
+func mutationPayload[TInfo any](res *engine.Result, cmdErr error) (*nifacePayload[TInfo], error) {
 	statuses := newItemStatuses(res.FailedTarget, res.Unreached, res.Conflicts, cmdErr)
-	p := &nifacePayload{itemBorne: res.FailedTarget != "" || len(res.Conflicts) > 0}
+	p := &nifacePayload[TInfo]{itemBorne: res.FailedTarget != "" || len(res.Conflicts) > 0}
 
 	// Items: the new manifest's inventory first, then the stale-removed old entries not
 	// shadowed by it (a method-change target lives in both; the new entry wins).
@@ -306,9 +308,9 @@ func mutationPayload(res *engine.Result, cmdErr error) (*nifacePayload, error) {
 // the generations are untouched, so there is no transition to observe · → issue #131).
 // An aborted run (confirmation declined — unreachable under --json, which never prompts)
 // changed nothing: items stay success, changes stay empty.
-func resetPayload(res *engine.ResetResult, cmdErr error) (*nifacePayload, error) {
+func resetPayload[TInfo any](res *engine.ResetResult, cmdErr error) (*nifacePayload[TInfo], error) {
 	statuses := newItemStatuses(res.FailedTarget, res.Unreached, nil, cmdErr)
-	p := &nifacePayload{itemBorne: res.FailedTarget != ""}
+	p := &nifacePayload[TInfo]{itemBorne: res.FailedTarget != ""}
 
 	byTarget := map[string]manifest.Entry{}
 	for _, e := range res.Entries {

--- a/cmd/nput/niface_payload_test.go
+++ b/cmd/nput/niface_payload_test.go
@@ -61,14 +61,16 @@ func changesFor(t *testing.T, changes []nputChange, target string) []nputChange 
 }
 
 // emitPayloadDoc runs the payload through the real emit path (command + subject + payload),
-// checks the document against niface's conformance checker, and returns it decoded.
-func emitPayloadDoc(t *testing.T, command string, p *nifacePayload, cmdErr error) map[string]any {
+// checks the document against niface's conformance checker, and returns it decoded. TInfo /
+// TEnvInfo are the emitting command's info pair (→ issue #196); the mutation commands' pairs are
+// empty seat types, so the emitted document carries no info key on either level.
+func emitPayloadDoc[TInfo, TEnvInfo any](t *testing.T, command string, p *nifacePayload[TInfo], cmdErr error) map[string]any {
 	t.Helper()
 	checker, err := conformance.NewDefaultChecker()
 	if err != nil {
 		t.Fatalf("conformance.NewDefaultChecker: %v", err)
 	}
-	r, buf := newTestRun(command)
+	r, buf := newTestRun[TInfo, TEnvInfo](command)
 	r.beginSubject("default")
 	r.setPayload(p)
 	if err := r.emit(cmdErr); err != nil {
@@ -116,7 +118,7 @@ func TestMutationPayloadFullInventory(t *testing.T) {
 		GenAfter:      ip(1),
 		Warnings:      []planner.Warning{{Kind: planner.WarnForeignReplace, Target: ".config/relinked"}},
 	}
-	p, err := mutationPayload(res, nil)
+	p, err := mutationPayload[*applyResultInfo](res, nil)
 	if err != nil {
 		t.Fatalf("mutationPayload: %v", err)
 	}
@@ -169,7 +171,7 @@ func TestMutationPayloadFullInventory(t *testing.T) {
 		t.Errorf("subject warnings = %+v, want none (the warned target is an item)", p.warnings)
 	}
 
-	doc := emitPayloadDoc(t, "apply", p, nil)
+	doc := emitPayloadDoc[*applyResultInfo, *applyEnvInfo](t, "apply", p, nil)
 	sr := subjectResultOf(t, doc)
 	gen, ok := sr["generation"].(map[string]any)
 	if !ok {
@@ -198,7 +200,7 @@ func TestMutationPayloadMethodChangeCoalesces(t *testing.T) {
 		Removed: []string{".config/x"},
 		Copied:  []string{".config/x"},
 	}
-	p, err := mutationPayload(res, nil)
+	p, err := mutationPayload[*applyResultInfo](res, nil)
 	if err != nil {
 		t.Fatalf("mutationPayload: %v", err)
 	}
@@ -234,7 +236,7 @@ func TestMutationPayloadNoopRelinkSuppressed(t *testing.T) {
 			".moved": "/nix/store/old",  // genuinely moved
 		},
 	}
-	p, err := mutationPayload(res, nil)
+	p, err := mutationPayload[*applyResultInfo](res, nil)
 	if err != nil {
 		t.Fatalf("mutationPayload: %v", err)
 	}
@@ -261,7 +263,7 @@ func TestMutationPayloadOrphanSubjectWarning(t *testing.T) {
 		},
 		Warnings: []planner.Warning{{Kind: planner.WarnCopyOrphan, Target: ".gone/copy"}},
 	}
-	p, err := mutationPayload(res, nil)
+	p, err := mutationPayload[*applyResultInfo](res, nil)
 	if err != nil {
 		t.Fatalf("mutationPayload: %v", err)
 	}
@@ -271,7 +273,7 @@ func TestMutationPayloadOrphanSubjectWarning(t *testing.T) {
 	if it := findItem(t, p.items, "a"); len(it.Warnings) != 0 {
 		t.Errorf("item warnings = %+v, want none (the orphan is not this item's)", it.Warnings)
 	}
-	doc := emitPayloadDoc(t, "apply", p, nil)
+	doc := emitPayloadDoc[*applyResultInfo, *applyEnvInfo](t, "apply", p, nil)
 	sr := subjectResultOf(t, doc)
 	warns, ok := sr["warnings"].([]any)
 	if !ok || len(warns) != 1 {
@@ -296,11 +298,11 @@ func TestMutationPayloadRollbackGeneration(t *testing.T) {
 		},
 		From: 5, To: 4,
 	}
-	p, err := mutationPayload(&rr.Result, nil)
+	p, err := mutationPayload[*rollbackResultInfo](&rr.Result, nil)
 	if err != nil {
 		t.Fatalf("mutationPayload: %v", err)
 	}
-	doc := emitPayloadDoc(t, "rollback", p, nil)
+	doc := emitPayloadDoc[*rollbackResultInfo, *rollbackEnvInfo](t, "rollback", p, nil)
 	sr := subjectResultOf(t, doc)
 	gen := sr["generation"].(map[string]any)
 	if gen["before"] != json.Number("5") || gen["after"] != json.Number("4") {
@@ -309,7 +311,7 @@ func TestMutationPayloadRollbackGeneration(t *testing.T) {
 
 	// A failed rollback pins the pointer at the unmoved current generation.
 	rr.GenBefore, rr.GenAfter = ip(5), ip(5)
-	p, err = mutationPayload(&rr.Result, errors.New("nput: failed to move the profile pointer"))
+	p, err = mutationPayload[*rollbackResultInfo](&rr.Result, errors.New("nput: failed to move the profile pointer"))
 	if err != nil {
 		t.Fatalf("mutationPayload: %v", err)
 	}
@@ -367,7 +369,7 @@ func TestMutationPayloadPartialFailure(t *testing.T) {
 		GenAfter:     ip(3),
 	}
 	cmdErr := &os.PathError{Op: "symlink", Path: "/root/b", Err: fs.ErrPermission}
-	p, err := mutationPayload(res, cmdErr)
+	p, err := mutationPayload[*applyResultInfo](res, cmdErr)
 	if err != nil {
 		t.Fatalf("mutationPayload: %v", err)
 	}
@@ -398,7 +400,7 @@ func TestMutationPayloadPartialFailure(t *testing.T) {
 		t.Errorf("subject warnings = %+v, want W_NPUT_UNWOUND for the unwound run", p.warnings)
 	}
 
-	doc := emitPayloadDoc(t, "apply", p, cmdErr)
+	doc := emitPayloadDoc[*applyResultInfo, *applyEnvInfo](t, "apply", p, cmdErr)
 	if doc["status"] != "error" {
 		t.Errorf("status = %v, want error", doc["status"])
 	}
@@ -428,7 +430,7 @@ func TestMutationPayloadSubjectBorneFailure(t *testing.T) {
 		GenAfter: ip(2), GenBefore: ip(2),
 	}
 	cmdErr := errors.New("nput: generation commit (nix-env --set) failed: exit status 1")
-	p, err := mutationPayload(res, cmdErr)
+	p, err := mutationPayload[*applyResultInfo](res, cmdErr)
 	if err != nil {
 		t.Fatalf("mutationPayload: %v", err)
 	}
@@ -438,7 +440,7 @@ func TestMutationPayloadSubjectBorneFailure(t *testing.T) {
 	if it := findItem(t, p.items, "a"); it.Status != niface.ItemSuccess {
 		t.Errorf("placed item status = %s, want success (the commit, not the entry, failed)", it.Status)
 	}
-	doc := emitPayloadDoc(t, "apply", p, cmdErr)
+	doc := emitPayloadDoc[*applyResultInfo, *applyEnvInfo](t, "apply", p, cmdErr)
 	sr := subjectResultOf(t, doc)
 	errList, ok := sr["errors"].([]any)
 	if !ok || len(errList) != 1 {
@@ -469,7 +471,7 @@ func TestMutationPayloadConflicts(t *testing.T) {
 		Unreached: []string{"b"},
 	}
 	cmdErr := errors.New("nput: 1 conflict(s) detected; stopped without placing (see above)")
-	p, err := mutationPayload(res, cmdErr)
+	p, err := mutationPayload[*applyResultInfo](res, cmdErr)
 	if err != nil {
 		t.Fatalf("mutationPayload: %v", err)
 	}
@@ -487,7 +489,7 @@ func TestMutationPayloadConflicts(t *testing.T) {
 	if len(p.changes) != 0 {
 		t.Errorf("changes = %+v, want none (the run stopped before any FS action)", p.changes)
 	}
-	doc := emitPayloadDoc(t, "apply", p, cmdErr)
+	doc := emitPayloadDoc[*applyResultInfo, *applyEnvInfo](t, "apply", p, cmdErr)
 	sr := subjectResultOf(t, doc)
 	if errList, ok := sr["errors"]; ok {
 		t.Errorf("subjectResult.errors = %v, want absent (conflicts are item-borne)", errList)
@@ -511,7 +513,7 @@ func TestResetPayload(t *testing.T) {
 		KeptForeign:     []string{"s2"},
 		Warnings:        []planner.Warning{{Kind: planner.WarnStaleMismatch, Target: "s2"}},
 	}
-	p, err := resetPayload(res, nil)
+	p, err := resetPayload[*resetResultInfo](res, nil)
 	if err != nil {
 		t.Fatalf("resetPayload: %v", err)
 	}
@@ -539,7 +541,7 @@ func TestResetPayload(t *testing.T) {
 		t.Errorf("kept target changes = %+v, want none (policy inaction is not a diff)", cs)
 	}
 
-	doc := emitPayloadDoc(t, "reset", p, nil)
+	doc := emitPayloadDoc[*resetResultInfo, *resetEnvInfo](t, "reset", p, nil)
 	sr := subjectResultOf(t, doc)
 	if gen, ok := sr["generation"]; ok {
 		t.Errorf("generation = %v, want the slot absent for reset", gen)
@@ -561,7 +563,7 @@ func TestResetPayloadPartialFailure(t *testing.T) {
 		Unreached:       []string{"c2"},
 	}
 	cmdErr := &os.PathError{Op: "removeall", Path: "/root/c1", Err: fs.ErrPermission}
-	p, err := resetPayload(res, cmdErr)
+	p, err := resetPayload[*resetResultInfo](res, cmdErr)
 	if err != nil {
 		t.Fatalf("resetPayload: %v", err)
 	}
@@ -581,7 +583,7 @@ func TestResetPayloadPartialFailure(t *testing.T) {
 	if cs := changesFor(t, p.changes, "s1"); len(cs) != 1 {
 		t.Errorf("removed-so-far changes = %+v, want the remove present despite the failure", cs)
 	}
-	doc := emitPayloadDoc(t, "reset", p, cmdErr)
+	doc := emitPayloadDoc[*resetResultInfo, *resetEnvInfo](t, "reset", p, cmdErr)
 	if doc["status"] != "error" {
 		t.Errorf("status = %v, want error", doc["status"])
 	}
@@ -660,11 +662,11 @@ func TestJSONEndToEndApplyAndResetPayload(t *testing.T) {
 
 	// First apply: two adds, no previous generation to observe.
 	res := apply(1, keep, drop)
-	p, err := mutationPayload(res, nil)
+	p, err := mutationPayload[*applyResultInfo](res, nil)
 	if err != nil {
 		t.Fatalf("mutationPayload: %v", err)
 	}
-	doc := emitPayloadDoc(t, "apply", p, nil)
+	doc := emitPayloadDoc[*applyResultInfo, *applyEnvInfo](t, "apply", p, nil)
 	sr := subjectResultOf(t, doc)
 	gen := sr["generation"].(map[string]any)
 	if _, hasBefore := gen["before"]; hasBefore || gen["after"] != json.Number("1") {
@@ -679,11 +681,11 @@ func TestJSONEndToEndApplyAndResetPayload(t *testing.T) {
 
 	// Second apply drops .drop: its old entry is stale-removed and stays in the inventory.
 	res = apply(2, keep)
-	p, err = mutationPayload(res, nil)
+	p, err = mutationPayload[*applyResultInfo](res, nil)
 	if err != nil {
 		t.Fatalf("mutationPayload: %v", err)
 	}
-	doc = emitPayloadDoc(t, "apply", p, nil)
+	doc = emitPayloadDoc[*applyResultInfo, *applyEnvInfo](t, "apply", p, nil)
 	sr = subjectResultOf(t, doc)
 	gen = sr["generation"].(map[string]any)
 	if gen["before"] != json.Number("1") || gen["after"] != json.Number("2") {
@@ -708,11 +710,11 @@ func TestJSONEndToEndApplyAndResetPayload(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Reset: %v", err)
 	}
-	rp, err := resetPayload(resetRes, nil)
+	rp, err := resetPayload[*resetResultInfo](resetRes, nil)
 	if err != nil {
 		t.Fatalf("resetPayload: %v", err)
 	}
-	doc = emitPayloadDoc(t, "reset", rp, nil)
+	doc = emitPayloadDoc[*resetResultInfo, *resetEnvInfo](t, "reset", rp, nil)
 	sr = subjectResultOf(t, doc)
 	if gen, ok := sr["generation"]; ok {
 		t.Errorf("reset generation = %v, want the slot absent", gen)
@@ -733,11 +735,11 @@ func TestDryrunPayloadFirstPlanOmitsGenerationNumbers(t *testing.T) {
 		Entries: []manifest.Entry{{SrcKind: "store", Src: "/nix/store/z", Target: ".zshrc", Method: "symlink"}},
 		Placed:  []string{".zshrc"},
 	}
-	p, err := mutationPayload(res, nil)
+	p, err := mutationPayload[*applyResultInfo](res, nil)
 	if err != nil {
 		t.Fatalf("mutationPayload: %v", err)
 	}
-	doc := emitPayloadDoc(t, "apply", p, nil)
+	doc := emitPayloadDoc[*applyResultInfo, *applyEnvInfo](t, "apply", p, nil)
 	gen := subjectResultOf(t, doc)["generation"].(map[string]any)
 	if gen["profile"] != res.Profile {
 		t.Errorf("generation.profile = %v, want %s", gen["profile"], res.Profile)
@@ -767,7 +769,7 @@ func TestDryrunPayloadConflictKeepsEnvelopeBesideExit2(t *testing.T) {
 			{Entry: manifest.Entry{Target: ".zshrc"}, Reason: "target already has an existing file/directory (will not overwrite)", Kind: planner.ConflictForeignEntity},
 		},
 	}
-	p, err := mutationPayload(res, nil) // the dryrun wiring passes cmdErr nil (→ runApply)
+	p, err := mutationPayload[*applyResultInfo](res, nil) // the dryrun wiring passes cmdErr nil (→ runApply)
 	if err != nil {
 		t.Fatalf("mutationPayload: %v", err)
 	}
@@ -778,7 +780,7 @@ func TestDryrunPayloadConflictKeepsEnvelopeBesideExit2(t *testing.T) {
 		t.Errorf("sibling item status = %s, want success (a dryrun attempts nothing)", it.Status)
 	}
 
-	r, buf := newTestRun("apply")
+	r, buf := newTestRun[*applyResultInfo, *applyEnvInfo]("apply")
 	r.dryRun = true
 	r.beginSubject("default")
 	r.setPayload(p)
@@ -833,7 +835,7 @@ func TestDryrunPayloadRelinkNotSuppressed(t *testing.T) {
 		Entries:  []manifest.Entry{{SrcKind: "store", Src: "/nix/store/same", Target: ".same", Method: "symlink"}},
 		Replaced: []string{".same"},
 	}
-	p, err := mutationPayload(res, nil)
+	p, err := mutationPayload[*applyResultInfo](res, nil)
 	if err != nil {
 		t.Fatalf("mutationPayload: %v", err)
 	}
@@ -860,7 +862,7 @@ func TestMutationPayloadKeptStaleSubjectWarning(t *testing.T) {
 			{Kind: planner.WarnStaleNonSymlink, Target: ".config/solidified"},
 		},
 	}
-	p, err := mutationPayload(res, nil)
+	p, err := mutationPayload[*applyResultInfo](res, nil)
 	if err != nil {
 		t.Fatalf("mutationPayload: %v", err)
 	}
@@ -894,7 +896,7 @@ func TestMutationPayloadConflictWithWarningStaysConformant(t *testing.T) {
 		},
 		Warnings: []planner.Warning{{Kind: planner.WarnForeignReplace, Target: ".zshrc"}},
 	}
-	p, err := mutationPayload(res, nil)
+	p, err := mutationPayload[*applyResultInfo](res, nil)
 	if err != nil {
 		t.Fatalf("mutationPayload: %v", err)
 	}
@@ -902,7 +904,7 @@ func TestMutationPayloadConflictWithWarningStaysConformant(t *testing.T) {
 	if it.Status != niface.ItemFailed || it.Error == nil || len(it.Warnings) != 1 {
 		t.Fatalf("item = %+v, want failed with both error and the entry-borne warning", it)
 	}
-	doc := emitPayloadDoc(t, "apply", p, &exitError{code: 2})
+	doc := emitPayloadDoc[*applyResultInfo, *applyEnvInfo](t, "apply", p, &exitError{code: 2})
 	if doc["status"] != "error" {
 		t.Errorf("status = %v, want error", doc["status"])
 	}
@@ -919,7 +921,7 @@ func TestMutationPayloadCopyForeignItemWarning(t *testing.T) {
 		Entries:  []manifest.Entry{{SrcKind: "store", Src: "/nix/store/c", Target: ".config/copydir", Method: "copy"}},
 		Warnings: []planner.Warning{{Kind: planner.WarnCopyForeign, Target: ".config/copydir"}},
 	}
-	p, err := mutationPayload(res, nil)
+	p, err := mutationPayload[*applyResultInfo](res, nil)
 	if err != nil {
 		t.Fatalf("mutationPayload: %v", err)
 	}

--- a/cmd/nput/niface_payload_test.go
+++ b/cmd/nput/niface_payload_test.go
@@ -82,6 +82,75 @@ func emitPayloadDoc[TInfo, TEnvInfo any](t *testing.T, command string, p *niface
 	return decodeEnvelope(t, buf)
 }
 
+// assertNoInfoKeys fails when the document carries an info key at the envelope level or inside
+// results[0].result. The seat types are empty structs held as nil pointers precisely so
+// omitempty drops both keys (→ issue #196 §4); a value struct, or a seat accidentally filled
+// with &T{}, would emit "info":{} — schema-valid (envelope.schema.json types info as a bare
+// object) and therefore invisible to the conformance checker, so it has to be pinned here.
+func assertNoInfoKeys(t *testing.T, doc map[string]any) {
+	t.Helper()
+	if v, ok := doc["info"]; ok {
+		t.Errorf("envelope info = %v, want the key absent (the seat type is a nil pointer)", v)
+	}
+	results, _ := doc["results"].([]any)
+	for i, r := range results {
+		res, _ := r.(map[string]any)["result"].(map[string]any)
+		if v, ok := res["info"]; ok {
+			t.Errorf("results[%d].result.info = %v, want the key absent (the seat type is a nil pointer)", i, v)
+		}
+	}
+}
+
+// TestMutationSeatInfoKeysStayAbsent pins the output-invariance requirement that made the
+// mutation info slots empty seat types behind pointers (→ issue #196 §4): apply / reset /
+// rollback must emit no info key at either level, both with a payload attached and on the
+// payload-less path (a failure before any engine result exists). Without this the seats could
+// silently start emitting "info":{} — the conformance checker accepts it, so no other test
+// in the suite would notice.
+func TestMutationSeatInfoKeysStayAbsent(t *testing.T) {
+	res := &engine.Result{
+		Profile: "/p",
+		Entries: []manifest.Entry{{SrcKind: "store", Src: "/nix/store/a", Target: "a", Method: "symlink"}},
+		Placed:  []string{"a"},
+	}
+	resetRes := &engine.ResetResult{
+		Entries:         []manifest.Entry{{SrcKind: "store", Src: "/nix/store/s", Target: "s", Method: "symlink"}},
+		RemovedSymlinks: []string{"s"},
+	}
+
+	t.Run("apply with payload", func(t *testing.T) {
+		p, err := mutationPayload[*applyResultInfo](res, nil)
+		if err != nil {
+			t.Fatalf("mutationPayload: %v", err)
+		}
+		assertNoInfoKeys(t, emitPayloadDoc[*applyResultInfo, *applyEnvInfo](t, "apply", p, nil))
+	})
+	t.Run("rollback with payload", func(t *testing.T) {
+		p, err := mutationPayload[*rollbackResultInfo](res, nil)
+		if err != nil {
+			t.Fatalf("mutationPayload: %v", err)
+		}
+		assertNoInfoKeys(t, emitPayloadDoc[*rollbackResultInfo, *rollbackEnvInfo](t, "rollback", p, nil))
+	})
+	t.Run("reset with payload", func(t *testing.T) {
+		p, err := resetPayload[*resetResultInfo](resetRes, nil)
+		if err != nil {
+			t.Fatalf("resetPayload: %v", err)
+		}
+		assertNoInfoKeys(t, emitPayloadDoc[*resetResultInfo, *resetEnvInfo](t, "reset", p, nil))
+	})
+	// The subject-registered-but-payload-less path: the command failed before any engine result
+	// existed, so Result.Info stays the zero value. A non-pointer seat would surface here.
+	t.Run("apply without payload", func(t *testing.T) {
+		r, buf := newTestRun[*applyResultInfo, *applyEnvInfo]("apply")
+		r.beginSubject("default")
+		if err := r.emit(errors.New("nput: no entrypoint found")); err != nil {
+			t.Fatalf("emit: %v", err)
+		}
+		assertNoInfoKeys(t, decodeEnvelope(t, buf))
+	})
+}
+
 // subjectResultOf digs results[0] out of a decoded envelope.
 func subjectResultOf(t *testing.T, doc map[string]any) map[string]any {
 	t.Helper()

--- a/cmd/nput/niface_payload_test.go
+++ b/cmd/nput/niface_payload_test.go
@@ -6,6 +6,7 @@ package main
 // conformance of every emitted shape against niface's checker.
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"io/fs"
@@ -61,16 +62,18 @@ func changesFor(t *testing.T, changes []nputChange, target string) []nputChange 
 }
 
 // emitPayloadDoc runs the payload through the real emit path (command + subject + payload),
-// checks the document against niface's conformance checker, and returns it decoded. TInfo /
-// TEnvInfo are the emitting command's info pair (→ issue #196); the mutation commands' pairs are
-// empty seat types, so the emitted document carries no info key on either level.
-func emitPayloadDoc[TInfo, TEnvInfo any](t *testing.T, command string, p *nifacePayload[TInfo], cmdErr error) map[string]any {
+// checks the document against niface's conformance checker, and returns it decoded. newRun is
+// the emitting command's test-run constructor (newApplyTestRun, ...), which carries both the
+// command name and its info pair from the production alias — so no call site re-spells the type
+// arguments (→ issue #196). The mutation commands' pairs are empty seat types, so the emitted
+// document carries no info key on either level.
+func emitPayloadDoc[TInfo, TEnvInfo any](t *testing.T, newRun func() (*nifaceRun[TInfo, TEnvInfo], *bytes.Buffer), p *nifacePayload[TInfo], cmdErr error) map[string]any {
 	t.Helper()
 	checker, err := conformance.NewDefaultChecker()
 	if err != nil {
 		t.Fatalf("conformance.NewDefaultChecker: %v", err)
 	}
-	r, buf := newTestRun[TInfo, TEnvInfo](command)
+	r, buf := newRun()
 	r.beginSubject("default")
 	r.setPayload(p)
 	if err := r.emit(cmdErr); err != nil {
@@ -83,10 +86,14 @@ func emitPayloadDoc[TInfo, TEnvInfo any](t *testing.T, command string, p *niface
 }
 
 // assertNoInfoKeys fails when the document carries an info key at the envelope level or inside
-// results[0].result. The seat types are empty structs held as nil pointers precisely so
-// omitempty drops both keys (→ issue #196 §4); a value struct, or a seat accidentally filled
-// with &T{}, would emit "info":{} — schema-valid (envelope.schema.json types info as a bare
-// object) and therefore invisible to the conformance checker, so it has to be pinned here.
+// any result. The seat types are empty structs held as nil pointers precisely so omitempty
+// drops both keys (→ issue #196 §4); a value struct, or a seat accidentally filled with &T{},
+// would emit "info":{} — schema-valid (envelope.schema.json types info as a bare object) and
+// therefore invisible to the conformance checker, so it has to be pinned here.
+//
+// The results loop is empty for the subject-less commands (init, and any --all path), leaving
+// the envelope-level check as the whole assertion there — which is the only level those
+// documents have.
 func assertNoInfoKeys(t *testing.T, doc map[string]any) {
 	t.Helper()
 	if v, ok := doc["info"]; ok {
@@ -123,26 +130,26 @@ func TestMutationSeatInfoKeysStayAbsent(t *testing.T) {
 		if err != nil {
 			t.Fatalf("mutationPayload: %v", err)
 		}
-		assertNoInfoKeys(t, emitPayloadDoc[*applyResultInfo, *applyEnvInfo](t, "apply", p, nil))
+		assertNoInfoKeys(t, emitPayloadDoc(t, newApplyTestRun, p, nil))
 	})
 	t.Run("rollback with payload", func(t *testing.T) {
 		p, err := mutationPayload[*rollbackResultInfo](res, nil)
 		if err != nil {
 			t.Fatalf("mutationPayload: %v", err)
 		}
-		assertNoInfoKeys(t, emitPayloadDoc[*rollbackResultInfo, *rollbackEnvInfo](t, "rollback", p, nil))
+		assertNoInfoKeys(t, emitPayloadDoc(t, newRollbackTestRun, p, nil))
 	})
 	t.Run("reset with payload", func(t *testing.T) {
 		p, err := resetPayload[*resetResultInfo](resetRes, nil)
 		if err != nil {
 			t.Fatalf("resetPayload: %v", err)
 		}
-		assertNoInfoKeys(t, emitPayloadDoc[*resetResultInfo, *resetEnvInfo](t, "reset", p, nil))
+		assertNoInfoKeys(t, emitPayloadDoc(t, newResetTestRun, p, nil))
 	})
 	// The subject-registered-but-payload-less path: the command failed before any engine result
 	// existed, so Result.Info stays the zero value. A non-pointer seat would surface here.
 	t.Run("apply without payload", func(t *testing.T) {
-		r, buf := newTestRun[*applyResultInfo, *applyEnvInfo]("apply")
+		r, buf := newApplyTestRun()
 		r.beginSubject("default")
 		if err := r.emit(errors.New("nput: no entrypoint found")); err != nil {
 			t.Fatalf("emit: %v", err)
@@ -240,7 +247,7 @@ func TestMutationPayloadFullInventory(t *testing.T) {
 		t.Errorf("subject warnings = %+v, want none (the warned target is an item)", p.warnings)
 	}
 
-	doc := emitPayloadDoc[*applyResultInfo, *applyEnvInfo](t, "apply", p, nil)
+	doc := emitPayloadDoc(t, newApplyTestRun, p, nil)
 	sr := subjectResultOf(t, doc)
 	gen, ok := sr["generation"].(map[string]any)
 	if !ok {
@@ -342,7 +349,7 @@ func TestMutationPayloadOrphanSubjectWarning(t *testing.T) {
 	if it := findItem(t, p.items, "a"); len(it.Warnings) != 0 {
 		t.Errorf("item warnings = %+v, want none (the orphan is not this item's)", it.Warnings)
 	}
-	doc := emitPayloadDoc[*applyResultInfo, *applyEnvInfo](t, "apply", p, nil)
+	doc := emitPayloadDoc(t, newApplyTestRun, p, nil)
 	sr := subjectResultOf(t, doc)
 	warns, ok := sr["warnings"].([]any)
 	if !ok || len(warns) != 1 {
@@ -371,7 +378,7 @@ func TestMutationPayloadRollbackGeneration(t *testing.T) {
 	if err != nil {
 		t.Fatalf("mutationPayload: %v", err)
 	}
-	doc := emitPayloadDoc[*rollbackResultInfo, *rollbackEnvInfo](t, "rollback", p, nil)
+	doc := emitPayloadDoc(t, newRollbackTestRun, p, nil)
 	sr := subjectResultOf(t, doc)
 	gen := sr["generation"].(map[string]any)
 	if gen["before"] != json.Number("5") || gen["after"] != json.Number("4") {
@@ -469,7 +476,7 @@ func TestMutationPayloadPartialFailure(t *testing.T) {
 		t.Errorf("subject warnings = %+v, want W_NPUT_UNWOUND for the unwound run", p.warnings)
 	}
 
-	doc := emitPayloadDoc[*applyResultInfo, *applyEnvInfo](t, "apply", p, cmdErr)
+	doc := emitPayloadDoc(t, newApplyTestRun, p, cmdErr)
 	if doc["status"] != "error" {
 		t.Errorf("status = %v, want error", doc["status"])
 	}
@@ -509,7 +516,7 @@ func TestMutationPayloadSubjectBorneFailure(t *testing.T) {
 	if it := findItem(t, p.items, "a"); it.Status != niface.ItemSuccess {
 		t.Errorf("placed item status = %s, want success (the commit, not the entry, failed)", it.Status)
 	}
-	doc := emitPayloadDoc[*applyResultInfo, *applyEnvInfo](t, "apply", p, cmdErr)
+	doc := emitPayloadDoc(t, newApplyTestRun, p, cmdErr)
 	sr := subjectResultOf(t, doc)
 	errList, ok := sr["errors"].([]any)
 	if !ok || len(errList) != 1 {
@@ -558,7 +565,7 @@ func TestMutationPayloadConflicts(t *testing.T) {
 	if len(p.changes) != 0 {
 		t.Errorf("changes = %+v, want none (the run stopped before any FS action)", p.changes)
 	}
-	doc := emitPayloadDoc[*applyResultInfo, *applyEnvInfo](t, "apply", p, cmdErr)
+	doc := emitPayloadDoc(t, newApplyTestRun, p, cmdErr)
 	sr := subjectResultOf(t, doc)
 	if errList, ok := sr["errors"]; ok {
 		t.Errorf("subjectResult.errors = %v, want absent (conflicts are item-borne)", errList)
@@ -610,7 +617,7 @@ func TestResetPayload(t *testing.T) {
 		t.Errorf("kept target changes = %+v, want none (policy inaction is not a diff)", cs)
 	}
 
-	doc := emitPayloadDoc[*resetResultInfo, *resetEnvInfo](t, "reset", p, nil)
+	doc := emitPayloadDoc(t, newResetTestRun, p, nil)
 	sr := subjectResultOf(t, doc)
 	if gen, ok := sr["generation"]; ok {
 		t.Errorf("generation = %v, want the slot absent for reset", gen)
@@ -652,7 +659,7 @@ func TestResetPayloadPartialFailure(t *testing.T) {
 	if cs := changesFor(t, p.changes, "s1"); len(cs) != 1 {
 		t.Errorf("removed-so-far changes = %+v, want the remove present despite the failure", cs)
 	}
-	doc := emitPayloadDoc[*resetResultInfo, *resetEnvInfo](t, "reset", p, cmdErr)
+	doc := emitPayloadDoc(t, newResetTestRun, p, cmdErr)
 	if doc["status"] != "error" {
 		t.Errorf("status = %v, want error", doc["status"])
 	}
@@ -735,7 +742,7 @@ func TestJSONEndToEndApplyAndResetPayload(t *testing.T) {
 	if err != nil {
 		t.Fatalf("mutationPayload: %v", err)
 	}
-	doc := emitPayloadDoc[*applyResultInfo, *applyEnvInfo](t, "apply", p, nil)
+	doc := emitPayloadDoc(t, newApplyTestRun, p, nil)
 	sr := subjectResultOf(t, doc)
 	gen := sr["generation"].(map[string]any)
 	if _, hasBefore := gen["before"]; hasBefore || gen["after"] != json.Number("1") {
@@ -754,7 +761,7 @@ func TestJSONEndToEndApplyAndResetPayload(t *testing.T) {
 	if err != nil {
 		t.Fatalf("mutationPayload: %v", err)
 	}
-	doc = emitPayloadDoc[*applyResultInfo, *applyEnvInfo](t, "apply", p, nil)
+	doc = emitPayloadDoc(t, newApplyTestRun, p, nil)
 	sr = subjectResultOf(t, doc)
 	gen = sr["generation"].(map[string]any)
 	if gen["before"] != json.Number("1") || gen["after"] != json.Number("2") {
@@ -783,7 +790,7 @@ func TestJSONEndToEndApplyAndResetPayload(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resetPayload: %v", err)
 	}
-	doc = emitPayloadDoc[*resetResultInfo, *resetEnvInfo](t, "reset", rp, nil)
+	doc = emitPayloadDoc(t, newResetTestRun, rp, nil)
 	sr = subjectResultOf(t, doc)
 	if gen, ok := sr["generation"]; ok {
 		t.Errorf("reset generation = %v, want the slot absent", gen)
@@ -808,7 +815,7 @@ func TestDryrunPayloadFirstPlanOmitsGenerationNumbers(t *testing.T) {
 	if err != nil {
 		t.Fatalf("mutationPayload: %v", err)
 	}
-	doc := emitPayloadDoc[*applyResultInfo, *applyEnvInfo](t, "apply", p, nil)
+	doc := emitPayloadDoc(t, newApplyTestRun, p, nil)
 	gen := subjectResultOf(t, doc)["generation"].(map[string]any)
 	if gen["profile"] != res.Profile {
 		t.Errorf("generation.profile = %v, want %s", gen["profile"], res.Profile)
@@ -849,7 +856,7 @@ func TestDryrunPayloadConflictKeepsEnvelopeBesideExit2(t *testing.T) {
 		t.Errorf("sibling item status = %s, want success (a dryrun attempts nothing)", it.Status)
 	}
 
-	r, buf := newTestRun[*applyResultInfo, *applyEnvInfo]("apply")
+	r, buf := newApplyTestRun()
 	r.dryRun = true
 	r.beginSubject("default")
 	r.setPayload(p)
@@ -973,7 +980,7 @@ func TestMutationPayloadConflictWithWarningStaysConformant(t *testing.T) {
 	if it.Status != niface.ItemFailed || it.Error == nil || len(it.Warnings) != 1 {
 		t.Fatalf("item = %+v, want failed with both error and the entry-borne warning", it)
 	}
-	doc := emitPayloadDoc[*applyResultInfo, *applyEnvInfo](t, "apply", p, &exitError{code: 2})
+	doc := emitPayloadDoc(t, newApplyTestRun, p, &exitError{code: 2})
 	if doc["status"] != "error" {
 		t.Errorf("status = %v, want error", doc["status"])
 	}

--- a/cmd/nput/niface_test.go
+++ b/cmd/nput/niface_test.go
@@ -196,7 +196,8 @@ func (failingWriter) Write([]byte) (int, error) { return 0, errors.New("broken p
 
 // TestNifaceEmitWriteFailure pins that a failed envelope write surfaces as an error from emit —
 // main then exits non-zero even for a succeeded command, so a missing/partial document is never
-// read as success (→ docs/spec.md emit タイミングと成立条件).
+// read as success (→ docs/spec.md emit タイミングと成立条件). The write path does not depend on
+// the info types, so applyRun stands in for any command's instantiation.
 func TestNifaceEmitWriteFailure(t *testing.T) {
 	r := &applyRun{now: fixedClock(time.Date(2026, 7, 19, 12, 0, 0, 0, time.UTC)), out: failingWriter{}}
 	r.begin("apply")
@@ -424,13 +425,18 @@ func TestJSONUtilityCommandsDoNotBegin(t *testing.T) {
 		nifaceReport = noopEmitter{}
 		root := newRootCmd()
 		root.SetArgs(args)
-		_ = captureStdout(t, func() {
+		out := captureStdout(t, func() {
 			if err := root.Execute(); err != nil {
 				t.Errorf("%v: Execute: %v", args, err)
 			}
 		})
 		if nifaceReport.began() {
 			t.Errorf("%v began a niface run; utility commands must not emit an envelope", args)
+		}
+		// The gate is began(), but assert the observable contract too, so a future wiring that
+		// writes an envelope past the gate is caught rather than inferred.
+		if strings.Contains(out, `"specVersion"`) {
+			t.Errorf("%v wrote an envelope to stdout; utility commands own it with their own text: %q", args, out)
 		}
 		nifaceReport = origReport
 	}
@@ -474,6 +480,12 @@ func TestJSONEndToEndSubjectBorneFailure(t *testing.T) {
 	if !nifaceReport.began() {
 		t.Fatal("apply's RunE did not publish a begun niface run")
 	}
+	// captureStdout replaces the whole of os.Stdout, so anything else the command wrote lands
+	// here too. Check that first: a stray line would otherwise surface as an opaque JSON decode
+	// error rather than the stdout-ownership violation it actually is (→ ADR-0043 §2).
+	if !strings.HasPrefix(out, "{") {
+		t.Fatalf("stdout must hold the envelope alone (the --json contract), got %q", out)
+	}
 	buf := bytes.NewBufferString(out)
 
 	checker, err := conformance.NewDefaultChecker()
@@ -501,4 +513,8 @@ func TestJSONEndToEndSubjectBorneFailure(t *testing.T) {
 	if topErrs, ok := doc["errors"]; ok {
 		t.Errorf("top-level errors present = %v, want the failure attached to the subject", topErrs)
 	}
+	// The subject is registered but no payload ever exists (the failure precedes any engine
+	// result), so both info slots stay at their nil-pointer zero value and must be omitted —
+	// the output-invariance requirement behind the seat types (→ issue #196 §4).
+	assertNoInfoKeys(t, doc)
 }

--- a/cmd/nput/niface_test.go
+++ b/cmd/nput/niface_test.go
@@ -35,9 +35,11 @@ func fixedClock(t0 time.Time) func() time.Time {
 }
 
 // newTestRun returns a nifaceRun with a pinned clock and buffer sink, already begun for command.
-func newTestRun(command string) (*nifaceRun, *bytes.Buffer) {
+// The info type arguments are the command's own pair (→ issue #196); callers spell them out
+// because the command name is a plain string and cannot drive inference.
+func newTestRun[TInfo, TEnvInfo any](command string) (*nifaceRun[TInfo, TEnvInfo], *bytes.Buffer) {
 	var buf bytes.Buffer
-	r := &nifaceRun{
+	r := &nifaceRun[TInfo, TEnvInfo]{
 		now: fixedClock(time.Date(2026, 7, 19, 12, 0, 0, 0, time.FixedZone("JST", 9*3600))),
 		out: &buf,
 	}
@@ -98,7 +100,7 @@ func TestNifaceEnvelopeConformance(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			r, buf := newTestRun("apply")
+			r, buf := newTestRun[*applyResultInfo, *applyEnvInfo]("apply")
 			if c.subject != "" {
 				r.beginSubject(c.subject)
 			}
@@ -171,7 +173,7 @@ func TestNifaceEnvelopeDryRunFlag(t *testing.T) {
 		t.Fatalf("conformance.NewDefaultChecker: %v", err)
 	}
 	for _, dryRun := range []bool{false, true} {
-		r, buf := newTestRun("apply")
+		r, buf := newTestRun[*applyResultInfo, *applyEnvInfo]("apply")
 		r.dryRun = dryRun
 		r.beginSubject("default")
 		if err := r.emit(nil); err != nil {
@@ -196,7 +198,7 @@ func (failingWriter) Write([]byte) (int, error) { return 0, errors.New("broken p
 // main then exits non-zero even for a succeeded command, so a missing/partial document is never
 // read as success (→ docs/spec.md emit タイミングと成立条件).
 func TestNifaceEmitWriteFailure(t *testing.T) {
-	r := &nifaceRun{now: fixedClock(time.Date(2026, 7, 19, 12, 0, 0, 0, time.UTC)), out: failingWriter{}}
+	r := &applyRun{now: fixedClock(time.Date(2026, 7, 19, 12, 0, 0, 0, time.UTC)), out: failingWriter{}}
 	r.begin("apply")
 	r.beginSubject("default")
 	if err := r.emit(nil); err == nil {
@@ -417,7 +419,9 @@ func TestJSONFlagRegistered(t *testing.T) {
 func TestJSONUtilityCommandsDoNotBegin(t *testing.T) {
 	for _, args := range [][]string{{"help"}, {"completion", "bash"}} {
 		origReport := nifaceReport
-		nifaceReport = &nifaceRun{now: fixedClock(time.Date(2026, 7, 19, 12, 0, 0, 0, time.UTC)), out: &bytes.Buffer{}}
+		// The process-start state: only a RunE of ours replaces it with a begun run, so a
+		// still-noop report after Execute proves the utility command emitted nothing.
+		nifaceReport = noopEmitter{}
 		root := newRootCmd()
 		root.SetArgs(args)
 		_ = captureStdout(t, func() {
@@ -445,24 +449,32 @@ func TestJSONEndToEndSubjectBorneFailure(t *testing.T) {
 		flagJSON, flagDryrun = origJSON, origDryrun
 	}()
 
-	var buf bytes.Buffer
-	nifaceReport = &nifaceRun{
-		now: fixedClock(time.Date(2026, 7, 19, 12, 0, 0, 0, time.UTC)),
-		out: &buf,
-	}
+	nifaceReport = noopEmitter{}
 
-	root := newRootCmd()
-	root.SetArgs([]string{"apply", "--json"})
-	execErr := root.Execute()
+	// RunE builds its own concrete run against os.Stdout (→ issue #196), so the document is
+	// captured off the real sink: Execute and the main-style emit both run inside the capture.
+	var execErr error
+	out := captureStdout(t, func() {
+		root := newRootCmd()
+		root.SetArgs([]string{"apply", "--json"})
+		execErr = root.Execute()
+		if execErr == nil {
+			return
+		}
+		if !nifaceReport.began() {
+			return
+		}
+		if err := nifaceReport.emit(execErr); err != nil {
+			t.Errorf("emit: %v", err)
+		}
+	})
 	if execErr == nil {
 		t.Fatal("apply in an entrypoint-less directory must fail")
 	}
 	if !nifaceReport.began() {
-		t.Fatal("apply's RunE did not begin the niface run")
+		t.Fatal("apply's RunE did not publish a begun niface run")
 	}
-	if err := nifaceReport.emit(execErr); err != nil {
-		t.Fatalf("emit: %v", err)
-	}
+	buf := bytes.NewBufferString(out)
 
 	checker, err := conformance.NewDefaultChecker()
 	if err != nil {
@@ -471,7 +483,7 @@ func TestJSONEndToEndSubjectBorneFailure(t *testing.T) {
 	if findings := checker.Check(buf.Bytes()); len(findings) > 0 {
 		t.Fatalf("conformance findings:\n%s\ndocument: %s", strings.Join(findings, "\n"), buf.String())
 	}
-	doc := decodeEnvelope(t, &buf)
+	doc := decodeEnvelope(t, buf)
 	if doc["status"] != "error" || doc["command"] != "apply" {
 		t.Errorf("status/command = %v/%v, want error/apply", doc["status"], doc["command"])
 	}

--- a/cmd/nput/niface_test.go
+++ b/cmd/nput/niface_test.go
@@ -53,6 +53,11 @@ func newTestRun[TInfo, TEnvInfo any](command string) (*nifaceRun[TInfo, TEnvInfo
 // ...), so changing a command's info pair updates its tests by construction: a test that kept
 // the old pair would no longer satisfy the alias-typed return and fails to compile (→ issue
 // #196, diff-review follow-up).
+//
+// The command strings are literals rather than cobra's Use values: the envelope's command field
+// is part of the output contract, so a rename must be a visible edit here (and
+// TestBeginRunPublishesEveryCommand checks that every registered RunE subcommand still has a
+// begin<Cmd>Run case, which is where a rename would otherwise hide).
 func newApplyTestRun() (*applyRun, *bytes.Buffer) {
 	return newTestRun[*applyResultInfo, *applyEnvInfo]("apply")
 }
@@ -423,6 +428,53 @@ func TestResetPromptAllowed(t *testing.T) {
 	}
 	if needPrompt, err := confirmPolicy(true, resetPromptAllowed(true, true)); err != nil || needPrompt {
 		t.Errorf("reset --json --yes: needPrompt=%v err=%v, want promptless success", needPrompt, err)
+	}
+}
+
+// TestBeginRunPublishesEveryCommand pins the wiring step this refactor introduced (→ issue
+// #196): every command's begin<Cmd>Run must begin its run AND publish it to nifaceReport, since
+// main emits what it finds there, not the command's local variable. A wrapper that dropped the
+// publish would silence that command's envelope entirely while every other test stayed green —
+// only apply and the read commands otherwise exercise the full RunE path (reset / rollback have
+// no --json coverage in the Go tests or the e2e scenarios).
+func TestBeginRunPublishesEveryCommand(t *testing.T) {
+	origReport := nifaceReport
+	defer func() { nifaceReport = origReport }()
+
+	// Each entry begins the command's run exactly as its RunE does.
+	begins := map[string]func(string) emitter{
+		"apply":            func(c string) emitter { return beginApplyRun(c) },
+		"reset":            func(c string) emitter { return beginResetRun(c) },
+		"rollback":         func(c string) emitter { return beginRollbackRun(c) },
+		"list-generations": func(c string) emitter { return beginListGenerationsRun(c) },
+		"gitignore":        func(c string) emitter { return beginGitignoreRun(c) },
+		"init":             func(c string) emitter { return beginInitRun(c) },
+	}
+	for command, begin := range begins {
+		t.Run(command, func(t *testing.T) {
+			nifaceReport = noopEmitter{}
+			run := begin(command)
+			if !run.began() {
+				t.Errorf("%s: the returned run is not begun", command)
+			}
+			if nifaceReport != emitter(run) {
+				t.Fatalf("%s: nifaceReport = %#v, want the run just begun (main emits what it finds here)", command, nifaceReport)
+			}
+			if !nifaceReport.began() {
+				t.Errorf("%s: the published run is not begun; main's gate would skip the envelope", command)
+			}
+		})
+	}
+
+	// Every subcommand the root registers must be covered above, so a command added later
+	// cannot quietly skip the begin/publish contract.
+	for _, cmd := range newRootCmd().Commands() {
+		if cmd.RunE == nil {
+			continue // cobra's own utility commands (help / completion) never begin a run
+		}
+		if _, ok := begins[cmd.Name()]; !ok {
+			t.Errorf("subcommand %q has a RunE but no begin<Cmd>Run case here", cmd.Name())
+		}
 	}
 }
 

--- a/cmd/nput/niface_test.go
+++ b/cmd/nput/niface_test.go
@@ -35,8 +35,10 @@ func fixedClock(t0 time.Time) func() time.Time {
 }
 
 // newTestRun returns a nifaceRun with a pinned clock and buffer sink, already begun for command.
-// The info type arguments are the command's own pair (→ issue #196); callers spell them out
-// because the command name is a plain string and cannot drive inference.
+// The info type arguments are the command's own pair (→ issue #196); the command name is a plain
+// string and cannot drive inference, so prefer the per-command wrappers below — they take their
+// arguments from the production run aliases, which keeps the tests from silently exercising a
+// type pair the CLI no longer uses.
 func newTestRun[TInfo, TEnvInfo any](command string) (*nifaceRun[TInfo, TEnvInfo], *bytes.Buffer) {
 	var buf bytes.Buffer
 	r := &nifaceRun[TInfo, TEnvInfo]{
@@ -45,6 +47,29 @@ func newTestRun[TInfo, TEnvInfo any](command string) (*nifaceRun[TInfo, TEnvInfo
 	}
 	r.begin(command)
 	return r, &buf
+}
+
+// The per-command test runs. Each is spelled against its production alias (applyRun, resetRun,
+// ...), so changing a command's info pair updates its tests by construction: a test that kept
+// the old pair would no longer satisfy the alias-typed return and fails to compile (→ issue
+// #196, diff-review follow-up).
+func newApplyTestRun() (*applyRun, *bytes.Buffer) {
+	return newTestRun[*applyResultInfo, *applyEnvInfo]("apply")
+}
+func newResetTestRun() (*resetRun, *bytes.Buffer) {
+	return newTestRun[*resetResultInfo, *resetEnvInfo]("reset")
+}
+func newRollbackTestRun() (*rollbackRun, *bytes.Buffer) {
+	return newTestRun[*rollbackResultInfo, *rollbackEnvInfo]("rollback")
+}
+func newListGenerationsTestRun() (*listGenerationsRun, *bytes.Buffer) {
+	return newTestRun[*generationsInfo, *struct{}]("list-generations")
+}
+func newGitignoreTestRun() (*gitignoreRun, *bytes.Buffer) {
+	return newTestRun[*gitignoreInfo, *struct{}]("gitignore")
+}
+func newInitTestRun() (*initRun, *bytes.Buffer) {
+	return newTestRun[*struct{}, *initInfo]("init")
 }
 
 // decodeEnvelope asserts buf holds exactly one JSON document with a trailing newline and
@@ -100,7 +125,7 @@ func TestNifaceEnvelopeConformance(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			r, buf := newTestRun[*applyResultInfo, *applyEnvInfo]("apply")
+			r, buf := newApplyTestRun()
 			if c.subject != "" {
 				r.beginSubject(c.subject)
 			}
@@ -173,7 +198,7 @@ func TestNifaceEnvelopeDryRunFlag(t *testing.T) {
 		t.Fatalf("conformance.NewDefaultChecker: %v", err)
 	}
 	for _, dryRun := range []bool{false, true} {
-		r, buf := newTestRun[*applyResultInfo, *applyEnvInfo]("apply")
+		r, buf := newApplyTestRun()
 		r.dryRun = dryRun
 		r.beginSubject("default")
 		if err := r.emit(nil); err != nil {

--- a/cmd/nput/reset.go
+++ b/cmd/nput/reset.go
@@ -16,7 +16,7 @@ import (
 // resetResultInfo / resetEnvInfo are reset's niface info slots (→ issue #196): empty seat types
 // held as nil pointers, so both info keys stay out of the document exactly as before. Reset's
 // record lives in items / changes; the seats are here so later mutation run facts arrive as
-// field additions alone (→ apply.go の applyResultInfo コメント).
+// field additions alone (→ applyResultInfo in apply.go for the full rationale).
 type (
 	resetResultInfo struct{}
 	resetEnvInfo    struct{}
@@ -35,9 +35,7 @@ func newResetCmd() *cobra.Command {
 			"--dryrun shows the removal targets with zero side effects and exits (no confirm / flock).",
 		Args: cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			run := newNifaceRun[*resetResultInfo, *resetEnvInfo]()
-			run.begin(cmd.Name())
-			nifaceReport = run
+			run := beginNifaceRun[*resetResultInfo, *resetEnvInfo](cmd.Name())
 			return runReset(run, args[0], args[1:], flagDryrun)
 		},
 	}

--- a/cmd/nput/reset.go
+++ b/cmd/nput/reset.go
@@ -25,6 +25,11 @@ type (
 // resetRun is reset's concrete run instantiation, threaded from RunE into runReset.
 type resetRun = nifaceRun[*resetResultInfo, *resetEnvInfo]
 
+// beginResetRun starts reset's run (→ beginNifaceRun, beginApplyRun).
+func beginResetRun(command string) *resetRun {
+	return beginNifaceRun[*resetResultInfo, *resetEnvInfo](command)
+}
+
 func newResetCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "reset <name> [target...]",
@@ -35,7 +40,7 @@ func newResetCmd() *cobra.Command {
 			"--dryrun shows the removal targets with zero side effects and exits (no confirm / flock).",
 		Args: cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			run := beginNifaceRun[*resetResultInfo, *resetEnvInfo](cmd.Name())
+			run := beginResetRun(cmd.Name())
 			return runReset(run, args[0], args[1:], flagDryrun)
 		},
 	}

--- a/cmd/nput/reset.go
+++ b/cmd/nput/reset.go
@@ -13,6 +13,18 @@ import (
 	"github.com/yasunori0418/nput/internal/engine"
 )
 
+// resetResultInfo / resetEnvInfo are reset's niface info slots (→ issue #196): empty seat types
+// held as nil pointers, so both info keys stay out of the document exactly as before. Reset's
+// record lives in items / changes; the seats are here so later mutation run facts arrive as
+// field additions alone (→ apply.go の applyResultInfo コメント).
+type (
+	resetResultInfo struct{}
+	resetEnvInfo    struct{}
+)
+
+// resetRun is reset's concrete run instantiation, threaded from RunE into runReset.
+type resetRun = nifaceRun[*resetResultInfo, *resetEnvInfo]
+
 func newResetCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "reset <name> [target...]",
@@ -23,8 +35,10 @@ func newResetCmd() *cobra.Command {
 			"--dryrun shows the removal targets with zero side effects and exits (no confirm / flock).",
 		Args: cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			nifaceReport.begin(cmd.Name())
-			return runReset(args[0], args[1:], flagDryrun)
+			run := newNifaceRun[*resetResultInfo, *resetEnvInfo]()
+			run.begin(cmd.Name())
+			nifaceReport = run
+			return runReset(run, args[0], args[1:], flagDryrun)
 		},
 	}
 	cmd.Flags().BoolVar(&flagDryrun, "dryrun", false,
@@ -34,9 +48,9 @@ func newResetCmd() *cobra.Command {
 
 // runReset resolves rootKind (→ profileDir) via eval pre-resolution and drives engine.Reset.
 // --dryrun prints the plan read-only to stdout and exits 0. Non-dryrun requires TTY confirmation / --yes.
-func runReset(name string, targets []string, dryrun bool) error {
+func runReset(run *resetRun, name string, targets []string, dryrun bool) error {
 	// The config name is the niface subject; errors from here on are subject-borne (→ issue #130).
-	nifaceReport.beginSubject(name)
+	run.beginSubject(name)
 	ep, err := discoverEntrypoint(flagFile)
 	if err != nil {
 		return err
@@ -94,7 +108,7 @@ func runReset(name string, targets []string, dryrun bool) error {
 		// Also on a mid-teardown failure: the partial result keeps the changes complete up to
 		// the failure point (→ issue #131, niface ADR-0020). No generation slot — reset never
 		// moves the profile pointer (FS-only teardown).
-		attachResetPayload(res, err)
+		attachResetPayload(run, res, err)
 	}
 	if err != nil {
 		return err

--- a/cmd/nput/rollback.go
+++ b/cmd/nput/rollback.go
@@ -10,6 +10,18 @@ import (
 	"github.com/yasunori0418/nput/internal/manifest"
 )
 
+// rollbackResultInfo / rollbackEnvInfo are rollback's niface info slots (→ issue #196): empty
+// seat types held as nil pointers, so both info keys stay out of the document exactly as before.
+// The generation transition rides generation.before/after, not info; the seats are here so later
+// mutation run facts arrive as field additions alone (→ apply.go の applyResultInfo コメント).
+type (
+	rollbackResultInfo struct{}
+	rollbackEnvInfo    struct{}
+)
+
+// rollbackRun is rollback's concrete run instantiation, threaded from RunE into runRollback.
+type rollbackRun = nifaceRun[*rollbackResultInfo, *rollbackEnvInfo]
+
 func newRollbackCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "rollback <name>",
@@ -19,16 +31,18 @@ func newRollbackCmd() *cobra.Command {
 			"before moving the profile pointer. A name is required (no --all); errors out if there is no previous generation.",
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			nifaceReport.begin(cmd.Name())
-			return runRollback(args[0])
+			run := newNifaceRun[*rollbackResultInfo, *rollbackEnvInfo]()
+			run.begin(cmd.Name())
+			nifaceReport = run
+			return runRollback(run, args[0])
 		},
 	}
 }
 
 // runRollback confirms rootKind via eval pre-resolution (home mode only) and drives engine.Rollback.
-func runRollback(name string) error {
+func runRollback(run *rollbackRun, name string) error {
 	// The config name is the niface subject; errors from here on are subject-borne (→ issue #130).
-	nifaceReport.beginSubject(name)
+	run.beginSubject(name)
 	ep, err := discoverEntrypoint(flagFile)
 	if err != nil {
 		return err
@@ -56,7 +70,7 @@ func runRollback(name string) error {
 		// The From→To transition rides generation.before/after (GenBefore/GenAfter), not
 		// result.info — no double encoding (→ issue #131, niface ADR-0015). A stage-failure
 		// partial result maps the same way, with the pointer pinned at the unmoved generation.
-		attachMutationPayload(&res.Result, err)
+		attachMutationPayload(run, &res.Result, err)
 	}
 	if err != nil {
 		return err

--- a/cmd/nput/rollback.go
+++ b/cmd/nput/rollback.go
@@ -13,7 +13,8 @@ import (
 // rollbackResultInfo / rollbackEnvInfo are rollback's niface info slots (→ issue #196): empty
 // seat types held as nil pointers, so both info keys stay out of the document exactly as before.
 // The generation transition rides generation.before/after, not info; the seats are here so later
-// mutation run facts arrive as field additions alone (→ apply.go の applyResultInfo コメント).
+// mutation run facts arrive as field additions alone (→ applyResultInfo in apply.go for the
+// full rationale).
 type (
 	rollbackResultInfo struct{}
 	rollbackEnvInfo    struct{}
@@ -31,9 +32,7 @@ func newRollbackCmd() *cobra.Command {
 			"before moving the profile pointer. A name is required (no --all); errors out if there is no previous generation.",
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			run := newNifaceRun[*rollbackResultInfo, *rollbackEnvInfo]()
-			run.begin(cmd.Name())
-			nifaceReport = run
+			run := beginNifaceRun[*rollbackResultInfo, *rollbackEnvInfo](cmd.Name())
 			return runRollback(run, args[0])
 		},
 	}

--- a/cmd/nput/rollback.go
+++ b/cmd/nput/rollback.go
@@ -23,6 +23,11 @@ type (
 // rollbackRun is rollback's concrete run instantiation, threaded from RunE into runRollback.
 type rollbackRun = nifaceRun[*rollbackResultInfo, *rollbackEnvInfo]
 
+// beginRollbackRun starts rollback's run (→ beginNifaceRun, beginApplyRun).
+func beginRollbackRun(command string) *rollbackRun {
+	return beginNifaceRun[*rollbackResultInfo, *rollbackEnvInfo](command)
+}
+
 func newRollbackCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "rollback <name>",
@@ -32,7 +37,7 @@ func newRollbackCmd() *cobra.Command {
 			"before moving the profile pointer. A name is required (no --all); errors out if there is no previous generation.",
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			run := beginNifaceRun[*rollbackResultInfo, *rollbackEnvInfo](cmd.Name())
+			run := beginRollbackRun(cmd.Name())
 			return runRollback(run, args[0])
 		},
 	}


### PR DESCRIPTION
## 概要

niface エンベロープの型パラメータ `TInfo`（`result.info`）/ `TEnvInfo`（トップレベル `info`）を `map[string]any` から各コマンドの具象型へ移行する。niface ADR-0018 は「`Envelope.Info` を `map[string]any` にする」案を明示的に棄却しており、conformance ガイドが示す producer 像（自ツールの info 型でパラメータ化）へ整合させる dogfooding。

**出力不変 refactor**であり、JSON 形状は一切変えていない。既存の conformance / e2e / niface-validate が**無改変で** green であることを回帰の基準とした。

主な内容:

- `nifaceRun` / `nifaceSubject` / `nifacePayload` と payload ビルダ群を `[TInfo, TEnvInfo]` / `[TInfo]` で generic 化。niface go module 側は改変不要（`Envelope.MarshalJSON` が既にあり、型引数の異なる Envelope も標準 `json.Marshaler` として一様に扱えるため）
- 型消去は nput 側の `emitter` interface（非 generic な `began()` / `emit(error)` の 2 メソッドのみ）。どのサブコマンドが走るかは cobra のディスパッチ前に決まらず、info 型を引数に取る setter は generic メソッドになり interface に載せられないため
- 具象 run は各コマンドの `begin<Cmd>Run` が生成・begin・`nifaceReport` への publish をまとめて行い、下位 run 関数へ引数で引き回す
- mutation 系（apply / reset / rollback）の未使用スロットはコマンドごとの空 struct 型へのポインタで座席化。後続 issue でフィールド追加だけで拡張できるようにするための座席で、本 PR ではフィールドを追加しない
- read 系は既存の実データを `generationsInfo` / `gitignoreInfo` に、init は `initInfo` に型付け

**issue #196 の割当表から 1 点意図的に逸脱している**（下記「docs / ADR 影響」に記載）。

範囲境界（issue で確定済み・本 PR では触らない）: subject は単数のまま（複数化は #164）、`--all` 経路の JSON は埋めない、niface go module と go.mod pin は動かさない。

動作確認:

- `go test ./...` / `gofmt` / `go vet` — green
- `nix flake check` — exit 0
- e2e 7 シナリオ全 PASS（`tests/` `dev/` は**無改変**）
- **出力不変の実測**: main と本ブランチのバイナリで `--json` 出力を 15 経路（mutation / read / init の成功・失敗・`--all`・`--dryrun`・引数エラー・help）比較し、タイムスタンプ正規化後**全てバイト一致**
- 新規回帰テストの検知力: 座席型・read 系 info を非ポインタへ改悪すると実際に FAIL することを確認（それぞれ `"info":{}` / `"info":{"generations":null}` を出力）

`diff-review` を 4 巡実施し、must / want+ / want の指摘ゼロを確認済み（1 巡目の must 2 件は回帰テスト不在の指摘で、`assertNoInfoKeys` と各 InfoAbsent 系テストを追加して解消）。

## 関連 issue

Closes #196
Refs #197

## docs / ADR 影響

なし（`docs/` の更新は不要）。

出力仕様（`docs/spec.md` の `--json` ペイロード詳細）は**変更していない**。本 PR は Go 型レベルの安全性を上げるだけで、consumer から見える JSON 形状・キーの有無は現行と完全に一致する。`docs/` 配下に `nifaceRun` 等の内部構造への言及は無く、更新箇所は生じなかった。ADR も新規追加なし（設計判断は issue #196 の grilling で確定済み、niface ADR-0018 / ADR-0043 の既存方針に沿う）。

**issue #196 §5 の割当表からの逸脱を 1 点報告する。** 表は read 系 `TInfo`（`generationsInfo` / `gitignoreInfo`）と init の `TEnvInfo`（`initInfo`）を**非ポインタ**としていたが、実装ではポインタにした。理由:

- 非ポインタ struct には `omitempty` が効かない（同 issue §4 が mutation 系座席型について指摘しているのと同じ罠）
- read 系は subject 登録後・`setPayload` 前に失敗する経路が実在し（entrypoint 探索失敗 / rootKind 判定拒否 / profile 解決失敗）、非ポインタだとそこで `"info":{"generations":null}` を**新規に出力**する
- init も不正 template 名で `setEnvelopeInfo` 到達前に return するため `"info":{"template":"","ref":""}` が出る
- いずれも同 issue §4 が要求する出力不変を破るため、§4 が §5 の表に優先すると判断した

この不変条件は目視ではなく回帰テストで固定してある（`assertNoInfoKeys` + 各コマンドの InfoAbsent 系テスト）。niface schema は `info` を素の object としか定めず `"info":{}` も適合扱いになるため、conformance checker も e2e も検知できない領域であり、専用テストが必要だった。
