### PR TITLE
docs(agents): risk の判別代表例を実在ペアへ差し替え、スコアリング規約を追記する

### DIFF
--- a/docs/agents/sara-graph.md
+++ b/docs/agents/sara-graph.md
@@ -190,6 +190,41 @@ Risks are where test conditions hang from (`test_condition --mitigates--> risk`)
 misplacing a risk misplaces the tests that cover it. A requirement-level risk parked under
 one design leaves the other designs looking untested for a concern they share.
 
+## How a risk is scored: `likelihood`, `impact` and `level`
+
+`docs/model.yaml` requires all three on every `risk` and constrains each to
+`high` / `medium` / `low`, but the enum alone says nothing about how to choose a value.
+Left unstated, parallel lanes invent their own scales and the corpus stops ranking
+anything — which is the same reason the `specification` and `threatens` conventions live
+in this file. The rules below fix the scale; `level` is then derived, not judged.
+
+### `likelihood` — how easily a regression that realises the threat gets in
+
+Judge it as "how often the code in question changes" × "how far the existing verification
+gates would miss the regression". Code that changes frequently and sits in a blind spot of
+the test suite is `high`; stable code already covered by a mechanical check is `low`.
+
+### `impact` — how recoverable it is once realised
+
+| Value | What is at stake |
+|---|---|
+| `high` | Destroys the user's environment or real data, or leaves a silent inconsistency. |
+| `medium` | Misbehaves, but a re-run or a rebuild recovers it. |
+| `low` | Confined to development; never reaches the shipped artifact. |
+
+### `level` — derived from the two, never judged by hand
+
+| `likelihood` \ `impact` | `high` | `medium` | `low` |
+|---|---|---|---|
+| **`high`** | `high` | `high` | `medium` |
+| **`medium`** | `high` | `medium` | `low` |
+| **`low`** | `medium` | `low` | `low` |
+
+Nothing mechanical checks the derivation — `sara check` validates the enum, not the
+relation between the three fields — so it is upheld by review like the rest of this file.
+A `level` that does not match the cell is a defect in the item, not a considered override:
+if the matrix feels wrong for an item, the mis-scored field is `likelihood` or `impact`.
+
 ## How an item states its norm: `specification` / `specification_ja`
 
 The three types of the section above — `requirement`, `quality` and `test_plan` — each

--- a/docs/agents/sara-graph.md
+++ b/docs/agents/sara-graph.md
@@ -212,6 +212,12 @@ the test suite is `high`; stable code already covered by a mechanical check is `
 | `medium` | Misbehaves, but a re-run or a rebuild recovers it. |
 | `low` | Confined to development; never reaches the shipped artifact. |
 
+Read the rows top-down and take the first that fits: a threat that stays inside development
+but passes silently — a verification gate that reports success while checking nothing — is
+`high` on the silent-inconsistency clause, not `low` on the confinement clause. What makes
+it `high` is that nothing announces the loss, and confinement to development does not
+supply the announcement.
+
 ### `level` — derived from the two, never judged by hand
 
 | `likelihood` \ `impact` | `high` | `medium` | `low` |
@@ -220,8 +226,14 @@ the test suite is `high`; stable code already covered by a mechanical check is `
 | **`medium`** | `high` | `medium` | `low` |
 | **`low`** | `medium` | `low` | `low` |
 
-Nothing mechanical checks the derivation — `sara check` validates the enum, not the
+Nothing mechanical checks the derivation today — `sara check` validates the enum, not the
 relation between the three fields — so it is upheld by review like the rest of this file.
+Unlike the rest of this file, though, it need not stay that way: the rule is a pure mapping
+over three frontmatter fields with no prose to interpret, so it is the one convention here
+that a script can decide outright. Reviewing it by eye is the weakest form of the check,
+and a repository-level check in the shape of `dev/tests/sara-id.sh` would replace it
+wholesale. Until such a check exists, verify the cell when touching any of the three fields.
+
 A `level` that does not match the cell is a defect in the item, not a considered override:
 if the matrix feels wrong for an item, the mis-scored field is `likelihood` or `impact`.
 

--- a/docs/agents/sara-graph.md
+++ b/docs/agents/sara-graph.md
@@ -161,8 +161,9 @@ were replaced — if so, it is the norm.
 
 ## Where a risk attaches: `requirement` or `design`
 
-A `risk` may point at either a `requirement` or a `design` via `threatens`. The model
-permits both, so the choice is a judgement call — make it by this rule.
+A `risk` may point at a `requirement` or a `design` via `threatens`. The model permits
+both, and constrains neither the count nor the mix, so the choice is a judgement call —
+make it by this rule.
 
 > A risk attaches to `requirement` by default. Attach it to `design` only when it is a
 > risk that **would disappear if the design were replaced by an alternative** — that is, a
@@ -172,6 +173,12 @@ permits both, so the choice is a judgement call — make it by this rule.
 The test: imagine the design being swapped for a different one that satisfies the same
 requirement. If the risk goes away with it, it belongs to the design. If it survives the
 swap, it belongs to the requirement.
+
+Apply the test once per `threatens` edge, not once per risk. A risk that names several
+facets of one threat may hold edges of both kinds at once — the facets that survive the
+swap to `requirement`, the facet intrinsic to the design to `design` — and the design-side
+example below is exactly that shape. What the rule forbids is an edge whose kind the test
+does not support, not a risk that earns more than one.
 
 Examples:
 

--- a/docs/agents/sara-graph.md
+++ b/docs/agents/sara-graph.md
@@ -177,7 +177,7 @@ Examples:
 
 | Risk | Attaches to | Why |
 |---|---|---|
-| The unwind of the undo journal fails partway through | `design` | The undo journal is one design for "leave no trace on failure". Replace it with another (e.g. staging into a temp tree and renaming into place) and this particular failure mode is gone. |
+| The semantics of root resolution and placement diverge per entrypoint form (`RISK-e916f742` → `DSG-92f54490`) | `design` | Confining the legacy branch to the attr path assembly is one design for "one implementation across entrypoint forms". Replace it — e.g. write each entrypoint's nix invocation out separately — and this particular divergence is gone. |
 | `apply` leaves traces on the filesystem when it fails | `requirement` | This is the requirement itself being broken. Every design has to answer for it; no change of design makes the concern go away. |
 
 Attaching a design-specific risk to the requirement loses the information that the risk is


### PR DESCRIPTION
<!--
PR テンプレート（ソロ運用・最小構成）。
チェックリストは置かない。形骸化を避け、このリポジトリで実際に意味のある 3 点だけ書く。
-->

## 概要

`docs/agents/sara-graph.md` へ risk 周りの規約を 2 件入れる。どちらも並列レーンの結論を
揃えるための規約で、同じファイルを触るため 1 レーンに閉じている（各 issue の決定事項で
そう分けられている）。

**1. risk 判別表の design 代表例を実在ペアへ差し替える（#275）**

design 側の代表例に挙げていた「undo ジャーナルの巻き戻しが途中で失敗する」は、対応する
design item がリポジトリに存在せず、例として辿れなかった。実在する
RISK-e916f742（entrypoint の形ごとに root 解決と配置の意味論が食い違う）→ DSG-92f54490
（legacy 分岐は attr path 組み立てに閉じる）へ差し替える。swap test の規範そのものは変えない。

差し替えた代表例が REQ 4 本 + DSG 1 本の複数張りである一方、規範文が二択に読めたため、
swap test の適用単位が `threatens` エッジ 1 本ごとであること・複数張りが規約違反ではないことを
併せて明記した（`docs/model.yaml` は本数も混在も縛っていない）。

**2. risk の likelihood / impact / level 付与規約を追記する（#292）**

3 フィールドは `docs/model.yaml` で必須 enum として定義されているが値の決め方の規約が無く、
レーンごとに独自基準で付くとスケールが揃わない。決定事項どおり、likelihood =「対象コードの
変更頻度 × 既存の検証ゲートが退行を見逃す度合い」、impact = 回復可能性の 3 段、level = 3×3
マトリクスからの決定論導出（手で判断しない）を 1 節として追加する。

レビューを受けて 2 点を詰めた。impact 表の 3 行が排他でなく「開発内に閉じるが黙って通り抜ける」
脅威が high と low の両方に読めたため、行を上から読んで最初に合致するものを採る旨とその理由を
追記。level 導出は本ファイルで唯一完全に機械判定可能な規約でありながら検出手段が review しか
示されていなかったため、`dev/tests/sara-id.sh` と同形のチェックで置き換えられる旨と暫定運用を
添えた。

**このPRの範囲外**: 既存 RISK 全 32 件への横断適用。#292 の決定事項で、#282 が RISK-f8e14849 の
内容を書き換えるためコンフリクトを構造的に避ける目的で後続 PR へ時間分離されている。
なお全 32 件の (likelihood, impact) → level を今回のマトリクスと突合したところ**全件一致**して
おり、規約追加が既存 corpus を遡って defect 化してはいない（後続の横断適用は likelihood /
impact 値そのものの見直しが本題になる）。

**申し送り**: 既存 RISK 11 件の本文が「level を〜とするのは」と level を手で判断した根拠を
書き下しており、新規約「level は手で判断しない」と文面が食い違う（値自体は一致しているため
即時の不整合はない）。実質は impact の判断根拠を述べたものなので書き直しが要るが、#292 の
後続 PR は「3 フィールドのみ触る」と宣言しているためスコープから構造的に漏れる。後続 PR の
スコープに含めるか別 issue の起票が要る。

## 関連 issue

- Closes #275
- Refs #292（規約追記のみ。完了条件の「全 RISK の 3 フィールド更新」は後続 PR）

## docs / ADR 影響

- concept / design / spec: 更新なし。今回触るのは `docs/agents/` 配下のエージェント向け規約
  文書のみで、solution / requirement / design item は 1 件も増減していない
- ADR: 追加なし。判別規約・スコアリング規約はいずれも既存方針の書き下しで、方針転換や
  trade-off の選択を伴わない（#275 は「代表例の差し替えか design item 新設か」を決定事項で
  前者に確定済み、#292 はスケールの言語化）
- `nix develop ./dev --command sara check` は pass（strict_mode = true、warning 0）
