### PR TITLE
ci: test.yml の sara job コメントを ADR-0050 の決着へ追従させる

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,8 +90,10 @@ jobs:
     # cycles) plus the sara-id numbering contract test. Non-required check with
     # no threshold gate, same policy as go-coverage: it is NOT registered as a
     # required status check and is NOT part of the DoD, so a failure reports on
-    # the PR without blocking merge. Making it strict / required is deferred
-    # until the migration completes (→ ADR-0048, epic #203).
+    # the PR without blocking merge. The check itself runs strict
+    # (strict_mode = true in sara.toml, all warnings are errors) since the
+    # epic #203 migration completed; staying non-required is a recorded
+    # decision, not a deferral (→ ADR-0050).
     #
     # The `changes` job is not reused here: its filter targets nix/Go sources,
     # whereas this check is most relevant on docs-only PRs. A job-local filter


### PR DESCRIPTION
## 概要

`.github/workflows/test.yml` の `sara` job コメントが「strict / required 化は移行完了まで保留（→ ADR-0048, epic #203）」のままで、実態と食い違っていた。strict 化は ADR-0050 で決着済みで `sara.toml` は既に `strict_mode = true`、required status check にしない判断も同 ADR に記録済み。コメントをこの決着（strict 済み・非 required は意図した決定）へ書き換える。コメントのみの 1 hunk 修正で、CI の挙動は変わらない。

## 関連 issue

Closes #294

## docs / ADR 影響

なし（既存 ADR-0050 の決着へワークフローコメントを追従させるのみ。docs / ADR の更新は不要）。
