### PR TITLE
docs(dev): 完成の定義を追加する

### DIFF
--- a/docs/dev/definition-of-done.md
+++ b/docs/dev/definition-of-done.md
@@ -1,0 +1,48 @@
+# 完成の定義
+
+- 改訂日: 2026-07-26
+
+プロジェクトに 1 つの恒久ドキュメント。配置は `docs/dev/definition-of-done.md` 固定で、
+機能単位の作業ディレクトリ（`docs/dev/<対象>/`）の削除対象に含めない。
+
+項目は**機械判定・人判定を合わせて最大 5 件**（機械パース契約の一部。dod-check.sh が検査する）。
+項目が多いほど各項目のクリアが重くなり完成が遠のくため、増やしたくなったら統合するか、
+優先度の低い項目を外す。
+
+## 機械判定
+
+各項目に判定手段を宣言する。dev-pipeline 等の決定論スクリプトがこのテーブルを
+パースして項目別判定を報告するため、列構成・種別・条件の語彙は変えない。
+
+| ID | 項目 | 種別 | 対象 | 条件 |
+|---|---|---|---|---|
+| DOD-01 | E2E テストが通っていること | ci-check | e2e | success |
+| DOD-02 | nix flake check が通っていること | ci-check | flake-check (ubuntu-latest, x86_64-linux) | success |
+
+DOD-01 / DOD-02 は ruleset `main branch protection` の required status check でもあり、
+未達ならそもそも `main` へマージできない（→ ADR-0030）。DOD-02 は matrix の代表 1 件のみを
+挙げているが、ruleset 側では残る 2 プラットフォーム
+（`flake-check (ubuntu-24.04-arm, aarch64-linux)` / `flake-check (macos-latest, aarch64-darwin)`）
+も必須のまま強制される。job 名 / matrix を変えると check 名が変わるため、
+ruleset と本テーブルの両方に追従が要る。
+
+`go-coverage` は計測・表示のみで閾値ゲートを持たない設計（マージ順依存の回避）であり、
+required check にも含めていないため、完成の定義にも入れない。
+
+### 種別と条件の語彙（機械パース契約）
+
+- `ci-check`: 対象 = GitHub Actions の check 名。条件 = `success`（成功していること）。
+- `artifact`: 対象 = リポジトリ相対パス。対象パスには `{target}` プレースホルダを使える
+  （判定時に対象機能名へ展開される。例: `docs/test/{target}/test-summary-report.md`）。
+  条件は次のいずれか:
+  - `exists`: ファイルが存在する。
+  - `contains:<文字列>`: ファイルが `<文字列>` を含む。
+
+## 人判定
+
+機械化できない項目のみを列挙する。人間が最終確認するチェックリストになる唯一の部分。
+
+- [ ] DOD-03: 設計判断を伴う変更であれば `docs/adr/` に ADR を追加し、既存 ADR と矛盾していない
+      （連番ファイル名のため、どの ADR が当該変更の分かを機械が特定できない）
+- [ ] DOD-04: `docs/design.md` / `docs/spec.md` / `docs/concept.md` が実装の変更に追従している
+      （追従の要否と十分性が意味判断になる）


### PR DESCRIPTION
## 概要

シフトレフト開発プロセスの工程 0 にあたる「完成の定義」を `docs/dev/definition-of-done.md` として追加する。
このリポジトリで「作業が完成した」と言える条件を、機械判定 2 件・人判定 2 件の計 4 件で宣言した恒久ドキュメント。

機械判定節のテーブルは dev-pipeline 等の決定論スクリプトがパースしてマージ可否の判定材料に使うため、
列構成・種別・条件の語彙は機械パース契約として固定している。

振り分けの方針は「機械化できるものは機械判定へ落とし、人判定には残余だけを置く」。その結果:

- **機械判定**: ruleset `main branch protection` の required status check から `e2e` と
  `flake-check (ubuntu-latest, x86_64-linux)` の 2 件。未達なら `main` へマージできない実効ゲートになっている。
- **人判定**: ADR の追加・既存 ADR との整合、`design.md` / `spec.md` / `concept.md` の追従更新の 2 件。
  いずれも機械化を検討したうえで落ちたもの（ADR は連番ファイル名のためどれが当該変更の分か機械が特定できず、
  docs 追従は要否と十分性が意味判断になる）。

含めなかったものとその理由も本文に記録している:

- `go-coverage` は計測・表示のみで閾値ゲートを持たない設計（マージ順依存の回避）であり、required check にも
  含まれていないため完成の定義にも入れない。
- `flake-check` は matrix 代表 1 件のみを挙げ、残る 2 プラットフォームは ruleset 側の強制に委ねる
  （項目数の上限 5 件に対する枠配分のため）。

レビュー時の注意点として、機械判定節の `対象` 列には matrix 展開後の check 名をそのまま書いている。
`test.yml` の job 名や matrix を変更すると check 名が変わるため、**ruleset と本テーブルの両方**に
追従が必要になる（この注意は成果物本文にも記載）。

## 関連 issue

なし

## docs / ADR 影響

- concept / design / spec の更新: なし。配置動作・API・方針のいずれにも触れず、開発プロセス側のドキュメントを
  1 件追加するのみ。
- ADR の追加: なし。既存の方針を変更するものではなく、ADR-0030（required status check によるマージ条件）と
  `.github/workflows/test.yml` で既に決まっている内容を、完成の定義の形に写している。ADR-0030 が挙げる
  4 つの check 名は本 PR 時点の ruleset の実設定と一致することを確認済み。

なお `docs/dev/definition-of-done.md` はプロジェクトに 1 つの恒久ドキュメントで、機能単位の作業ディレクトリ
（`docs/dev/<対象>/`）とは別階層に置く。doc-integrate による作業ディレクトリ削除の対象外。

内容の改訂は `/def-done` の改訂モードで行う想定。テストプロセス成果物（`docs/test/{target}/`）を完成条件に
加えるかは、パイプラインを実際に 1 周してから判断するため今回は見送っている。
