### PR TITLE
docs: defect 型を廃止し欠陥を GitHub Issues 管理へ移行する

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,14 +31,14 @@ item を新設し、概要文書にはリンクを 1 行足すに留める。
 | `docs/risks/` | risk | `RISK` | requirement / design |
 | `docs/test/<対象>/` | test_condition | `TC` | risk |
 | `docs/test/<対象>/` | test_case | `CASE` | test_condition |
-| `docs/test/<対象>/` | defect | `D` | test_case |
 | `docs/adr/` | adr | `ADR` | なし（分離型）|
 
 型・関係・フィールドの定義は `docs/model.yaml` が持つ。親を持たない根は **solution と adr のみ**で、
 他の型は upstream relation を 1 本以上張る（張り忘れは `sara check` の orphan warning で出る）。
-例外は defect で、upstream relation を張る手段が無く必ず orphan warning になる（→ model.yaml 冒頭）。
+検出した欠陥（defect）は型として持たず、GitHub Issues（`bug` label）で管理する
+（→ ADR-0051。運用規約は `docs/agents/issue-tracker.md` の「Defect issues」節）。
 
-**quality（`QA`）・test_plan（`TP`）・risk（`RISK`）・テスト系（`TC` / `CASE` / `D`）は
+**quality（`QA`）・test_plan（`TP`）・risk（`RISK`）・テスト系（`TC` / `CASE`）は
 model.yaml に定義済みだが、item もディレクトリもまだ無い。** quality / test_plan は既存 item の
 移設で作られる。テスト系は工程に着手する段で `docs/risks/` と `docs/test/<対象>/` を作り、
 `<対象>` の粒度（機能単位か requirement 単位か）はその時点で決めて本節へ追記する。

--- a/dev/flake.nix
+++ b/dev/flake.nix
@@ -111,8 +111,7 @@
               fi
 
               # 型名 → prefix。docs/model.yaml の item_types と対応させる。
-              # 別名は sara init のサブコマンド別名に揃える。ただし defect の `d` は
-              # 落とす（design を `d` と略した入力が黙って defect を引くため）。
+              # 別名は sara init のサブコマンド別名に揃える。
               # 未知の入力は prefix そのものを渡されたとみなして大文字化して通す。
               case "$1" in
                 solution | sol) prefix=SOL ;;
@@ -126,7 +125,6 @@
                 risk) prefix=RISK ;;
                 test_condition | test-condition | tc) prefix=TC ;;
                 test_case | test-case | case) prefix=CASE ;;
-                defect) prefix=D ;;
                 *) prefix=$(printf '%s' "$1" | tr '[:lower:]' '[:upper:]') ;;
               esac
 

--- a/docs/adr/0048-sara-knowledge-graph-and-uuid-id-convention.md
+++ b/docs/adr/0048-sara-knowledge-graph-and-uuid-id-convention.md
@@ -37,6 +37,11 @@ references:
 > §5 のそれ以外の決定（required status check に登録しない・DoD に追加しない・CI job のローカル
 > filter）は不変で、§1〜§4 も全て不変（→ ADR-0050）。
 
+> **2026-08-09 改訂注記（ADR-0051）**: 改訂対象は本 ADR **§2 の型定義表のうち defect（D）の行だけ**。
+> defect 型は廃止され、発生した欠陥は GitHub Issues（`bug` label）で管理する。テスト系統のグラフは
+> `risk → test_condition → test_case` で終端し、relation `reveals` / `is_revealed_by` も削除された。
+> §2 のそれ以外の決定と §1 / §3 / §4 / §5 は不変（→ ADR-0051）。
+
 ## 背景
 
 nput の仕様・設計・テストは `docs/spec.md`（1200 行超）/ `docs/design.md`（550 行）/ `docs/concept.md`

--- a/docs/adr/0049-quality-test-plan-types-and-infrastructure-reparenting.md
+++ b/docs/adr/0049-quality-test-plan-types-and-infrastructure-reparenting.md
@@ -22,6 +22,12 @@ revises:
   不変で、§1 / §3 / §4 / §5 も全て不変
 - 起点: epic #203 の grilling セッション（2026-08-08）で確定
 
+> **2026-08-09 改訂注記（ADR-0051）**: 改訂対象は **§1 の型テーブルのうち defect（D）の行と、
+> defect の orphan 例外の記述・再検討条件「defect の `is_revealed_by`」だけ**。defect 型は廃止され
+> （12 型 → 11 型）、発生した欠陥は GitHub Issues で管理する。再検討条件は「`is_revealed_by` を
+> 足すか」の二択ではなく型の廃止で解消された。§2 / §3 と再検討条件「risk への peer relation 追加」は
+> 不変（→ ADR-0051）。
+
 ## 背景
 
 ADR-0048 §2 は 10 型（solution / use_case / requirement / design / infrastructure / adr /

--- a/docs/adr/0050-sara-check-strict-mode.md
+++ b/docs/adr/0050-sara-check-strict-mode.md
@@ -24,6 +24,11 @@ references:
   §1〜§4 も全て不変
 - 起点: epic #203 の移行完了（Batch 2・2026-08-08）を受けた残論点判断（Issue #255）
 
+> **2026-08-09 改訂注記（ADR-0051）**: 改訂対象は **再検討条件のうち defect 起因のトリガーだけ**。
+> defect 型は廃止され（→ ADR-0051）、「defect item が最初に起こされた時点で strict 化と衝突する」
+> 事態は発生しなくなった。`strict_mode = true` を含む決定 1〜3 は不変で、テスト系型の工程着手時に
+> 再判断する枠組み自体も（対象が risk / test_condition / test_case の 3 型になるだけで）不変。
+
 ## 背景
 
 ADR-0048 §5 は `sara check` の CI 導入にあたり `strict_mode = false`（orphan は警告止まり）で

--- a/docs/adr/0051-drop-defect-type.md
+++ b/docs/adr/0051-drop-defect-type.md
@@ -1,0 +1,97 @@
+---
+id: "ADR-0051"
+type: adr
+name: "defect 型を廃止する — 欠陥は GitHub Issues で管理し、グラフは規範のみを持つ"
+status: 採用
+issues:
+  - "#268"
+  - "#203"
+  - "#267"
+origin: "Issue #268（epic #203 残ブロッカー）の判断（2026-08-09）で確定"
+justifies:
+  - "INF-659b139d-0cf8-4c65-b30d-93c5ee2dfc71"
+revises:
+  - "ADR-0048"
+  - "ADR-0049"
+  - "ADR-0050"
+---
+# ADR-0051: defect 型を廃止する — 欠陥は GitHub Issues で管理し、グラフは規範のみを持つ
+
+- ステータス: 採用
+- 日付: 2026-08-09
+- 関連: ADR-0048, ADR-0049, ADR-0050, GitHub Issue #268, #203, #267
+- 改訂対象: ADR-0048 の型テーブルから defect を除去（12 型 → 11 型）。ADR-0049 §1 の
+  defect 例外の記述と再検討条件「defect の `is_revealed_by`」を解消。ADR-0050 の
+  再検討条件のうち defect 起因のトリガー（最初の defect item での strict 衝突）を消滅
+- 起点: Issue #268「defect の upstream relation（is_revealed_by）の要否を判断する」
+
+## 背景
+
+defect は ADR-0048 で ISTQB のテスト実行・欠陥管理工程に対応する型として定義されたが、
+他の型と異なり `allowed_targets` が空で自分から upstream relation を張れず、親側の
+test_case が downstream の `reveals`（primary）で接続する唯一の構造だった。この構造は
+3 つの例外として顕在化していた（→ Issue #268）:
+
+1. defect item は作った時点で必ず orphan warning になる（model.yaml 冒頭の既知例外）
+2. strict_mode（ADR-0050）稼働後は defect 新設が即 `sara check` exit 1 になり、
+   テスト工程の着手自体をブロックする
+3. 型関係図の機械生成（#267）で `CASE -->|reveals| D` だけが「upstream の辺のみ描く」
+   規約から漏れ、生成側に特例が要る
+
+Issue #268 は「`is_revealed_by` を足すか・primary をどちらに置くか・足さない場合の代替」
+の 3 論点を挙げ、最初の defect item を起こす前の判断を必須としていた。
+
+## 決定
+
+**defect 型を廃止し、発生した欠陥は GitHub Issues で管理する。**
+
+1. **model.yaml から defect 型を削除する**（12 型 → 11 型）。使い手がいなくなる
+   relation 定義 `reveals` / `is_revealed_by` と、test_case の allowed_target
+   `reveals → defect` も同時に削除する。グラフのテスト系統は
+   `risk → test_condition → test_case` で終端する
+2. **欠陥は GitHub Issues（`bug` label）で管理する**。トレーサビリティは片方向で、
+   欠陥 issue 本文に発見元の `CASE-xxxxxxxx` と遡及先の REQ / DSG を記載する。
+   docs 側から issue への参照は張らない（欠陥発生のたびに docs へ PR を出さない）
+3. **フィードバックループを規約化する**。欠陥 issue のクローズ時に「この欠陥を事前に
+   捕まえられたはずの risk / test_condition の欠落」を検討し、欠けていれば item を
+   追補する。運用規約の本体は `docs/agents/issue-tracker.md` の「Defect issues」節が持つ
+4. Issue #268 の論点 1・2（`is_revealed_by` の追加・primary の向き）は型の廃止により
+   消滅する。#267 の図生成特例も不要になる
+
+## 理由
+
+このプロジェクトのドキュメント管理は、要求・設計から始まりリスク・テスト観点を
+シフトレフトで管理する**予防の体系**であり、グラフが持つのは規範（あるべき姿）である。
+defect は他の型と唯一異なり「規範」ではなく「発生した出来事の記録」で、出来事の記録・
+状態遷移・修正作業の追跡は issue tracker の領分。この区別に沿えば defect をグラフに
+置く必然性は無く、構造例外（orphan・strict 衝突・図生成特例）はこの不整合の症状だった。
+
+型の廃止により「接続漏れ = orphan warning」の不変条件が**例外なしに全型で成立**し、
+ADR-0050 の strict_mode とも無条件に整合する。
+
+## 検討した代替案
+
+### `is_revealed_by` を defect の allowed_targets へ足す（#268 論点 1 の採用側）
+
+orphan 例外と strict 衝突は解消するが、「defect は test_case が発見するもの（下流からの
+発見）」という意味論を defect 側から親を張る形に反転させ、かつ出来事の記録をグラフに
+持ち込む不整合自体は残る。GitHub Issues との二重管理も解消しない。
+
+### GitHub Issue を一次とし defect item をグラフ接続用スタブとして残す
+
+item の存在意義が「issue への転送」だけになり、欠陥発生のたびに docs へ PR を出す
+運用コストと二重管理が残る。トレーサビリティは issue 本文の CASE / REQ / DSG 記載
+（片方向参照）で足りる。
+
+### strict_mode を解除する（#268 論点 3・ADR-0050 の再検討条件どおり）
+
+defect 1 型のために全型の機械的担保を弱める本末転倒。採らない。
+
+## 影響
+
+- `docs/model.yaml`: defect 型・`reveals` / `is_revealed_by` の削除、冒頭コメントの更新
+- `CLAUDE.md`・`docs/agents/domain.md`: 型テーブルから defect 行を削除、orphan 例外の
+  記述を撤去
+- `docs/agents/issue-tracker.md`: 「Defect issues」節を新設
+- Issue #268 は本 ADR でクローズ。#267 へ特例消滅を通知
+- テスト工程着手時に作る成果物は risk / test_condition / test_case の 3 型となる

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -34,10 +34,9 @@ don't skim it as an index.
 | `docs/risks/` | risk | `RISK` | What threatens a requirement or a design — **not started** |
 | `docs/test/<subject>/` | test_condition | `TC` | What a risk needs covered — **not started** |
 | `docs/test/<subject>/` | test_case | `CASE` | A concrete case under a condition — **not started** |
-| `docs/test/<subject>/` | defect | `D` | What a case revealed — **not started** |
 | `docs/adr/` | adr | `ADR` | Decisions, linked by `justifies` |
 
-The four types marked **not started** are defined in `docs/model.yaml` but have neither items nor
+The three types marked **not started** are defined in `docs/model.yaml` but have neither items nor
 directories yet; they get created when the test process is taken up, at which point the granularity
 of `<subject>` (per feature or per requirement) is decided.
 
@@ -46,8 +45,9 @@ parents `docs/model.yaml` permits: `infrastructure` may hang off a `design` as w
 `quality`, though every `INF` item satisfies a `QA` today.
 
 Every type but `solution` and `adr` hangs off at least one upstream relation, so a missing link
-shows up as an orphan warning. `defect` is the exception: it has no way to declare one, and so
-always raises the warning — see the header of `docs/model.yaml`.
+shows up as an orphan warning, with no exceptions. Defects found in the product are not graph
+items: they live in GitHub Issues under the `bug` label (→ ADR-0051; conventions in
+`docs/agents/issue-tracker.md`, "Defect issues").
 
 Start from the overview that matches the topic (spec for behaviour, design for structure, concept
 for positioning), follow its link into the item, then traverse relations for the surrounding context.

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -20,3 +20,19 @@ Create a GitHub issue.
 ## When a skill says "fetch the relevant ticket"
 
 Run `gh issue view <number> --comments`.
+
+## Defect issues
+
+Defects found in the product are managed here, not in the document graph — there is no
+`defect` item type (→ ADR-0051). The graph holds norms (what should hold); a defect is an
+event, and events belong to the tracker.
+
+- **File** a defect as a GitHub issue with the `bug` label.
+- **Trace** in the issue body, when the defect was revealed by executing a test case:
+  the revealing test case (`CASE-xxxxxxxx`) and the requirement or design it traces back
+  to (`REQ-xxxxxxxx` / `DSG-xxxxxxxx`). References are one-way — items in `docs/` never
+  link back to defect issues.
+- **Feed back** before closing: ask whether a `risk` or `test_condition` was missing that
+  would have caught this defect earlier. If so, add the missing item(s) in `docs/` — this
+  shift-left loop is what keeps the risk and test analysis from decaying into a static
+  snapshot.

--- a/docs/model.yaml
+++ b/docs/model.yaml
@@ -8,25 +8,23 @@
 # 設計の出典: epic GitHub Issue #203（grilling 2026-07-31 / 2026-08-01 で確定）、
 # ADR-0048。
 #
-# ## 型構成（12 型）
+# ## 型構成（11 型）
 #
 # 矢印は全て親 → 子（上流 → 下流）で書く。
 #
 # 仕様の系統:       solution → use_case → requirement → design
 # 品質とテスト計画: solution → quality、solution → test_plan → design
 # 技術基盤:         quality → infrastructure、design → infrastructure
-# リスクとテスト:   requirement / design → risk → test_condition → test_case → defect
+# リスクとテスト:   requirement / design → risk → test_condition → test_case
 # 独立した根:       adr（justifies で requirement / design / infrastructure / quality /
 #                   test_plan へ必須で接続する。1 本以上 → docs/adr/README.md）
 #
 # 親を持たない根は solution と adr のみ。adr も justifies（upstream relation）を
 # 1 本以上持つため、「接続漏れ = orphan warning」は全型で成立する（→ #203・#237・#253）。
 #
-# 例外は defect で、allowed_targets が空のため upstream relation を張る手段が無い
-# （親側の test_case が downstream の reveals で接続する）。defect item は作った時点で
-# 必ず orphan warning になるため、テスト工程に着手する段で is_revealed_by（定義済みの
-# upstream relation）を defect の allowed_targets へ足すかを再検討する
-# （現時点で defect item は 0 件）。
+# 検出した欠陥（defect）は型として持たない。欠陥は規範（あるべき姿）ではなく発生した
+# 出来事であり、GitHub Issues（bug label）で管理する（→ ADR-0051。issue 本文に発見元の
+# CASE と遡及先の REQ / DSG を記載する片方向参照。運用規約は docs/agents/issue-tracker.md）。
 #
 # ## 組み込みから落とした型
 #
@@ -189,7 +187,7 @@ item_types:
 
   # ISTQB のテスト計画活動の成果物。docs/test-plan/。テストスコープ・スコープ外宣言・
   # テストレベル・テストアプローチ・テスト容易性の要求を収容する。
-  # 既存のテスト系 4 型（risk / test_condition / test_case / defect）はテスト分析以降に
+  # 既存のテスト系 3 型（risk / test_condition / test_case）はテスト分析以降に
   # 対応しており、テスト計画に対応する型が空いていた（→ #237）。
   #
   # risk の parent_types には test_plan を追加しない。risk の親は「リスクが何に対して
@@ -327,7 +325,7 @@ item_types:
         targets:
           - adr
 
-  # ---- リスクとテストの系統（risk → test_condition → test_case → defect）----
+  # ---- リスクとテストの系統（risk → test_condition → test_case）----
 
   # 満たされない懸念。docs/risks/。requirement と design の両方を脅かせる。
   # どちらへ張るかの使い分け規約は docs/agents/sara-graph.md（→ #203・#210）。
@@ -397,19 +395,6 @@ item_types:
       - relation: covers
         targets:
           - test_condition
-      - relation: reveals
-        targets:
-          - defect
-
-  # 検出した不具合。docs/test/<対象>/。
-  - id: defect
-    display_name: Defect
-    prefix: D
-    id_format: '{prefix}-{uuid}'
-    parent_types:
-      - test_case
-    fields: []
-    allowed_targets: []
 
 relations:
   # ---- 組み込み由来（そのまま使う）----
@@ -541,16 +526,4 @@ relations:
     display_name: Is covered by
     inverse: covers
     direction: downstream
-    primary: false
-
-  # test_case → defect。テストが不具合を暴く方向。
-  - id: reveals
-    display_name: Reveals
-    inverse: is_revealed_by
-    direction: downstream
-    primary: true
-  - id: is_revealed_by
-    display_name: Is revealed by
-    inverse: reveals
-    direction: upstream
     primary: false


### PR DESCRIPTION
## 概要

defect 型を廃止し、発生した欠陥は GitHub Issues（`bug` label）で管理する（Issue #268 の決着・ADR-0051）。

defect は `allowed_targets` が空で自分から upstream relation を張れない唯一の型で、item を作った時点で必ず orphan warning になり、strict_mode（ADR-0050）稼働後は最初の defect item がテスト工程の着手自体をブロックする構造だった。grilling で「グラフは規範（あるべき姿）のみを持ち、欠陥は発生した出来事として issue tracker が持つ」という区別に沿って型ごと落とす判断をした。

- model.yaml から defect 型と relation `reveals` / `is_revealed_by` を削除（12 型 → 11 型）。テスト系統は `risk → test_condition → test_case` で終端
- トレーサビリティは片方向: 欠陥 issue 本文に発見元 `CASE-xxxxxxxx` と遡及先 REQ / DSG を記載（docs 側から issue へは張らない）
- クローズ前に「事前に捕まえられたはずの risk / test_condition の欠落」を検討して item を追補するフィードバックループを `docs/agents/issue-tracker.md` の「Defect issues」節として規約化

副次効果として「接続漏れ = orphan warning」の不変条件が例外なしに全型で成立し、#267 の図生成特例（`CASE -->|reveals| D`）も不要になる。`sara check`（strict）は warning 0 で通過。

## 関連 issue

Closes #268 / Refs #203, #267

## docs / ADR 影響

- ADR-0051 を新設（defect 型の廃止・欠陥の issue 管理・フィードバックループの決定）
- 改訂対象の ADR-0048 / 0049 / 0050 へ同一 PR で改訂注記を書き戻し（`docs/adr/README.md` の運用に従う）
- `docs/model.yaml`・`CLAUDE.md`・`docs/agents/domain.md` の型テーブルと orphan 例外の記述を追従
- `docs/agents/issue-tracker.md` に「Defect issues」節を新設
- concept / design / spec の更新: なし（defect への言及なし）
