### PR TITLE
chore: .claude/skills の ignore をパス自体に広げ symlink 時の dirty 表示を防ぐ

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,9 @@ result-*
 
 # ---- Project ----
 .agents/
-.claude/skills/*
+# `/*`（中身のみ）だと .claude/skills 自体が symlink のとき（worktrunk の
+# symlink-ignored hook や nput のディレクトリ配置）untracked に出るため、パスごと ignore する
+.claude/skills
 
 # nput ドッグフーディング配置物（nput apply default で生成・→ Issue #7）
 /.nput-example/


### PR DESCRIPTION
## 概要

`.gitignore` の `.claude/skills/*` は「ディレクトリの中身」だけを ignore するパターンのため、
`.claude/skills` というパス自体が symlink として置かれた場合（worktrunk の symlink-ignored
hook が worktree 作成時に作るケースや、nput がディレクトリ単位で配置するケース）に一致せず、
`?? .claude/skills` の untracked 表示（dirty ノイズ）が出ていた。実際に #272/#273 の並列
worktree 6 本すべてでこの dirty 表示が発生し、post-merge cleanup の削除可否判定を妨げた。

パターンを `.claude/skills`（`/*` なし）に変更し、実ディレクトリ・symlink のどちらでも
パスごと ignore されるようにする。ディレクトリ内に追跡ファイルは存在しないため、
ignore 範囲の実質は変わらない。

## 関連 issue

なし

## docs / ADR 影響

なし（開発環境の gitignore 調整のみ。配置動作・API・方針に変更なし）
