### PR TITLE
docs(requirements): レビューで申し送られた規範の欠落を requirement item として回収する

### DIFF
--- a/docs/adr/0035-hm-multi-profile-configs.md
+++ b/docs/adr/0035-hm-multi-profile-configs.md
@@ -10,6 +10,7 @@ justifies:
   - "REQ-5c6b07da-3d06-414d-8770-4f438234b322"
   - "REQ-fc1118b1-b0e8-4ddf-80f6-c70956651693"
   - "REQ-c847d1af-a437-46bb-bd64-42083810d034"
+  - "REQ-5923ac79-4a2d-43cd-b56c-2f1000c01b44"
 revises:
   - "ADR-0024"
   - "ADR-0025"

--- a/docs/adr/0035-hm-multi-profile-configs.md
+++ b/docs/adr/0035-hm-multi-profile-configs.md
@@ -9,6 +9,7 @@ justifies:
   - "REQ-fc1c7ce6-dc9d-4dd3-98f5-7877d9f99d10"
   - "REQ-5c6b07da-3d06-414d-8770-4f438234b322"
   - "REQ-fc1118b1-b0e8-4ddf-80f6-c70956651693"
+  - "REQ-c847d1af-a437-46bb-bd64-42083810d034"
 revises:
   - "ADR-0024"
   - "ADR-0025"

--- a/docs/requirements/20260802-5c6b07da-target-collision-eval-detection.md
+++ b/docs/requirements/20260802-5c6b07da-target-collision-eval-detection.md
@@ -13,7 +13,8 @@ specification: |
   instead be handled at engine runtime as last-writer-wins plus a foreign symlink warning.
   The two SHALL remain separate paths. Where several configs do ride on a single
   evaluation, as the `nput.configs` of one module configuration do, static detection is
-  possible and SHALL NOT be precluded by this.
+  possible and SHALL NOT be precluded by this; that case is stated by REQ-5923ac79 and is
+  not restated here.
 specification_ja: |
   別キー A / B が `target` フィールドを同値に明示上書きした衝突は、正規化後 target
   文字列の重複として eval 時に `lib.throwIf` で検出し停止しなければならない
@@ -21,7 +22,8 @@ specification_ja: |
   別ツールに跨る場合）の同一 target 衝突は eval では検出できず、engine 実行時の後勝ち +
   foreign symlink warning として扱う。両者は別経路とする。単一の eval に載る複数 config
   （1 つのモジュール config の `nput.configs` など）については静的検出が可能であり、
-  本 item はそれを妨げない。
+  本 item はそれを妨げない。その場合の規範は REQ-5923ac79 の担当で、本 item では
+  規定しない。
 ---
 # REQ-5c6b07da: target 衝突の検出経路を同一 manifest 内と cross-config で分ける
 
@@ -41,9 +43,8 @@ cross-config（別 profile・別 manifest）の同一 target 衝突は eval で�
 > eval 時 assertion で停止すると決定済み**で、原文の無条件な言い切りはこれを否定してしまう
 > （原文が ADR-0035 に未追従・REQ-37b56673 / REQ-16faf428 で ADR-0036 由来の未追従を扱ったのと
 > 同じ扱い）。本 item は静的検出が可能な場合を妨げないことまでを規範とし、その場合に実際に
-> eval 停止する規範（ADR-0035 §4）そのものは持たない。同 §4 の item 化は `docs/spec.md` の
-> 追従（epic #203 の段階 7）とあわせて別途扱う（→ REQ-c6891aeb の注記）。`docs/spec.md` の
-> 追従は本 item の担当範囲外。
+> eval 停止する規範（ADR-0035 §4）そのものは持たない。**同 §4 の規範は REQ-5923ac79 が
+> 持つ**。`docs/spec.md` の追従は本 item の担当範囲外。
 
 ## 出典
 

--- a/docs/requirements/20260802-8085f194-hm-activation-contract.md
+++ b/docs/requirements/20260802-8085f194-hm-activation-contract.md
@@ -17,9 +17,9 @@ specification: |
   structurally. This states the contract of a single kick; the correspondence of one
   config to one manifest and one profile is stated by REQ-c6891aeb, and the definition of
   the option supplying its entries by REQ-fc1c7ce6, neither being restated here. How many
-  times the activation kicks the engine when several configs are present (ADR-0035 §3) is
-  as yet held by no item — the original text carries no corresponding passage — and is
-  taken up separately, together with its following.
+  times the activation kicks the engine when several configs are present, in what order
+  and how a partial failure is aggregated (ADR-0035 §3), is stated by REQ-c847d1af and is
+  likewise not restated here.
 specification_ja: |
   home-manager モジュールは `home.activation.nput`（`entryAfter ["writeBoundary"]`）から
   `nput apply --manifest <link-farm>` で engine を kick しなければならない。link-farm は
@@ -31,9 +31,9 @@ specification_ja: |
   同一 flake input 由来のため、schemaVersion skew は構造的に起こらないものとする。本 item が
   規定するのは 1 起動あたりの契約であり、1 config が 1 manifest = 1 profile に対応することは
   REQ-c6891aeb、その entries を供給するオプションの定義は REQ-fc1c7ce6 の担当で、いずれも
-  本 item では規定しない。複数 config があるとき activation が engine を何回 kick するか
-  （ADR-0035 §3）は、原文に対応記述が無いためどの item も未だ規範として持たず、原文の追従と
-  あわせて別途扱う。
+  本 item では規定しない。複数 config があるとき activation が engine を何回 kick するか・
+  その順序・部分失敗の集約（ADR-0035 §3）は REQ-c847d1af の担当で、これも本 item では
+  規定しない。
 ---
 # REQ-8085f194: home-manager モジュールの engine kick 1 回は activation からビルド済み link-farm を渡し、失敗で switch を止める
 
@@ -70,8 +70,9 @@ specification_ja: |
 >   `nput.entries` はその糖衣）→ REQ-fc1c7ce6、1 config が 1 manifest = 1 profile に対応する
 >   ことと profile 粒度 → REQ-c6891aeb。本 item の写しにある `nput.entries` は原文逐語であり、
 >   規範文では供給元を「config の entries」と述べて ADR-0035 と衝突しない形にしている。
->   activation が profile ごとに engine を kick する規律（ADR-0035 §3）は原文に対応記述が無く、
->   **どの item も規範として持たない**（item 化は REQ-c6891aeb の注記のとおり別途扱う）
+>   activation が profile ごとに engine を kick する規律（ADR-0035 §3・辞書順・部分失敗の
+>   集約）は原文に対応記述が無いため本 item の写しには現れないが、規範は REQ-c847d1af が
+>   持つ
 > - flock を既定 blocking で取ること → REQ-1c1526b1。レポートと warning を stderr へ出す
 >   ストリーム規律 → REQ-fea038de。終了コードの体系 → REQ-2c5a10d8
 > - 世代が nput 自前 profile に乗ること → REQ-1be4d678。profile 名の次元 → REQ-c6891aeb、

--- a/docs/requirements/20260802-c6891aeb-hm-named-configs-profiles.md
+++ b/docs/requirements/20260802-c6891aeb-hm-named-configs-profiles.md
@@ -65,11 +65,11 @@ specification_ja: |
 > 最後に集約）、§4 で単一 HM config 内の `configs` 間の正規化後 target 衝突を eval 時
 > assertion で停止することも決めているが、いずれも `docs/spec.md` に対応記述が無い
 > （原文が ADR-0035 未追従のため）。本 item は原文 blockquote の担当範囲＝profile 粒度に
-> 留め、§3〜§4 の item 化は原文の追従（段階 7）とあわせて別途扱う。なお §4 の eval 停止は、
-> 別 entrypoint・別 manifest の cross-config を「eval では検出不可・実行時の後勝ち + foreign
-> warning」とする REQ-5c6b07da / REQ-fc1118b1 に対する**例外**（HM の `configs` は全 config が
-> 単一のモジュール eval に載るため静的検出が可能）であり、item 化の際はこの関係を明示する
-> 必要がある。
+> 留め、**§3 の規範は REQ-c847d1af、§4 の規範は REQ-5923ac79 が持つ**。なお §4 の eval
+> 停止は、別 entrypoint・別 manifest の cross-config を「eval では検出不可・実行時の
+> 後勝ち + foreign warning」とする REQ-5c6b07da / REQ-fc1118b1 に対する**例外**（HM の
+> `configs` は全 config が単一のモジュール eval に載るため静的検出が可能）であり、この
+> 関係は REQ-5923ac79 の注記が明示している。
 
 ## 出典
 

--- a/docs/requirements/20260802-fc1118b1-cross-config-target-oscillation.md
+++ b/docs/requirements/20260802-fc1118b1-cross-config-target-oscillation.md
@@ -13,7 +13,7 @@ specification: |
   foreign symlink warning and SHALL NOT hold any mechanism that detects and stops it at
   engine runtime. Where several configs ride on a single evaluation, as the `nput.configs`
   of one module configuration do, a static detection at eval time is possible and SHALL
-  NOT be precluded by this.
+  NOT be precluded by this; that case is stated by REQ-5923ac79 and is not restated here.
   The foreign warning during an oscillation will keep appearing under the high frequency
   at which a `shellHook` runs, and this SHALL be regarded as correct, being the signal of
   a misconfiguration; the warning SHALL be outside the scope of silence on success and
@@ -26,7 +26,8 @@ specification_ja: |
   「同一 target を複数 config で狙わない」はユーザー責任とし、nput は foreign symlink warning で
   可視化するに留め、engine 実行時に検知して止める機構を持ってはならない。単一の eval に載る
   複数 config（1 つのモジュール config の `nput.configs` など）については eval 時の静的検出が
-  可能であり、本 item はそれを妨げない。振動中の foreign warning は
+  可能であり、本 item はそれを妨げない。その場合の規範は REQ-5923ac79 の担当で、本 item
+  では規定しない。振動中の foreign warning は
   `shellHook` の高頻度実行で出続けるが、これは設定ミスのシグナルとして正しい。この warning は
   成功時沈黙の対象外であり、`-v` の有無に関わらず常時出る。MVP では抑制 / 集約機構を持たず、
   config の同一 target 重複を解消して直す。
@@ -54,8 +55,8 @@ specification_ja: |
 > 載るため正規化後 target の衝突を静的に検出でき、eval 時 assertion で停止すると決定済み**で、
 > 原文の無条件な言い切りはこれを否定してしまう（原文が ADR-0035 に未追従・REQ-5c6b07da と
 > 同じ扱い）。本 item は静的検出が可能な場合を妨げないことまでを規範とし、その場合に実際に
-> eval 停止する規範そのものは持たない（同 §4 の item 化は `docs/spec.md` の追従とあわせて
-> 別途扱う・→ REQ-c6891aeb の注記）。`docs/spec.md` の追従は本 item の担当範囲外。
+> eval 停止する規範そのものは持たない（**同 §4 の規範は REQ-5923ac79 が持つ**）。
+> `docs/spec.md` の追従は本 item の担当範囲外。
 
 ## 出典
 

--- a/docs/requirements/20260803-2bd0d35f-modules-common-nixpkgs-lib-only.md
+++ b/docs/requirements/20260803-2bd0d35f-modules-common-nixpkgs-lib-only.md
@@ -5,23 +5,23 @@ name: "modules/common.nix は nixpkgs.lib のみに依存する"
 derives_from:
   - "UC-d39c1994-f9a5-4860-80ba-f6e584adaf14"
 specification: |
-  `modules/common.nix` SHALL depend only on nixpkgs.lib. It MUST NOT introduce a
+  `modules/common.nix` SHALL depend only on nixpkgs.lib. It SHALL NOT introduce a
   dependency on the module system of home-manager, NixOS or nix-darwin, so that the common
   option set it holds can be imported from every integration layer without one layer's
   module system leaking into another. Which options it defines is stated by REQ-fc1c7ce6,
-  and the same constraint on `lib` by REQ-d85f0cef; neither is restated here. The
-  dependency on the module system of an integration layer belongs to the per-layer files
-  (`modules/home-manager.nix` and its counterparts), which are wiring that kicks the
-  engine (REQ-c1b3ca5f).
+  and the same constraint on `lib` by REQ-d85f0cef; neither is restated here. What the
+  per-layer files (`modules/home-manager.nix` and its counterparts) may depend on is
+  outside the scope of this item and is not stated here; that they are wiring which kicks
+  the engine is stated by REQ-c1b3ca5f.
 specification_ja: |
   `modules/common.nix` は nixpkgs.lib のみに依存しなければならない。home-manager /
   NixOS / nix-darwin の module system への依存を持ち込んではならない。同ファイルが持つ
   共通オプション集合を、ある統合層の module system を別の統合層へ漏らすことなく全統合層
   から import できるようにするためである。同ファイルがどのオプションを定義するかは
   REQ-fc1c7ce6、`lib` に対する同種の制約は REQ-d85f0cef の担当で、いずれも本 item では
-  規定しない。統合層の module system への依存は統合層ごとのファイル
-  （`modules/home-manager.nix` 等）の担当であり、それらは engine を起動する配線である
-  （REQ-c1b3ca5f）。
+  規定しない。統合層ごとのファイル（`modules/home-manager.nix` 等）が何に依存してよいかは
+  本 item の射程外であり、ここでは規定しない。それらが engine を起動する配線であることは
+  REQ-c1b3ca5f の担当である。
 ---
 # REQ-2bd0d35f: modules/common.nix は nixpkgs.lib のみに依存する
 
@@ -35,26 +35,30 @@ specification_ja: |
 > （`enable` / `configs`（`entries` を含む）/ `backup.*` と `nput.entries` の糖衣）は
 > REQ-fc1c7ce6、entry submodule の型定義を `lib/types.nix` と共有することは REQ-d1b5b3f5、
 > `lib` が nixpkgs.lib のみに依存する純データ生成器であることは REQ-d85f0cef、engine が
-> stdlib-only であることは REQ-b74a118a の担当。統合層ごとのファイルが自層の module
-> system に依存し engine を起動する配線に徹することは REQ-c1b3ca5f。層の積み方と依存の
-> 向きを一方向に限る設計は DSG-17db0831 が持つ。
+> stdlib-only であることは REQ-b74a118a の担当。統合層ごとのファイルが engine を起動する
+> 配線に徹することは REQ-c1b3ca5f が定めるが、**それらが何に依存してよいかの規範は現状
+> どの item も持たない**（原文の `modules/home-manager.nix` 行以下も `modules/common.nix`
+> 行と同じく縮退で落ちたまま未回収）。層の積み方と依存の向きを一方向に限る設計は
+> DSG-17db0831 が持つ。
 >
 > **新規 item にした理由（REQ-d85f0cef との粒度合わせ）**: 依存制約は層ごとに 1 item
 > 立てるのが既存の粒度で、`lib` は REQ-d85f0cef、engine は REQ-b74a118a が各層 1 item
 > として持つ。`modules/common.nix` は DSG-17db0831 の 5 段のうち `lib` とも統合層とも
 > 別の 1 段であり、同じ粒度に揃えるなら独立した item になる。既存 item への編入も
 > 検討したが、REQ-fc1c7ce6 は「共通オプションとして何を公開するか」の item で軸が別
-> （公開する集合 vs 依存の範囲）であり、REQ-d85f0cef へ相乗りさせると 1 item 1 主張が
-> 崩れるため採らなかった。DSG-17db0831 の層構成図は `common.nix` を「options 型定義
+> （公開する集合 vs 依存の範囲）であり、REQ-d85f0cef へ相乗りさせると `lib` と
+> `common.nix` という別の層に対する 2 つの依存制約が 1 item に同居して 1 item 1 主張が
+> 崩れるため、いずれも採らなかった。DSG-17db0831 の層構成図は `common.nix` を「options 型定義
 > （nixpkgs.lib のみ依存）」と記載するが、これは設計の図であって規範文（specification）
 > ではないため、本 item が規範を持つ。
 
 ## 出典
 
-分割時点の原文（縮退前）の `docs/spec.md`「依存関係」節の表の `modules/common.nix` 行
-「nixpkgs.lib のみ」。#209 の分割では同表の `lib/` 行が REQ-d85f0cef、`internal/` 行が
-REQ-b74a118a へ入った一方、`modules/common.nix` 行はどの item の規範にも入らないまま
-縮退で落ちていた（epic #203 / issue #228 で回収）。
+`docs/spec.md`「依存関係」節の表の `modules/common.nix` 行「nixpkgs.lib のみ」。#209 の
+分割では同表の `internal/` 行が REQ-b74a118a へ入った一方、`modules/common.nix` 行は
+どの item の規範にも入らないまま縮退で落ちていた（epic #203 / issue #228 で回収）。
+`lib` に対する同種の依存制約は、同表の `lib/` 行ではなく別出典（「lib API」節）の
+REQ-d85f0cef が持つ。
 
 同表の他行と異なり原文の当該行は ADR 参照を伴わず、`modules/common.nix` の依存制約
 そのものを決定した ADR も無いため、`justifies` は張らない（側面としては、lib を

--- a/docs/requirements/20260803-2bd0d35f-modules-common-nixpkgs-lib-only.md
+++ b/docs/requirements/20260803-2bd0d35f-modules-common-nixpkgs-lib-only.md
@@ -1,0 +1,63 @@
+---
+id: "REQ-2bd0d35f-dc29-4771-9cfe-6998247afa0f"
+type: requirement
+name: "modules/common.nix は nixpkgs.lib のみに依存する"
+derives_from:
+  - "UC-d39c1994-f9a5-4860-80ba-f6e584adaf14"
+specification: |
+  `modules/common.nix` SHALL depend only on nixpkgs.lib. It MUST NOT introduce a
+  dependency on the module system of home-manager, NixOS or nix-darwin, so that the common
+  option set it holds can be imported from every integration layer without one layer's
+  module system leaking into another. Which options it defines is stated by REQ-fc1c7ce6,
+  and the same constraint on `lib` by REQ-d85f0cef; neither is restated here. The
+  dependency on the module system of an integration layer belongs to the per-layer files
+  (`modules/home-manager.nix` and its counterparts), which are wiring that kicks the
+  engine (REQ-c1b3ca5f).
+specification_ja: |
+  `modules/common.nix` は nixpkgs.lib のみに依存しなければならない。home-manager /
+  NixOS / nix-darwin の module system への依存を持ち込んではならない。同ファイルが持つ
+  共通オプション集合を、ある統合層の module system を別の統合層へ漏らすことなく全統合層
+  から import できるようにするためである。同ファイルがどのオプションを定義するかは
+  REQ-fc1c7ce6、`lib` に対する同種の制約は REQ-d85f0cef の担当で、いずれも本 item では
+  規定しない。統合層の module system への依存は統合層ごとのファイル
+  （`modules/home-manager.nix` 等）の担当であり、それらは engine を起動する配線である
+  （REQ-c1b3ca5f）。
+---
+# REQ-2bd0d35f: modules/common.nix は nixpkgs.lib のみに依存する
+
+## 仕様
+
+| コンポーネント | 依存 |
+|---|---|
+| `modules/common.nix` | nixpkgs.lib のみ |
+
+> **上は原文の写しで、規範は frontmatter が正**。同ファイルが定義する共通オプション集合
+> （`enable` / `configs`（`entries` を含む）/ `backup.*` と `nput.entries` の糖衣）は
+> REQ-fc1c7ce6、entry submodule の型定義を `lib/types.nix` と共有することは REQ-d1b5b3f5、
+> `lib` が nixpkgs.lib のみに依存する純データ生成器であることは REQ-d85f0cef、engine が
+> stdlib-only であることは REQ-b74a118a の担当。統合層ごとのファイルが自層の module
+> system に依存し engine を起動する配線に徹することは REQ-c1b3ca5f。層の積み方と依存の
+> 向きを一方向に限る設計は DSG-17db0831 が持つ。
+>
+> **新規 item にした理由（REQ-d85f0cef との粒度合わせ）**: 依存制約は層ごとに 1 item
+> 立てるのが既存の粒度で、`lib` は REQ-d85f0cef、engine は REQ-b74a118a が各層 1 item
+> として持つ。`modules/common.nix` は DSG-17db0831 の 5 段のうち `lib` とも統合層とも
+> 別の 1 段であり、同じ粒度に揃えるなら独立した item になる。既存 item への編入も
+> 検討したが、REQ-fc1c7ce6 は「共通オプションとして何を公開するか」の item で軸が別
+> （公開する集合 vs 依存の範囲）であり、REQ-d85f0cef へ相乗りさせると 1 item 1 主張が
+> 崩れるため採らなかった。DSG-17db0831 の層構成図は `common.nix` を「options 型定義
+> （nixpkgs.lib のみ依存）」と記載するが、これは設計の図であって規範文（specification）
+> ではないため、本 item が規範を持つ。
+
+## 出典
+
+分割時点の原文（縮退前）の `docs/spec.md`「依存関係」節の表の `modules/common.nix` 行
+「nixpkgs.lib のみ」。#209 の分割では同表の `lib/` 行が REQ-d85f0cef、`internal/` 行が
+REQ-b74a118a へ入った一方、`modules/common.nix` 行はどの item の規範にも入らないまま
+縮退で落ちていた（epic #203 / issue #228 で回収）。
+
+同表の他行と異なり原文の当該行は ADR 参照を伴わず、`modules/common.nix` の依存制約
+そのものを決定した ADR も無いため、`justifies` は張らない（側面としては、lib を
+データ生成に徹させる ADR-0006、entry submodule の型定義を `lib/types.nix` と
+`modules/common.nix` で共有すると定めた ADR-0010、モジュールを配線に徹させる ADR-0003 が
+この制約と整合する）。

--- a/docs/requirements/20260803-5923ac79-hm-configs-target-collision-assertion.md
+++ b/docs/requirements/20260803-5923ac79-hm-configs-target-collision-assertion.md
@@ -13,8 +13,9 @@ specification: |
   that eval can see, stated for a single manifest by REQ-5c6b07da. It SHALL be an exception
   to the general cross-config collision, which does not ride on a single evaluation and
   which REQ-5c6b07da and REQ-fc1118b1 leave to last-writer-wins plus a foreign symlink
-  warning at engine runtime; that treatment SHALL remain unchanged for collisions across
-  separate entrypoints, machines or tools. Without this detection, the two configs would
+  warning at engine runtime; how a collision across separate entrypoints, machines or
+  tools is treated is stated by those two items and is not restated or altered here.
+  Without this detection, the two configs would
   take the same target from each other at every activation, making a flip-flop permanent,
   the introduction of role separation itself being what breeds the collision.
 specification_ja: |
@@ -25,7 +26,8 @@ specification_ja: |
   eval で止めること（同一 manifest 内について REQ-5c6b07da が定める）の自然な延長で
   ある。これは単一の eval に載らない一般の cross-config 衝突（REQ-5c6b07da /
   REQ-fc1118b1 が engine 実行時の後勝ち + foreign symlink warning に委ねるもの）に
-  対する例外とする。別 entrypoint・別マシン・別ツールに跨る衝突の扱いは変わらない。
+  対する例外とする。別 entrypoint・別マシン・別ツールに跨る衝突をどう扱うかは
+  同 2 item の担当であり、本 item では再掲も変更もしない。
   検出しなければ、activation のたびに A と B が同じ target を交互に奪い合う
   フリップフロップが恒常化する。役割分離の導入自体が衝突の温床になるためである。
 ---

--- a/docs/requirements/20260803-5923ac79-hm-configs-target-collision-assertion.md
+++ b/docs/requirements/20260803-5923ac79-hm-configs-target-collision-assertion.md
@@ -48,16 +48,12 @@ specification_ja: |
 > ADR-0035 に未追従のため #209 の分割では item 化されず、REQ-c6891aeb / REQ-5c6b07da /
 > REQ-fc1118b1 の注記に申し送りとして残っていた（epic #203 / issue #228 で回収）。
 >
-> **REQ-5c6b07da / REQ-fc1118b1 との整合**: 両 item は原文の「cross-config は eval では
-> 検出不可」という無条件の言い切りを**単一の eval に載らない場合**へ限定し、単一の eval に
-> 載る複数 config について「静的検出が可能であり本 item はそれを妨げない」までを規範と
-> して、実際に eval 停止する規範そのものは持たないと明記していた。本 item がその欠けて
-> いた規範を担う。したがって三者の関係は、REQ-5c6b07da が同一 manifest 内の衝突を eval で
-> 止めること・単一の eval に載らない cross-config を engine 実行時へ回すこと、
-> REQ-fc1118b1 が engine 実行時に検知して止める機構を持たないこと、本 item が単一の
-> eval に載る `configs` 間について eval 停止することを、それぞれ規定する形になる。
-> 検出層を「設定の誤りは評価時・実体の不整合は engine 実行時」に分ける原則そのものは
-> REQ-c5dfcae6 の担当。
+> **REQ-5c6b07da / REQ-fc1118b1 との整合**: 両 item は規範文を「単一の eval に載らない
+> 場合」へ限定したうえで、単一の eval に載る複数 config については「静的検出を妨げない」
+> までを述べ、実際に eval 停止する規範そのものは持たないと明記している。本 item がその
+> 欠けていた規範を担う。両 item が何を規定するかはそれぞれの specification が正で、
+> ここでは再掲しない。検出層を「設定の誤りは評価時・実体の不整合は engine 実行時」に
+> 分ける原則そのものは REQ-c5dfcae6 の担当。
 >
 > **他 item との担当分界**: 正規化後 target 文字列の同値判定と属性キー = target という
 > 識別の体系は REQ-cb77ea05 / REQ-b232ec98、`nput.configs` オプションの定義は

--- a/docs/requirements/20260803-5923ac79-hm-configs-target-collision-assertion.md
+++ b/docs/requirements/20260803-5923ac79-hm-configs-target-collision-assertion.md
@@ -1,0 +1,75 @@
+---
+id: "REQ-5923ac79-4a2d-43cd-b56c-2f1000c01b44"
+type: requirement
+name: "単一 HM config 内の configs 間 target 衝突は eval 時 assertion で停止する"
+derives_from:
+  - "UC-1c280dce-7c72-44c0-95ea-d06344f62a47"
+specification: |
+  Where `configs.<A>` and `configs.<B>` of a single home-manager configuration duplicate a
+  normalized target — the string resolved after the attribute-key default and any explicit
+  `target` override — the module evaluation SHALL be stopped by an assertion at eval time.
+  This is possible because every config of one module configuration rides on a single
+  module evaluation, and it is the natural extension of stopping at eval time a collision
+  that eval can see, stated for a single manifest by REQ-5c6b07da. It SHALL be an exception
+  to the general cross-config collision, which does not ride on a single evaluation and
+  which REQ-5c6b07da and REQ-fc1118b1 leave to last-writer-wins plus a foreign symlink
+  warning at engine runtime; that treatment SHALL remain unchanged for collisions across
+  separate entrypoints, machines or tools. Without this detection, the two configs would
+  take the same target from each other at every activation, making a flip-flop permanent,
+  the introduction of role separation itself being what breeds the collision.
+specification_ja: |
+  単一の home-manager config 内の `configs.<A>` と `configs.<B>` が正規化後 target
+  （属性キー既定値・明示 `target` 上書きを解決した後の文字列）を重複させた場合、
+  モジュール eval 時に assertion で停止しなければならない。1 つのモジュール config の
+  全 config が単一のモジュール eval に載るため静的検出が可能であり、eval で分かる衝突を
+  eval で止めること（同一 manifest 内について REQ-5c6b07da が定める）の自然な延長で
+  ある。これは単一の eval に載らない一般の cross-config 衝突（REQ-5c6b07da /
+  REQ-fc1118b1 が engine 実行時の後勝ち + foreign symlink warning に委ねるもの）に
+  対する例外とする。別 entrypoint・別マシン・別ツールに跨る衝突の扱いは変わらない。
+  検出しなければ、activation のたびに A と B が同じ target を交互に奪い合う
+  フリップフロップが恒常化する。役割分離の導入自体が衝突の温床になるためである。
+---
+# REQ-5923ac79: 単一 HM config 内の configs 間 target 衝突は eval 時 assertion で停止する
+
+## 仕様
+
+- 同一 HM config 内の `configs.<A>` と `configs.<B>` が**正規化後 target**（属性キー
+  既定値・明示 `target` 上書きを解決した後の文字列）を重複させた場合、**モジュール
+  eval 時に assertion で停止**する
+- 一般の cross-config 衝突（別 entrypoint・別マシン・別ツール）が「engine 実行時の
+  後勝ち + foreign symlink warning」であることは**不変**。HM の `configs` は全 config が
+  単一のモジュール eval に載るため例外的に静的検出が可能であり、「eval で分かる衝突は
+  eval で止める」の自然な延長として扱う
+- 検出しなければ、activation のたびに A と B が同じ target を交互に奪い合う（毎回
+  foreign symlink warning + 上書き）フリップフロップが恒常化する。役割分離の導入自体が
+  衝突の温床になるため、eval 停止が正しい
+
+> **本 item の出典は ADR-0035 §4 であり、`docs/spec.md` に対応記述は無い**。原文が
+> ADR-0035 に未追従のため #209 の分割では item 化されず、REQ-c6891aeb / REQ-5c6b07da /
+> REQ-fc1118b1 の注記に申し送りとして残っていた（epic #203 / issue #228 で回収）。
+>
+> **REQ-5c6b07da / REQ-fc1118b1 との整合**: 両 item は原文の「cross-config は eval では
+> 検出不可」という無条件の言い切りを**単一の eval に載らない場合**へ限定し、単一の eval に
+> 載る複数 config について「静的検出が可能であり本 item はそれを妨げない」までを規範と
+> して、実際に eval 停止する規範そのものは持たないと明記していた。本 item がその欠けて
+> いた規範を担う。したがって三者の関係は、REQ-5c6b07da が同一 manifest 内の衝突を eval で
+> 止めること・単一の eval に載らない cross-config を engine 実行時へ回すこと、
+> REQ-fc1118b1 が engine 実行時に検知して止める機構を持たないこと、本 item が単一の
+> eval に載る `configs` 間について eval 停止することを、それぞれ規定する形になる。
+> 検出層を「設定の誤りは評価時・実体の不整合は engine 実行時」に分ける原則そのものは
+> REQ-c5dfcae6 の担当。
+>
+> **他 item との担当分界**: 正規化後 target 文字列の同値判定と属性キー = target という
+> 識別の体系は REQ-cb77ea05 / REQ-b232ec98、`nput.configs` オプションの定義は
+> REQ-fc1c7ce6、`<name>` 次元と役割分離そのものは REQ-c6891aeb、foreign symlink warning
+> と単発の後勝ちは REQ-622787dc の担当。
+
+## 出典
+
+ADR-0035「HM モジュールに `nput.configs.<name>` を導入し複数 profile（役割分離）を
+可能にする」§4「configs 間の target 衝突は eval 時に検出して停止する」。
+
+`docs/spec.md` には対応記述が無いため、原文の写しは持たない（規範は frontmatter が正で、
+上の箇条書きは ADR 本文の要約）。同一 manifest 内の target 衝突を eval 時に検出すると
+定めたのは ADR-0024 §5、cross-config を engine 実行時の後勝ち + foreign symlink warning
+とするのは ADR-0015、未定義挙動を早期に弾く姿勢は ADR-0010 が定めている。

--- a/docs/requirements/20260803-c847d1af-hm-activation-per-config-kick.md
+++ b/docs/requirements/20260803-c847d1af-hm-activation-per-config-kick.md
@@ -58,9 +58,15 @@ specification_ja: |
 > REQ-1c1526b1、profileDir のキーは REQ-d5a2e289。世代が nput 自前 profile に積まれる
 > ことは REQ-1be4d678、module 経路で rollback を host へ一本化することは REQ-844ee375。
 > 辞書順・部分失敗続行・最後に集約という姿勢を standalone の `apply --all` について
-> 定めるのは REQ-4cbd9a0d で、本 item は同じ姿勢を HM activation の configs ループへ
-> 適用する（同一の規範を再掲するのではなく、適用先が別経路であるため独立した item に
-> なる）。
+> 定めるのは REQ-4cbd9a0d。本 item は同じ姿勢を HM activation の configs ループについて
+> 独立に規定する。文面は重なるが、適用先（CLI の `--all` か activation の configs ループか）
+> が別経路であり、片方の規範が他方を含意しないため、規範としては別立てになる。
+>
+> **本文箇条書き 2 番目に対応する規範文を持たない理由**: 「各起動は profileDir 単位の
+> flock・前世代 diff・保守的 stale 除去・`nix-env --set` が profile ごとに独立して走る」は、
+> 本 item の「config ごとに 1 回 engine を起動する」と、profileDir 単位の flock を定める
+> REQ-1c1526b1・profileDir のキーを定める REQ-d5a2e289・世代機構を定める REQ-1be4d678 の
+> 合成から従うため、規範として再掲しない。
 
 ## 出典
 

--- a/docs/requirements/20260803-c847d1af-hm-activation-per-config-kick.md
+++ b/docs/requirements/20260803-c847d1af-hm-activation-per-config-kick.md
@@ -1,0 +1,73 @@
+---
+id: "REQ-c847d1af-a437-46bb-bd64-42083810d034"
+type: requirement
+name: "HM の activation は configs を辞書順に走査して profile ごとに engine を起動し、部分失敗を最後に集約する"
+derives_from:
+  - "UC-d39c1994-f9a5-4860-80ba-f6e584adaf14"
+  - "UC-1c280dce-7c72-44c0-95ea-d06344f62a47"
+specification: |
+  The `home.activation.nput` of the home-manager module SHALL walk `nput.configs` and kick
+  the engine once per config, so that each profile takes its own engine invocation. The
+  order of execution SHALL be the lexical order of `<name>`, so that the run is
+  deterministic and its log reproducible. A failure of one profile SHALL NOT stop the
+  profiles that follow; every failure SHALL instead be aggregated and the activation SHALL
+  be failed at the end, as `apply --all` does on a partial failure. No CLI extension
+  passing several manifests to a single engine invocation SHALL be introduced, so that the
+  unit of atomicity — one profile — is kept at the CLI boundary as well. The contract of a
+  single kick is stated by REQ-8085f194, and the correspondence of one config to one
+  manifest and one profile by REQ-c6891aeb; neither is restated here. The posture of
+  continuing past a partial failure and aggregating it is common with the `apply --all` of
+  the standalone path stated by REQ-4cbd9a0d.
+specification_ja: |
+  home-manager モジュールの `home.activation.nput` は `nput.configs` を走査し、config
+  ごとに 1 回ずつ engine を起動しなければならない（profile ごとに独立した engine 起動を
+  取るため）。実行順は `<name>` の辞書順としなければならない（実行を決定的にしログを
+  再現可能にするため）。1 profile の失敗は後続の profile を止めてはならず、失敗は最後に
+  集約して activation を失敗させなければならない（`apply --all` の部分失敗と同じ姿勢）。
+  複数 manifest を 1 回の engine 起動へ渡す CLI 拡張を導入してはならない（atomic 性の
+  単位である profile を CLI 界面にも保つため）。1 起動あたりの契約は REQ-8085f194、
+  1 config が 1 manifest = 1 profile に対応することは REQ-c6891aeb の担当で、いずれも
+  本 item では規定しない。部分失敗で続行し集約する姿勢は、standalone 経路の
+  `apply --all` を定める REQ-4cbd9a0d と共通である。
+---
+# REQ-c847d1af: HM の activation は configs を辞書順に走査して profile ごとに engine を起動し、部分失敗を最後に集約する
+
+## 仕様
+
+- `home.activation.nput` は `configs` を走査し、**profile ごとに 1 回ずつ**
+  `nput apply --manifest <link-farm-N> <name>` を実行する
+- 各起動は profileDir 単位の flock・前世代 diff・保守的 stale 除去・`nix-env --set` が
+  **profile ごとに独立して**走る
+- 実行順は `<name>` の**辞書順**で決定的にする（Nix の attrset 走査順と一致・ログの
+  再現性のため）
+- **1 profile の失敗は後続 profile を止めず、最後に集約して activation を失敗させる**
+- 複数 manifest を 1 回の engine 起動に渡す CLI 拡張は行わない（atomic 性の単位 =
+  profile を CLI 界面にも保つ）
+
+> **本 item の出典は ADR-0035 §3 であり、`docs/spec.md` に対応記述は無い**。原文が
+> ADR-0035 に未追従で、複数 config があるとき activation が engine を何回 kick するかを
+> 述べていないため、#209 の分割では item 化されず REQ-8085f194 / REQ-c6891aeb の注記に
+> 申し送りとして残っていた（epic #203 / issue #228 で回収）。
+>
+> **他 item との担当分界**: 1 起動あたりの activation 契約（`entryAfter ["writeBoundary"]`・
+> `apply --manifest` でビルド済み link-farm を渡すこと・activation が `nix eval` /
+> `build` を行わないこと・engine error が非 0 終了で switch を止めること）は
+> REQ-8085f194。1 config = 1 profile = 1 manifest の対応と `<name>` 次元そのものは
+> REQ-c6891aeb。`nput.configs` オプションの定義は REQ-fc1c7ce6。`apply --manifest` と
+> 位置引数 `name` の直交・両立は REQ-dec58330 / REQ-c2d44626。profileDir 単位の flock は
+> REQ-1c1526b1、profileDir のキーは REQ-d5a2e289。世代が nput 自前 profile に積まれる
+> ことは REQ-1be4d678、module 経路で rollback を host へ一本化することは REQ-844ee375。
+> 辞書順・部分失敗続行・最後に集約という姿勢を standalone の `apply --all` について
+> 定めるのは REQ-4cbd9a0d で、本 item は同じ姿勢を HM activation の configs ループへ
+> 適用する（同一の規範を再掲するのではなく、適用先が別経路であるため独立した item に
+> なる）。
+
+## 出典
+
+ADR-0035「HM モジュールに `nput.configs.<name>` を導入し複数 profile（役割分離）を
+可能にする」§3「activation は profile ごとに独立した engine 起動」。
+
+`docs/spec.md` には対応記述が無いため、原文の写しは持たない（規範は frontmatter が正で、
+上の箇条書きは ADR 本文の要約）。部分失敗を集約する姿勢の淵源は ADR-0018、rollback を
+host へ一本化する点は ADR-0002 / ADR-0024、`apply --manifest` と位置引数の両立は
+ADR-0026 が定めている。

--- a/docs/requirements/20260803-c847d1af-hm-activation-per-config-kick.md
+++ b/docs/requirements/20260803-c847d1af-hm-activation-per-config-kick.md
@@ -62,7 +62,7 @@ specification_ja: |
 > 独立に規定する。文面は重なるが、適用先（CLI の `--all` か activation の configs ループか）
 > が別経路であり、片方の規範が他方を含意しないため、規範としては別立てになる。
 >
-> **本文箇条書き 2 番目に対応する規範文を持たない理由**: 「各起動は profileDir 単位の
+> **本文箇条書き第 2 項に対応する規範文を持たない理由**: 「各起動は profileDir 単位の
 > flock・前世代 diff・保守的 stale 除去・`nix-env --set` が profile ごとに独立して走る」は、
 > 本 item の「config ごとに 1 回 engine を起動する」と、profileDir 単位の flock を定める
 > REQ-1c1526b1・profileDir のキーを定める REQ-d5a2e289・世代機構を定める REQ-1be4d678 の

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -73,7 +73,6 @@ manifest をエンジンへ渡す。エンジンは `manifest.json` を唯一の
 - [REQ-b232ec98](requirements/20260802-b232ec98-normalize-manifest-defaults.md) — normalizeManifest が検査・デフォルト適用・marker 変換を行い mkManifest が derivation を組む
 - [REQ-6911eab6](requirements/20260802-6911eab6-path-safety-validation.md) — target / subpath のパス安全性を評価時に検査する
 - [REQ-5c6b07da](requirements/20260802-5c6b07da-target-collision-eval-detection.md) — target 衝突の検出経路を同一 manifest 内と cross-config で分ける
-- [REQ-5923ac79](requirements/20260803-5923ac79-hm-configs-target-collision-assertion.md) — 単一 HM config 内の configs 間 target 衝突は eval 時 assertion で停止する
 - [REQ-16faf428](requirements/20260802-16faf428-normalize-manifest-cross-field-checks.md) — 意図が矛盾する組み合わせをクロスフィールドチェックで評価時に拒否する
 - [REQ-1dcc9a33](requirements/20260802-1dcc9a33-marker-tag-discrimination.md) — marker は判別タグで識別し manifest.json には漏らさない
 
@@ -261,6 +260,7 @@ root は評価時にパスへ展開せず、マーカーが運ぶ kind をエン
 - [REQ-c1b3ca5f](requirements/20260802-c1b3ca5f-modules-are-engine-wiring.md) — 全モジュールと devShell は engine をキックするだけの配線とし、ネイティブ機構へ翻訳しない
 - [REQ-8085f194](requirements/20260802-8085f194-hm-activation-contract.md) — home-manager モジュールの engine kick 1 回は activation からビルド済み link-farm を渡し、失敗で switch を止める
 - [REQ-c847d1af](requirements/20260803-c847d1af-hm-activation-per-config-kick.md) — HM の activation は configs を辞書順に走査して profile ごとに engine を起動し、部分失敗を最後に集約する
+- [REQ-5923ac79](requirements/20260803-5923ac79-hm-configs-target-collision-assertion.md) — 単一 HM config 内の configs 間 target 衝突は eval 時 assertion で停止する
 - [REQ-a0bdf6db](requirements/20260802-a0bdf6db-devshell-wiring.md) — devShell は shellHook から engine を起動する配線で、シェル入室のたびに project mode で配置する
 
 ---

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -73,6 +73,7 @@ manifest をエンジンへ渡す。エンジンは `manifest.json` を唯一の
 - [REQ-b232ec98](requirements/20260802-b232ec98-normalize-manifest-defaults.md) — normalizeManifest が検査・デフォルト適用・marker 変換を行い mkManifest が derivation を組む
 - [REQ-6911eab6](requirements/20260802-6911eab6-path-safety-validation.md) — target / subpath のパス安全性を評価時に検査する
 - [REQ-5c6b07da](requirements/20260802-5c6b07da-target-collision-eval-detection.md) — target 衝突の検出経路を同一 manifest 内と cross-config で分ける
+- [REQ-5923ac79](requirements/20260803-5923ac79-hm-configs-target-collision-assertion.md) — 単一 HM config 内の configs 間 target 衝突は eval 時 assertion で停止する
 - [REQ-16faf428](requirements/20260802-16faf428-normalize-manifest-cross-field-checks.md) — 意図が矛盾する組み合わせをクロスフィールドチェックで評価時に拒否する
 - [REQ-1dcc9a33](requirements/20260802-1dcc9a33-marker-tag-discrimination.md) — marker は判別タグで識別し manifest.json には漏らさない
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -282,6 +282,7 @@ root は評価時にパスへ展開せず、マーカーが運ぶ kind をエン
 ## 依存関係
 
 - [REQ-b74a118a](requirements/20260802-b74a118a-engine-stdlib-only.md) — engine は第三者依存ゼロの stdlib-only とし内部層に閉じる
+- [REQ-2bd0d35f](requirements/20260803-2bd0d35f-modules-common-nixpkgs-lib-only.md) — modules/common.nix は nixpkgs.lib のみに依存する
 - [REQ-637599dc](requirements/20260802-637599dc-cli-dependency-policy.md) — CLI が持ち込む依存は許可した第三者ライブラリと pin した Go に限り、いずれも固定する
 
 ---

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -259,6 +259,7 @@ root は評価時にパスへ展開せず、マーカーが運ぶ kind をエン
 - [REQ-c2654ca5](requirements/20260802-c2654ca5-module-user-option.md) — NixOS / nix-darwin モジュールは配置先ユーザーを特定する user オプションを必須で取る
 - [REQ-c1b3ca5f](requirements/20260802-c1b3ca5f-modules-are-engine-wiring.md) — 全モジュールと devShell は engine をキックするだけの配線とし、ネイティブ機構へ翻訳しない
 - [REQ-8085f194](requirements/20260802-8085f194-hm-activation-contract.md) — home-manager モジュールの engine kick 1 回は activation からビルド済み link-farm を渡し、失敗で switch を止める
+- [REQ-c847d1af](requirements/20260803-c847d1af-hm-activation-per-config-kick.md) — HM の activation は configs を辞書順に走査して profile ごとに engine を起動し、部分失敗を最後に集約する
 - [REQ-a0bdf6db](requirements/20260802-a0bdf6db-devshell-wiring.md) — devShell は shellHook から engine を起動する配線で、シェル入室のたびに project mode で配置する
 
 ---


### PR DESCRIPTION
## 概要

#209 の分割作業で「段階 7（#213）で扱う」と申し送られたまま、段階 7 の PR #227 で回収されずに
落ちた規範を requirement item として回収する。`docs/spec.md` はすでに索引へ縮退しているため、
これらの規範は現在どの文書にも存在しない状態だった。

回収した 3 件:

- **REQ-c847d1af**（ADR-0035 §3）— HM の activation が `configs` を辞書順に走査して profile ごとに
  engine を起動し、部分失敗を後続で止めず最後に集約する規律。`docs/spec.md` に対応記述が無いため
  #209 の分割では item 化されなかった
- **REQ-5923ac79**（ADR-0035 §4）— 単一 HM config 内の `configs` 間 target 衝突を eval 時 assertion
  で停止する規範。REQ-5c6b07da / REQ-fc1118b1 が「単一の eval に載らない場合」へ限定し「静的検出を
  妨げない」までを規範としていた欠落分を担う
- **REQ-2bd0d35f** — 旧 `docs/spec.md` 依存関係表の `modules/common.nix` 行「nixpkgs.lib のみ」。
  粒度は層ごとに 1 item 立てる既存の形（lib は REQ-d85f0cef・engine は REQ-b74a118a）へ揃え、
  新規 item にした判断根拠を item 注記に残した

あわせて REQ-8085f194 / REQ-c6891aeb / REQ-5c6b07da / REQ-fc1118b1 の申し送り注記（「どの item も
規範として持たない」「別途扱う」）を、実体 item への担当分界の記述へ更新した。

`nix develop ./dev --command sara check` は broken reference / duplicate ID 0 件で通る
（warning 12 件はいずれも本 PR 以前から存在する orphan）。

## 関連 issue

Closes #228
Refs #203

## docs / ADR 影響

- `docs/requirements/` — 新規 item 3 件を追加、既存 item 4 件の注記・specification を更新
- `docs/spec.md` — 縮退規約に従い、新規 item 3 件のリンクを対応する節のリンク集へ 1 行ずつ追加
  （散文の追記なし）
- `docs/adr/0035-hm-multi-profile-configs.md` — frontmatter の `justifies` へ REQ-c847d1af /
  REQ-5923ac79 を追加。本文は変更していない。REQ-2bd0d35f は原文の当該行が ADR 参照を伴わず、
  `modules/common.nix` の依存制約そのものを決定した ADR も無いため `justifies` を張っていない
- 新規 ADR の追加は無い。本 PR は既存 ADR の決定を requirement item へ落とす作業であり、方針転換や
  trade-off の判断を含まない
