### PR TITLE
docs(model): quality / test_plan 型を新設し infrastructure を再定義する

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,15 +24,23 @@ item を新設し、概要文書にはリンクを 1 行足すに留める。
 | `docs/solution/` | solution | `SOL` | なし（根）|
 | `docs/use-cases/` | use_case | `UC` | solution |
 | `docs/requirements/` | requirement | `REQ` | use_case |
-| `docs/design/` | design | `DSG` | requirement |
-| `docs/infrastructure/` | infrastructure | `INF` | なし（根）|
+| `docs/design/` | design | `DSG` | requirement / test_plan |
+| `docs/quality/` | quality | `QA` | solution |
+| `docs/test-plan/` | test_plan | `TP` | solution |
+| `docs/infrastructure/` | infrastructure | `INF` | quality / design |
+| `docs/risks/` | risk | `RISK` | requirement / design |
+| `docs/test/<対象>/` | test_condition | `TC` | risk |
+| `docs/test/<対象>/` | test_case | `CASE` | test_condition |
+| `docs/test/<対象>/` | defect | `D` | test_case |
 | `docs/adr/` | adr | `ADR` | なし（分離型）|
 
-型・関係・フィールドの定義は `docs/model.yaml` が持つ。
+型・関係・フィールドの定義は `docs/model.yaml` が持つ。親を持たない根は **solution と adr のみ**で、
+他の型は upstream relation を 1 本以上張る（張り忘れは `sara check` の orphan warning で出る）。
 
-**risk（`RISK`）とテスト系（`TC` / `CASE` / `D`）は model.yaml に定義済みだが、item も
-ディレクトリもまだ無い。** テスト工程に着手する段で `docs/risks/` と `docs/test/<対象>/` を
-作る。`<対象>` の粒度（機能単位か requirement 単位か）はその時点で決めて本節へ追記する。
+**quality（`QA`）・test_plan（`TP`）・risk（`RISK`）・テスト系（`TC` / `CASE` / `D`）は
+model.yaml に定義済みだが、item もディレクトリもまだ無い。** quality / test_plan は既存 item の
+移設で作られる。テスト系は工程に着手する段で `docs/risks/` と `docs/test/<対象>/` を作り、
+`<対象>` の粒度（機能単位か requirement 単位か）はその時点で決めて本節へ追記する。
 risk を `requirement` と `design` のどちらに張るかの使い分けは `docs/agents/sara-graph.md`。
 
 ### ID 規約（UUIDv4 二層構成）

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,7 @@ item を新設し、概要文書にはリンクを 1 行足すに留める。
 
 型・関係・フィールドの定義は `docs/model.yaml` が持つ。親を持たない根は **solution と adr のみ**で、
 他の型は upstream relation を 1 本以上張る（張り忘れは `sara check` の orphan warning で出る）。
+例外は defect で、upstream relation を張る手段が無く必ず orphan warning になる（→ model.yaml 冒頭）。
 
 **quality（`QA`）・test_plan（`TP`）・risk（`RISK`）・テスト系（`TC` / `CASE` / `D`）は
 model.yaml に定義済みだが、item もディレクトリもまだ無い。** quality / test_plan は既存 item の
@@ -56,9 +57,10 @@ risk を `requirement` と `design` のどちらに張るかの使い分けは `
 - **ADR のみ連番を維持する**。既存 ADR の相互参照・`docs/adr/README.md` の運用・Issue 言及を
   壊さないため。`sara-id ADR` は採番せず exit 2 で落ちる仕様なので、`docs/adr/` の最大値 + 1 を
   手で採る
-- requirement の `specification` フィールドは **英語で書く**。sara が RFC2119 キーワード
-  （MUST / SHALL / SHOULD …）の存在をハードコードで検証するため。対になる日本語の規範文は
-  `specification_ja` に併記する
+- `specification` フィールドを持つ型（requirement / quality / test_plan）は**英語で書く**。
+  sara が RFC2119 キーワード（MUST / SHALL / SHOULD …）の存在をハードコードで検証するため。
+  対になる日本語の規範文は `specification_ja` に併記する。ただし検証が効くのは requirement
+  だけ（型名がハードコードされている）で、quality / test_plan の様式はレビューで守る
 
 ### item を辿る（`sara query`）
 

--- a/dev/flake.nix
+++ b/dev/flake.nix
@@ -120,6 +120,8 @@
                 requirement | req) prefix=REQ ;;
                 design | dsg) prefix=DSG ;;
                 infrastructure | inf) prefix=INF ;;
+                quality | qa) prefix=QA ;;
+                test_plan | test-plan | tp) prefix=TP ;;
                 adr) prefix=ADR ;;
                 risk) prefix=RISK ;;
                 test_condition | test-condition | tc) prefix=TC ;;

--- a/docs/model.yaml
+++ b/docs/model.yaml
@@ -24,8 +24,9 @@
 #
 # 例外は defect で、allowed_targets が空のため upstream relation を張る手段が無い
 # （親側の test_case が downstream の reveals で接続する）。defect item は作った時点で
-# 必ず orphan warning になるため、テスト工程に着手する段で reveals の逆向き upstream を
-# 定義するかを再検討する（現時点で defect item は 0 件）。
+# 必ず orphan warning になるため、テスト工程に着手する段で is_revealed_by（定義済みの
+# upstream relation）を defect の allowed_targets へ足すかを再検討する
+# （現時点で defect item は 0 件）。
 #
 # ## 組み込みから落とした型
 #

--- a/docs/model.yaml
+++ b/docs/model.yaml
@@ -120,12 +120,86 @@ item_types:
       - requirement
     fields: []
     allowed_targets:
+      # satisfies の対象に test_plan を含めるのは、テストハーネスの実装形を表す design が
+      # requirement ではなくテスト計画を満たす実体だから（→ #237 §3）。専用 relation の
+      # 新設案は「satisfies と意味が重なる関係を 2 本持つ」ことになるため採らず、design を
+      # orphan のまま容認する案も epic #203 の完了条件（warning 0）と両立しないため採らない。
       - relation: satisfies
         targets:
           - requirement
+          - test_plan
       - relation: depends_on
         targets:
           - design
+
+  # ---- 品質とテスト計画の系統（solution 直下）----
+
+  # 品質方針・規約・プロセス横断のガバナンス文書。docs/quality/。
+  # テストプロセスの外にある関心事なので test_plan とは別型に分ける（1 型へ混ぜると
+  # infrastructure が抱えていた「品質系と基盤系の混在」を新型内で再発させる → #237）。
+  - id: quality
+    display_name: Quality
+    prefix: QA
+    id_format: '{prefix}-{uuid}'
+    parent_types:
+      - solution
+    fields:
+      # requirement の specification / specification_ja と同じ様式で書く。ただし sara の
+      # RFC2119 キーワード検証は requirement 型にハードコードされており（metadata.rs）、
+      # quality / test_plan の specification には効かない。英語の規範文で書く規約は
+      # 機械検証されないのでレビューで守る。
+      - name: specification
+        display_name: Specification
+        field_type: text
+        required: true
+        placeholder: The project SHALL <describe the quality policy>.
+      - name: specification_ja
+        display_name: Specification (ja)
+        field_type: text
+        required: true
+        placeholder: nput は <品質方針> を満たさなければならない。
+    allowed_targets:
+      - relation: derives_from
+        targets:
+          - solution
+      - relation: depends_on
+        targets:
+          - quality
+
+  # ISTQB のテスト計画活動の成果物。docs/test-plan/。テストスコープ・スコープ外宣言・
+  # テストレベル・テストアプローチ・テスト容易性の要求を収容する。
+  # 既存のテスト系 4 型（risk / test_condition / test_case / defect）はテスト分析以降に
+  # 対応しており、テスト計画に対応する型が空いていた（→ #237）。
+  #
+  # risk の parent_types には test_plan を追加しない。risk の親は「リスクが何に対して
+  # 発生しているか」を示す構造であり、requirement / design が正しい対応先であるため。
+  # テスト計画がどの risk を扱うかは下流の test_condition → mitigates → risk で追跡できる。
+  # テスト工程が動いてから不足が判明した場合に peer relation の追加を再検討する。
+  - id: test_plan
+    display_name: Test Plan
+    prefix: TP
+    id_format: '{prefix}-{uuid}'
+    parent_types:
+      - solution
+    fields:
+      # RFC2119 検証が効かない点は quality の同フィールドのコメントを参照。
+      - name: specification
+        display_name: Specification
+        field_type: text
+        required: true
+        placeholder: The test process SHALL <describe the test planning decision>.
+      - name: specification_ja
+        display_name: Specification (ja)
+        field_type: text
+        required: true
+        placeholder: テストプロセスは <テスト計画上の決定> を満たさなければならない。
+    allowed_targets:
+      - relation: derives_from
+        targets:
+          - solution
+      - relation: depends_on
+        targets:
+          - test_plan
 
   # ---- 独立した根 ----
 
@@ -156,7 +230,8 @@ item_types:
           - infrastructure
 
   # 意思決定の記録。docs/adr/。仕様ツリーから分離した独立型で、justifies で
-  # requirement / design / infrastructure へ任意に接続する（接続は必須ではない）。
+  # requirement / design / infrastructure / quality / test_plan へ任意に接続する
+  # （接続は必須ではない）。
   - id: adr
     display_name: Architecture Decision Record
     prefix: ADR
@@ -204,6 +279,8 @@ item_types:
           - requirement
           - design
           - infrastructure
+          - quality
+          - test_plan
       # ADR ヘッダの「改訂対象:」。詳細は下の relations 節のコメントを参照。
       - relation: revises
         targets:

--- a/docs/model.yaml
+++ b/docs/model.yaml
@@ -10,14 +10,22 @@
 #
 # ## 型構成（12 型）
 #
-# 仕様の系統: solution → use_case → requirement → design
-# 品質とテスト計画: solution → quality / test_plan（design は test_plan も satisfy する）
-# 技術基盤: quality / design ← infrastructure
-# リスクとテスト: requirement / design ← risk → test_condition → test_case → defect
-# 独立した根: adr（justifies で仕様・基盤・品質の各型へ任意に接続する）
+# 矢印は全て親 → 子（上流 → 下流）で書く。
 #
-# 親を持たない根は solution と adr のみ。他の全型は upstream relation を 1 本以上持ち、
-# 「接続漏れ = orphan warning」が全型で成立する（→ #203・#237）。
+# 仕様の系統:       solution → use_case → requirement → design
+# 品質とテスト計画: solution → quality、solution → test_plan → design
+# 技術基盤:         quality → infrastructure、design → infrastructure
+# リスクとテスト:   requirement / design → risk → test_condition → test_case → defect
+# 独立した根:       adr（justifies で requirement / design / infrastructure / quality /
+#                   test_plan へ任意に接続する）
+#
+# 親を持たない根は solution と adr のみ。他の型は upstream relation を 1 本以上持ち、
+# 「接続漏れ = orphan warning」が成立する（→ #203・#237）。
+#
+# 例外は defect で、allowed_targets が空のため upstream relation を張る手段が無い
+# （親側の test_case が downstream の reveals で接続する）。defect item は作った時点で
+# 必ず orphan warning になるため、テスト工程に着手する段で reveals の逆向き upstream を
+# 定義するかを再検討する（現時点で defect item は 0 件）。
 #
 # ## 組み込みから落とした型
 #
@@ -129,6 +137,7 @@ item_types:
     id_format: '{prefix}-{uuid}'
     parent_types:
       - requirement
+      - test_plan
     fields: []
     allowed_targets:
       # satisfies の対象に test_plan を含めるのは、テストハーネスの実装形を表す design が

--- a/docs/model.yaml
+++ b/docs/model.yaml
@@ -8,6 +8,17 @@
 # 設計の出典: epic GitHub Issue #203（grilling 2026-07-31 / 2026-08-01 で確定）、
 # ADR-0048。
 #
+# ## 型構成（12 型）
+#
+# 仕様の系統: solution → use_case → requirement → design
+# 品質とテスト計画: solution → quality / test_plan（design は test_plan も satisfy する）
+# 技術基盤: quality / design ← infrastructure
+# リスクとテスト: requirement / design ← risk → test_condition → test_case → defect
+# 独立した根: adr（justifies で仕様・基盤・品質の各型へ任意に接続する）
+#
+# 親を持たない根は solution と adr のみ。他の全型は upstream relation を 1 本以上持ち、
+# 「接続漏れ = orphan warning」が全型で成立する（→ #203・#237）。
+#
 # ## 組み込みから落とした型
 #
 # hardware_requirement / hardware_detailed_design / scenario / system_architecture は
@@ -201,15 +212,25 @@ item_types:
         targets:
           - test_plan
 
-  # ---- 独立した根 ----
+  # ---- 技術基盤 ----
 
-  # CI・リリース・開発環境など、プロダクト仕様の系統に載らない基盤。docs/infrastructure/。
-  # requirement 系統の子ではないため親を持たない根として置く。
+  # プロダクトを開発・提供・稼働させる技術基盤。docs/infrastructure/。CI/CD・リリース・
+  # 開発環境に加え、配信・ホスティング・クラウド（Cloudflare / AWS / Vercel 等）を含む。
+  # web アプリケーションを想定範囲に含めた横展開を見据えた定義（→ #237 §5）。
+  #
+  # dev 基盤は quality を、runtime 基盤は design を satisfy する。この 2 経路で
+  # solution ツリーへ接続できるようになったため根から外した（root は solution と adr のみ）。
+  #
+  # 型名・prefix は変更しない。INF-<UUID> は ADR の justifies から参照されており、
+  # 改名は ID 変更 = 全参照の張り替えを伴う。違和感の主因だった品質系との混在は
+  # quality 型の分離で解消した。
   - id: infrastructure
     display_name: Infrastructure
     prefix: INF
     id_format: '{prefix}-{uuid}'
-    parent_types: []
+    parent_types:
+      - quality
+      - design
     fields:
       # `docs/dev/definition-of-done.md` の項目 ID（DOD-01 …）への対応。DoD は sara の
       # item ではないため relation にはせず text フィールドへ逃がす（→ #212）。
@@ -225,9 +246,15 @@ item_types:
         field_type: !list text
         required: false
     allowed_targets:
+      - relation: satisfies
+        targets:
+          - quality
+          - design
       - relation: depends_on
         targets:
           - infrastructure
+
+  # ---- 独立した根 ----
 
   # 意思決定の記録。docs/adr/。仕様ツリーから分離した独立型で、justifies で
   # requirement / design / infrastructure / quality / test_plan へ任意に接続する


### PR DESCRIPTION
## 概要

シフトレフトで仕様と品質を管理するドキュメント構造へ移行するための型基盤を整える。

現状の orphan warning 12 件は「張り忘れ」ではなく**受け皿となる型が無い**ことに起因する。
テスト計画・品質方針にあたる文書が requirement として置かれ、親となる use_case を持てずに
宙に浮いている。型を 2 つ新設し infrastructure を再定義することで、root を solution と adr の
みに絞り、**「接続漏れ = orphan warning」という不変条件を全型で成立させる**。

- **`quality`（QA・`docs/quality/`・親 solution）を新設** — 品質方針・規約・プロセス横断の
  ガバナンス文書を収容する
- **`test_plan`（TP・`docs/test-plan/`・親 solution）を新設** — ISTQB のテスト計画活動の成果物
  （テストスコープ・スコープ外宣言・テストレベル・テストアプローチ・テスト容易性）を収容する。
  既存のテスト系 4 型はテスト分析以降に対応しており、テスト計画に対応する型が空いていた
- **`design` の `satisfies` 対象へ `test_plan` を追加** — テストハーネスの実装形 design が
  テスト計画を satisfy できないと、移設時に design 側が orphan 化して epic #203 の完了条件
  （warning 0）が成立しない
- **`infrastructure` を再定義** — 定義を「開発・提供・稼働させる技術基盤」へ拡張し（CI/CD に
  加えて配信・ホスティング・クラウドを含む）、`satisfies`（dev 基盤 → quality / runtime 基盤 →
  design）を与えて root から外す。型名・prefix は据え置き（`INF-<UUID>` は ADR の justifies から
  参照されており改名は全参照の張り替えを伴う）
- **`adr` の `justifies` 対象へ 2 新型を追加**、**`sara-id` の prefix マップを拡張**

品質方針とテスト計画を 1 型へ混ぜない理由は、infrastructure が抱えていた「品質系と基盤系の
混在」を新型内で再発させるため。`risk` の `parent_types` に `test_plan` を追加しない判断
（risk の親は「リスクが何に対して発生しているか」を示す構造）とあわせて、model.yaml の
コメントへ記録した。

検証:

- `nix develop ./dev --command sara check` → **warning 18 件で pass**。内訳は既存 12 件 +
  本 PR で root から外れた infrastructure 6 件の orphan 化で、issue #237 の期待値どおり。
  これらの解消は後続 issue（#238〜#243）の担当で、本 PR では直しに行かない
- `nix flake check ./dev` → all checks passed（`dev/tests/sara-id.sh` の 25 ケースを含む）
- `sara-id quality` / `sara-id test_plan` / `sara-id qa` / `sara-id tp` が `QA-` / `TP-` を
  返すことを実行確認

## 関連 issue

Closes #237
Refs #203（epic: sara によるドキュメントのグラフ構造化）

レビューで境界外として申し送られた指摘は sub-issue へ切り出した:

- #248 — ADR-0048 の型定義表を 12 型構成へ改訂する
- #249 — 索引文書 3 本（`docs/design.md` / `docs/agents/domain.md` / `docs/agents/sara-graph.md`）を 12 型構成へ追従させる
- #250 — `sara-id` の prefix マップに契約テストを足す

## docs / ADR 影響

**ADR の追加はなし。docs は更新済み（ただし一部を後続 issue へ送っている）。**

- **更新済み**: `docs/model.yaml`（型定義の SSOT・冒頭の型構成コメント）、`CLAUDE.md`
  （ディレクトリ表を 12 型構成へ・`specification` の英語規約を 3 型へ拡張）
- **未更新（#249 で対応）**: `docs/design.md` の ADR 接続先が旧構成のまま。`docs/agents/` 配下の
  索引 2 本も同様。いずれも #237 の作業境界（`docs/model.yaml` / `dev/flake.nix` / `CLAUDE.md`）外
- **未更新（#248 で対応）**: ADR-0048 §2 の型定義表が「10 型」「infrastructure は根」のまま
  陳腐化した。`docs/adr/README.md` の「同じ変更の中で旧 ADR 側へ改訂注記を追記する」規約に
  照らすと本来この PR で対応すべきものだが、`docs/adr/` が作業境界外のため独立 issue とした。
  **完成の定義 DOD-03 / DOD-04 はこの 2 issue の完了をもって満たされる**

なお `docs/spec.md` / `docs/concept.md` への影響はなし（型定義の追加であり、要求・コンセプトの
内容は変わらない）。#203 本文の mermaid モデル図の 12 型構成への差し替えは、GitHub への書き込み
のため本 PR のスコープ外（マージ後にオーケストレータが実施）。
