### PR TITLE
docs(adr): ADR-0030 の ADR-0027 への関係を references から revises へ昇格する

### DIFF
--- a/docs/adr/0027-flake-check-ci-matrix-and-triggers.md
+++ b/docs/adr/0027-flake-check-ci-matrix-and-triggers.md
@@ -18,10 +18,12 @@ references:
 - 関連: ADR-0012, ADR-0011（cgo 未使用 / stdlib-only）, ADR-0006
 - 参照: PR #40, `~/src/github.com/yasunori0418/cryoflow` の CI 構成
 
-> **2026-06-21 改訂注記（ADR-0030）**: §2 のトリガ段 `paths` フィルタ記述が対象。
-> 「docs-only で nix を実走させない」最適化意図と §1 / §3 の決定は不変で、実現手段だけが
-> trigger-paths から変更検出 action + `if:` スキップへ変わった（→ ADR-0030 §2）。詳細は §2 の
-> インライン注記。
+> **2026-06-21 改訂注記（ADR-0030）**: 本 ADR §2 のトリガ段 `paths` フィルタ記述と、それに伴う
+> 「docs-only PR は `workflow_dispatch` で回す」回避策が対象。「docs-only で nix を実走させない」
+> 最適化意図と §1 / §3 の決定は不変で、実現手段だけが trigger-paths から変更検出 action + `if:`
+> スキップへ変わった（→ ADR-0030 §2）。`paths` 撤去で docs-only PR でも workflow は起動するため
+> 回避策は不要になる（`workflow_dispatch` トリガ自体は手動再実行用として存続）。詳細は
+> 本 ADR §2 のインライン注記。
 
 ## 背景
 

--- a/docs/adr/0027-flake-check-ci-matrix-and-triggers.md
+++ b/docs/adr/0027-flake-check-ci-matrix-and-triggers.md
@@ -18,6 +18,11 @@ references:
 - 関連: ADR-0012, ADR-0011（cgo 未使用 / stdlib-only）, ADR-0006
 - 参照: PR #40, `~/src/github.com/yasunori0418/cryoflow` の CI 構成
 
+> **2026-06-21 改訂注記（ADR-0030）**: §2 のトリガ段 `paths` フィルタ記述が対象。
+> 「docs-only で nix を実走させない」最適化意図と §1 / §3 の決定は不変で、実現手段だけが
+> trigger-paths から変更検出 action + `if:` スキップへ変わった（→ ADR-0030 §2）。詳細は §2 の
+> インライン注記。
+
 ## 背景
 
 ADR-0012 §3 は「lib（nix-unit / namaka）と engine Go を `nix flake check` に集約し PR で常時実行する」と決めたが、

--- a/docs/adr/0030-required-status-checks-for-merge.md
+++ b/docs/adr/0030-required-status-checks-for-merge.md
@@ -18,7 +18,7 @@ references:
 - ステータス: 採用（public 化を前提とする）
 - 日付: 2026-06-21
 - 関連: ADR-0027（flake check CI マトリクス / トリガ・本 ADR が §2 を補足訂正）, ADR-0012（CI とテスト実行）, ADR-0028（cachix push）
-- 改訂対象: ADR-0027 §2 のトリガ段 `paths` フィルタ記述を補足訂正
+- 改訂対象: ADR-0027 §2 のトリガ段 `paths` フィルタ記述と docs-only の `workflow_dispatch` 回避策を補足訂正
 - 参照: 現行 `.github/workflows/test.yml`, `.github/actions/setup-nix`
 
 ## 背景

--- a/docs/adr/0030-required-status-checks-for-merge.md
+++ b/docs/adr/0030-required-status-checks-for-merge.md
@@ -7,9 +7,10 @@ status_note: "public 化を前提とする"
 origin: "参照: 現行 `.github/workflows/test.yml`, `.github/actions/setup-nix`"
 justifies:
   - "INF-8b97573f-d4d6-4abf-85e2-d859afbd96c6"
+revises:
+  - "ADR-0027"
 references:
   - "ADR-0012"
-  - "ADR-0027"
   - "ADR-0028"
 ---
 # ADR-0030: テスト成功を main マージの必須条件にする（ruleset で required status check）
@@ -17,6 +18,7 @@ references:
 - ステータス: 採用（public 化を前提とする）
 - 日付: 2026-06-21
 - 関連: ADR-0027（flake check CI マトリクス / トリガ・本 ADR が §2 を補足訂正）, ADR-0012（CI とテスト実行）, ADR-0028（cachix push）
+- 改訂対象: ADR-0027 §2 のトリガ段 `paths` フィルタ記述を補足訂正
 - 参照: 現行 `.github/workflows/test.yml`, `.github/actions/setup-nix`
 
 ## 背景


### PR DESCRIPTION
## 概要

ADR-0030 は ADR-0027 §2 を実質的に補足訂正しているが、本文に `改訂対象:` 行が無かったため
#208 のマッピング規則（`改訂対象:` の ADR → `revises`）に従って frontmatter が `references`
止まりになっていた。#215 は「既存の本文メタデータ行はそのまま残す」というスコープ制約から
本文追記を避け、昇格の要否を留保していた。2026-08-03 の grilling で「昇格する」と確定した
判断をここで実施する。

変更は関係の表現のみで、両 ADR の決定内容には触れていない。

- ADR-0030 本文のメタデータ行へ `改訂対象:` 行を新設（`関連:` の後・README の行順どおり。
  既存の `関連:` 行は変更せず、本文からの削除行はゼロ）
- ADR-0030 の frontmatter で `references` から `ADR-0027` を除き `revises` へ移動
  （「revises 優先・同一ペアに二重辺を張らない」規則。フィールド順は justifies → revises →
  references）
- ADR-0027 へ README 書式の改訂注記 blockquote を新設（メタデータ行と `## 背景` の間。日付は
  改訂した側 ADR-0030 の日付 2026-06-21）。所在案内の短文とし、詳細は §2 の既存インライン注記が
  持つ（インライン注記は残置）

レビュー（3 巡・閾値 want で収束）で以下 2 点を追加修正した。

- 改訂の対象範囲を、ADR-0027 §2 の `paths` フィルタ記述だけでなく同項の「docs-only PR は
  `workflow_dispatch` で回す」回避策まで含めるよう明記（`workflow_dispatch` トリガ自体は手動
  再実行用として存続する旨を添え、トリガ削除と誤読されないようにした）
- ADR-0030 の `改訂対象:` 行 / ADR-0030 §2 本文 / ADR-0027 の改訂注記の 3 箇所で改訂範囲を一致させた

`docs/adr/README.md` の検算リストは変更不要であることを確認済み（追記条件は「既存 ADR の
`関連:` に後発 ADR を追記したとき」で、本 PR は ADR-0027 の `関連:` 行を変更していない）。

`nix develop ./dev --command sara check` は broken reference / duplicate ID / circular reference
いずれも 0 件で通り（warning 12 件はすべて ADR / requirement の Orphan item で設計どおり）、
`sara query ADR-0027` の `Is revised by` に ADR-0030 が出ることも確認した。

stacked PR の一段で、base は `sara-229-spec-style-unify`。frontmatter 自体が #215 由来で stack 上に
しか存在しないため。

## 関連 issue

Closes #230
Refs #203

## docs / ADR 影響

- ADR: 既存 2 本（ADR-0030 / ADR-0027）の関係表現のみを本文の実態へ揃える変更で、新規 ADR の追加は
  なし。両 ADR の決定内容・ステータス行は変更していない
- concept / design / spec: 変更なし。CI の実現手段に関する記述は ADR-0027 §2 の既存インライン注記と
  `docs/infrastructure/` の item が既に持っており、本 PR で内容は動かしていない
