### PR TITLE
docs: 索引文書 3 本を 12 型構成へ追従させる

### DIFF
--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -27,10 +27,10 @@ don't skim it as an index.
 | `docs/solution/` | solution | `SOL` | What nput is and what it solves |
 | `docs/use-cases/` | use_case | `UC` | How it gets used |
 | `docs/requirements/` | requirement | `REQ` | What must hold of the product (normative, RFC2119) |
-| `docs/design/` | design | `DSG` | How a requirement is realised |
+| `docs/design/` | design | `DSG` | How a requirement or a test_plan is realised |
 | `docs/quality/` | quality | `QA` | Norms binding the development process (normative, RFC2119) |
 | `docs/test-plan/` | test_plan | `TP` | Scope, levels and approach of testing (normative, RFC2119) |
-| `docs/infrastructure/` | infrastructure | `INF` | CI, release, docs site, merge gate |
+| `docs/infrastructure/` | infrastructure | `INF` | The machinery upholding a quality or a design (CI, release, docs site, merge gate) |
 | `docs/risks/` | risk | `RISK` | What threatens a requirement or a design — **not started** |
 | `docs/test/<subject>/` | test_condition | `TC` | What a risk needs covered — **not started** |
 | `docs/test/<subject>/` | test_case | `CASE` | A concrete case under a condition — **not started** |
@@ -39,9 +39,11 @@ don't skim it as an index.
 
 The four types marked **not started** are defined in `docs/model.yaml` but have neither items nor
 directories yet; they get created when the test process is taken up, at which point the granularity
-of `<subject>` (per feature or per requirement) is decided. Note also that `defect` has no way to
-declare an upstream relation, so a `defect` item always raises an orphan warning — see the header
-of `docs/model.yaml`.
+of `<subject>` (per feature or per requirement) is decided.
+
+Every type but `solution` and `adr` hangs off at least one upstream relation, so a missing link
+shows up as an orphan warning. `defect` is the exception: it has no way to declare one, and so
+always raises the warning — see the header of `docs/model.yaml`.
 
 Start from the overview that matches the topic (spec for behaviour, design for structure, concept
 for positioning), follow its link into the item, then traverse relations for the surrounding context.
@@ -55,7 +57,8 @@ Full conventions — ID format, placement rules, which type owns what — are in
 
 ```bash
 sara query <full-id> -u      # upstream: requirement -> use_case -> solution
-sara query <full-id> -d      # downstream: requirement -> design (risk / test not started yet)
+sara query <full-id> -d      # downstream: requirement / test_plan -> design, quality -> infrastructure
+                             #             (risk and below not started yet)
 sara check                   # validate the whole graph (broken refs / duplicate IDs / cycles)
 sara report coverage         # coverage
 sara report matrix           # traceability matrix

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -30,7 +30,7 @@ don't skim it as an index.
 | `docs/design/` | design | `DSG` | How a requirement or a test_plan is realised |
 | `docs/quality/` | quality | `QA` | Norms binding the development process (normative, RFC2119) |
 | `docs/test-plan/` | test_plan | `TP` | Scope, levels and approach of testing (normative, RFC2119) |
-| `docs/infrastructure/` | infrastructure | `INF` | The machinery upholding a quality or a design (CI, release, docs site, merge gate) |
+| `docs/infrastructure/` | infrastructure | `INF` | The machinery upholding a quality — CI, release, docs site, merge gate |
 | `docs/risks/` | risk | `RISK` | What threatens a requirement or a design — **not started** |
 | `docs/test/<subject>/` | test_condition | `TC` | What a risk needs covered — **not started** |
 | `docs/test/<subject>/` | test_case | `CASE` | A concrete case under a condition — **not started** |
@@ -40,6 +40,10 @@ don't skim it as an index.
 The four types marked **not started** are defined in `docs/model.yaml` but have neither items nor
 directories yet; they get created when the test process is taken up, at which point the granularity
 of `<subject>` (per feature or per requirement) is decided.
+
+The Holds column above describes each type as the graph currently stands, not the full set of
+parents `docs/model.yaml` permits: `infrastructure` may hang off a `design` as well as a
+`quality`, though every `INF` item satisfies a `QA` today.
 
 Every type but `solution` and `adr` hangs off at least one upstream relation, so a missing link
 shows up as an orphan warning. `defect` is the exception: it has no way to declare one, and so
@@ -56,7 +60,8 @@ Full conventions — ID format, placement rules, which type owns what — are in
 `sara` lives in the dev shell, so prefix commands with `nix develop ./dev --command`.
 
 ```bash
-sara query <full-id> -u      # upstream: requirement -> use_case -> solution
+sara query <full-id> -u      # upstream: requirement -> use_case -> solution,
+                             #           quality / test_plan -> solution
 sara query <full-id> -d      # downstream: requirement / test_plan -> design, quality -> infrastructure
                              #             (risk and below not started yet)
 sara check                   # validate the whole graph (broken refs / duplicate IDs / cycles)

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -26,14 +26,28 @@ don't skim it as an index.
 |---|---|---|---|
 | `docs/solution/` | solution | `SOL` | What nput is and what it solves |
 | `docs/use-cases/` | use_case | `UC` | How it gets used |
-| `docs/requirements/` | requirement | `REQ` | What must hold (normative, RFC2119) |
+| `docs/requirements/` | requirement | `REQ` | What must hold of the product (normative, RFC2119) |
 | `docs/design/` | design | `DSG` | How a requirement is realised |
+| `docs/quality/` | quality | `QA` | Norms binding the development process (normative, RFC2119) |
+| `docs/test-plan/` | test_plan | `TP` | Scope, levels and approach of testing (normative, RFC2119) |
 | `docs/infrastructure/` | infrastructure | `INF` | CI, release, docs site, merge gate |
+| `docs/risks/` | risk | `RISK` | What threatens a requirement or a design — **not started** |
+| `docs/test/<subject>/` | test_condition | `TC` | What a risk needs covered — **not started** |
+| `docs/test/<subject>/` | test_case | `CASE` | A concrete case under a condition — **not started** |
+| `docs/test/<subject>/` | defect | `D` | What a case revealed — **not started** |
 | `docs/adr/` | adr | `ADR` | Decisions, linked by `justifies` |
+
+The four types marked **not started** are defined in `docs/model.yaml` but have neither items nor
+directories yet; they get created when the test process is taken up, at which point the granularity
+of `<subject>` (per feature or per requirement) is decided. Note also that `defect` has no way to
+declare an upstream relation, so a `defect` item always raises an orphan warning — see the header
+of `docs/model.yaml`.
 
 Start from the overview that matches the topic (spec for behaviour, design for structure, concept
 for positioning), follow its link into the item, then traverse relations for the surrounding context.
-Full conventions — ID format, placement rules, which type owns what — are in `CLAUDE.md`.
+Full conventions — ID format, placement rules, which type owns what — are in `CLAUDE.md`. Which of
+`requirement` / `quality` / `test_plan` a norm belongs to, and whether a risk attaches to a
+`requirement` or a `design`, are decided by `docs/agents/sara-graph.md`.
 
 ## Traverse with `sara query`
 
@@ -74,7 +88,10 @@ This repo (single-context, with the item graph under `docs/`):
     ├── model.yaml                     ← the graph's type definitions
     ├── solution/  use-cases/          ← SOL / UC
     ├── requirements/  design/         ← REQ / DSG
+    ├── quality/  test-plan/           ← QA / TP
     ├── infrastructure/                ← INF
+    ├── risks/                         ← RISK (not started; no directory yet)
+    ├── test/<subject>/                ← TC / CASE / D (not started; no directory yet)
     └── adr/                           ← ADR (sequential IDs, unlike the rest)
 ```
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -156,6 +156,6 @@ CI での実行基盤・キャッシュ・リリースは infrastructure item �
 
 - `README.md` / `README.ja.md` — 3 層構造の最上段（導入と使い方）
 - `docs/concept.md` — コンセプト（solution / use_case への索引）
-- `docs/spec.md` — 仕様（requirement item への索引）
+- `docs/spec.md` — 仕様（requirement / quality / test_plan item への索引）
 - `docs/adr/` — 意思決定の記録
 - `docs/model.yaml` — sara の型定義（item の型・関係・ID 形式）

--- a/docs/design.md
+++ b/docs/design.md
@@ -1,6 +1,7 @@
 # nput 設計書
 
-要求（requirement）を「どう実現するか」の全体像と、個別設計（design item）への索引。
+要求（requirement）とテスト計画（test_plan）を「どう実現するか」の全体像と、個別設計
+（design item）への索引。
 
 設計判断は **すべて `docs/design/` の item が持ち**、その決定と根拠は `docs/adr/` の ADR が
 `justifies` で裏づける。本文書は通読の入口として全体像だけを述べ、詳細は item へのリンクで

--- a/docs/design.md
+++ b/docs/design.md
@@ -146,9 +146,9 @@ CI での実行基盤・キャッシュ・リリースは infrastructure item �
 ## 設計判断の所在
 
 本節はリンク集ではなく、決定がどこにあるかの案内。主要な設計判断の決定と根拠は **ADR が持つ**
-（`docs/adr/`）。ADR は `justifies` で requirement / design / infrastructure へ接続しているため、
-ある item を裏づける決定は本文書の一覧ではなく `sara query <フル ID> -u` で辿る。全 ADR を
-ここへ並べても改訂のたびに古くなるだけなので置かない。
+（`docs/adr/`）。ADR は `justifies` で requirement / design / infrastructure / quality / test_plan へ
+接続しているため、ある item を裏づける決定は本文書の一覧ではなく `sara query <フル ID> -u` で
+辿る。全 ADR をここへ並べても改訂のたびに古くなるだけなので置かない。
 
 ---
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -147,9 +147,10 @@ CI での実行基盤・キャッシュ・リリースは infrastructure item �
 ## 設計判断の所在
 
 本節はリンク集ではなく、決定がどこにあるかの案内。主要な設計判断の決定と根拠は **ADR が持つ**
-（`docs/adr/`）。ADR は `justifies` で requirement / design / infrastructure / quality / test_plan へ
-接続しているため、ある item を裏づける決定は本文書の一覧ではなく `sara query <フル ID> -u` で
-辿る。全 ADR をここへ並べても改訂のたびに古くなるだけなので置かない。
+（`docs/adr/`）。`docs/model.yaml` は ADR の `justifies` の接続先として requirement / design /
+infrastructure / quality / test_plan の 5 型を許す（現時点で実際に張られているのは quality を
+除く 4 型）。ある item を裏づける決定は本文書の一覧ではなく `sara query <フル ID> -u` で辿る。
+全 ADR をここへ並べても改訂のたびに古くなるだけなので置かない。
 
 ---
 


### PR DESCRIPTION
<!--
PR テンプレート（ソロ運用・最小構成）。
チェックリストは置かない。形骸化を避け、このリポジトリで実際に意味のある 3 点だけ書く。
-->

## 概要

#237 で model.yaml の型構成を 12 型へ改訂した際、CLAUDE.md と model.yaml 冒頭コメントは追従させた
一方、`docs/` 配下の索引・規約文書が旧構成のまま取り残されていた。#237 の task-boundary の allow 外
だったため、レビューで申し送られた 3 点を本レーンで回収する。

- **`docs/design.md`** — ADR の `justifies` 接続先へ quality / test_plan を足し、model.yaml の
  `allowed_targets` を写した列挙であることと、quality だけ実際の接続が 0 件であることを明示した。
  あわせてリード文（design が実現する対象に test_plan を追加）と関連文書の spec.md の説明を
  更新済みの spec.md 本文へ合わせた
- **`docs/agents/domain.md`** — 型テーブルと file structure を 12 型全載せにした。item 未着手の
  risk / test_condition / test_case / defect には CLAUDE.md と同じ流儀で未着手注記を付け、
  `<subject>` の粒度が未決であることも書いた。`sara query` の上流 / 下流の経路コメントも実グラフの
  経路（quality / test_plan → solution、test_plan → design、quality → infrastructure）へ更新した
- **`docs/agents/sara-graph.md`** — specification の英語規約は先行レーン #242 で
  requirement / quality / test_plan の 3 型へ既に一般化済みだったため、本 PR に差分はない

記述の基準は「実グラフに存在する接続」を既定とし、model.yaml が許すだけで実 item が無い経路
（infrastructure → design、ADR → quality）は注記や但し書きへ分離した。レビュー 4 周でこの基準を
3 文書へ揃えている。

## 関連 issue

Closes #249 / Refs #203, #237, #242

## docs / ADR 影響

docs のみの変更で、実装への影響はない。ADR の追加も不要（#237 / ADR-0049 で確定した 12 型構成へ
索引を追従させるだけで、新たな方針転換や trade-off を含まない）。

検証は `nix develop ./dev --command sara check`（warning 0 件 / ✅ Check passed）と、model.yaml の
型定義・実 item の relation との人手突合による。

**申し送り（別 Issue での回収を要する事項）**。いずれも本レーンの task-boundary
（`docs/design.md` / `docs/agents/sara-graph.md` / `docs/agents/domain.md`）の外側にあり、
本 PR では触っていない。

- **`sara check` は索引文書を検証していない** — sara は frontmatter を持たないファイルを
  `ParseResult::Skipped` で無視するため、`domain.md` / `design.md` / `CLAUDE.md` の型テーブルを
  全て間違えても check は緑のまま通る。#249 を生んだ「索引が model.yaml から取り残される」欠陥を
  次回も検知できない構図が残っている。model.yaml の型集合と索引文書の型テーブルを突き合わせる
  検査の起票が要る
- **`CLAUDE.md:41-44`** — quality / test_plan を「item もディレクトリもまだ無い」と未着手扱いする
  記述が、#242 マージで item が実在するようになった事実と食い違う
- **`docs/concept.md:171`** — 関連文書の spec.md の説明が「requirement item への索引」の旧記述
- **`docs/model.yaml:169`（および `CLAUDE.md:63`）** — RFC2119 検証が requirement 型に
  ハードコードされているという記述が、`sara-graph.md` の訂正済み記述（sara は型を問わず非空の
  `specification` に適用する。sara 0.9.4 で実地確認）と矛盾している
