### PR TITLE
feat(dev): テストコード⇔テストドキュメント対応を機械化する

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -250,9 +250,15 @@ jobs:
               - 'docs/risks/**'
               - 'docs/model.yaml'
               - 'sara.toml'
-              - '**/*_test.go'
               - 'tests/**'
               - 'flake.nix'
+              # `--full` runs `go test -json ./...` and evaluates each nix-unit
+              # file, so generation also depends on non-test Go sources and on
+              # lib/ — a build break or an eval break there degrades the table.
+              - '**/*.go'
+              - 'go.mod'
+              - 'go.sum'
+              - 'lib/**'
 
       - name: Setup Nix
         if: steps.filter.outputs.relevant != 'false'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,15 @@ on:
   # nix/Go/CI files change" optimisation is preserved either way
   # (→ ADR-0027 §2, ADR-0030).
   pull_request:
+  # Only `test-doc-matrix` consumes this trigger: the correspondence table is
+  # generated from merged state and uploaded as an artifact (→ #304). Every
+  # other job stays PR-only via an explicit `github.event_name != 'push'`
+  # guard — the `changes` job treats any non-pull_request event as "run", so
+  # without those guards a main push would newly fire flake-check / go-coverage
+  # / e2e, which this trigger is not meant to change.
+  push:
+    branches:
+      - main
 
 jobs:
   changes:
@@ -49,18 +58,18 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Nix
-        if: needs.changes.outputs.run == 'true'
+        if: needs.changes.outputs.run == 'true' && github.event_name != 'push'
         uses: ./.github/actions/setup-nix
         with:
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
       - name: Run nix flake check
-        if: needs.changes.outputs.run == 'true'
+        if: needs.changes.outputs.run == 'true' && github.event_name != 'push'
         run: nix flake check -L
 
   go-coverage:
     needs: changes
-    if: needs.changes.outputs.run == 'true'
+    if: needs.changes.outputs.run == 'true' && github.event_name != 'push'
     # buildGoModule の checkPhase が出力する coverprofile / func レポートを成果物（$out）から取り出し、
     # Job Summary に表示する（計測・表示のみ。閾値ゲートは持たない → 他テスト追加 PR とのマージ順依存回避）。
     # $out 同梱なので cachix の cache hit でも決定論的に同じレポートを参照できる。
@@ -104,10 +113,12 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       # Scoped to what this job actually exercises: the documents sara scans,
-      # its config, the sara-id implementation, and this workflow. On
-      # non-pull_request events the step is skipped and `relevant` stays empty,
-      # which the guard below treats as "run" — the event/filter decision lives
-      # in a single expression rather than being restated in a shell step.
+      # its config, the sara-id / test-doc-map implementations, the test assets
+      # test-doc-map enumerates, and this workflow. On non-pull_request events
+      # the step is skipped and `relevant` stays empty, which the guards below
+      # treat as "run" (except on push, which only test-doc-matrix serves) —
+      # the event/filter decision lives in a single expression per step rather
+      # than being restated in a shell step.
       - name: Detect sara-relevant changes
         id: filter
         if: github.event_name == 'pull_request'
@@ -136,7 +147,7 @@ jobs:
               - 'flake.nix'
 
       - name: Setup Nix
-        if: steps.filter.outputs.relevant != 'false'
+        if: steps.filter.outputs.relevant != 'false' && github.event_name != 'push'
         uses: ./.github/actions/setup-nix
         with:
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
@@ -146,14 +157,14 @@ jobs:
       # exactly this reason → 2c9f9fa). The dedicated `sara` devShell avoids
       # building nput and running the dogfood shellHook.
       - name: Run sara check
-        if: steps.filter.outputs.relevant != 'false'
+        if: steps.filter.outputs.relevant != 'false' && github.event_name != 'push'
         run: nix develop '.?dir=dev#sara' -c sara check
 
       # The numbering contract for sara-id (UUIDv4 two-tier IDs). Also exposed
       # as `checks.sara-id` for `nix flake check ./dev`, but that never runs in
       # CI because flake-check targets the root flake — hence this explicit step.
       - name: Run sara-id contract test
-        if: steps.filter.outputs.relevant != 'false'
+        if: steps.filter.outputs.relevant != 'false' && github.event_name != 'push'
         run: nix develop '.?dir=dev#sara' -c dev/tests/sara-id.sh
 
       # The test-code ⇔ CASE mapping contract (→ #304). Purely static: it reads
@@ -162,12 +173,12 @@ jobs:
       # as `checks.test-doc-map` for local `nix flake check ./dev`, which CI's
       # root-flake flake-check never reaches.
       - name: Run test-doc-map contract test
-        if: steps.filter.outputs.relevant != 'false'
+        if: steps.filter.outputs.relevant != 'false' && github.event_name != 'push'
         run: nix develop '.?dir=dev#sara' -c dev/tests/test-doc-map.sh
 
   e2e:
     needs: changes
-    if: needs.changes.outputs.run == 'true'
+    if: needs.changes.outputs.run == 'true' && github.event_name != 'push'
     # Non-NixOS (ubuntu-latest) E2E. Verifies the "works as long as nix is present"
     # claim with real nix (→ ADR-0012). Runs tests/e2e/run.sh inside the ci devShell
     # (nput / git / jq / coreutils).
@@ -182,3 +193,37 @@ jobs:
 
       - name: Run E2E harness
         run: nix develop '.?dir=dev#ci' -c tests/e2e/run.sh
+
+  test-doc-matrix:
+    # Generates the test-code ⇔ CASE ⇔ TC ⇔ RISK correspondence table and uploads
+    # it as an artifact (→ #304). Deliberately NOT committed to the repository:
+    # a generated file tracked alongside its sources drifts, and reviewing its
+    # diff adds nothing the contract test does not already enforce.
+    #
+    # Runs on main push and workflow_dispatch only — not per PR. Unlike the
+    # test-doc-map contract test (purely static, every PR), generation needs the
+    # `--full` inventory, which runs `go test -json` over the whole module and
+    # evaluates each nix-unit file. That cost buys a document nobody reads
+    # mid-review, so it is paid once per merge instead.
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Setup Nix
+        uses: ./.github/actions/setup-nix
+        with:
+          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+
+      # The default dev devShell, not `sara`: generation needs go + jq + yq-go +
+      # sara together. Its shellHook dogfoods `nput apply skills`, which is
+      # harmless here (it places into the checkout and is allowed to no-op).
+      - name: Generate correspondence table
+        run: nix develop ./dev -c dev/scripts/test-doc-matrix.sh test-doc-matrix.md
+
+      - name: Upload correspondence table
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: test-doc-matrix
+          path: test-doc-matrix.md
+          if-no-files-found: error

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -226,7 +226,13 @@ jobs:
 
       # On push / workflow_dispatch this step is skipped and `relevant` stays
       # empty, which the guards below treat as "run". On pull_request it decides
-      # whether this PR touches generation.
+      # whether this PR touches anything the table is generated from.
+      #
+      # Covers the generator's real inputs, not just its implementation: CASE
+      # frontmatter and the test assets `--full` walks feed the output, and
+      # docs/model.yaml defines the type names the `sara report matrix` jq
+      # filters select on — renaming a display name would silently empty the
+      # TC / RISK columns. Kept in step with the sara job's filter above.
       - name: Detect generation-relevant changes
         id: filter
         if: github.event_name == 'pull_request'
@@ -240,6 +246,13 @@ jobs:
               - 'dev/flake.nix'
               - 'dev/flake.lock'
               - '.github/workflows/test.yml'
+              - 'docs/test/**'
+              - 'docs/risks/**'
+              - 'docs/model.yaml'
+              - 'sara.toml'
+              - '**/*_test.go'
+              - 'tests/**'
+              - 'flake.nix'
 
       - name: Setup Nix
         if: steps.filter.outputs.relevant != 'false'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -259,6 +259,9 @@ jobs:
               - 'go.mod'
               - 'go.sum'
               - 'lib/**'
+              # nix-unit の名前採取は getFlake → inputs.nixpkgs.lib を経由するので、
+              # root の lock bump も eval の挙動を変えうる（dev/flake.lock と同じ論拠）.
+              - 'flake.lock'
 
       - name: Setup Nix
         if: steps.filter.outputs.relevant != 'false'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -87,18 +87,18 @@ jobs:
 
   sara:
     # Knowledge-graph validation of docs/ (broken references, duplicate IDs,
-    # cycles) plus the sara-id numbering contract test. Non-required check with
-    # no threshold gate, same policy as go-coverage: it is NOT registered as a
-    # required status check and is NOT part of the DoD, so a failure reports on
-    # the PR without blocking merge. The check itself runs strict
-    # (strict_mode = true in sara.toml, all warnings are errors) since the
-    # epic #203 migration completed; staying non-required is a recorded
-    # decision, not a deferral (→ ADR-0050).
+    # cycles) plus two contract tests: sara-id's numbering and test-doc-map's
+    # test-code ⇔ CASE mapping. Non-required check with no threshold gate, same
+    # policy as go-coverage: it is NOT registered as a required status check and
+    # is NOT part of the DoD, so a failure reports on the PR without blocking
+    # merge. The check itself runs strict (strict_mode = true in sara.toml, all
+    # warnings are errors) since the epic #203 migration completed; staying
+    # non-required is a recorded decision, not a deferral (→ ADR-0050).
     #
-    # The `changes` job is not reused here: its filter targets nix/Go sources,
-    # whereas this check is most relevant on docs-only PRs. A job-local filter
-    # covers the inputs that actually matter instead, so unrelated PRs skip the
-    # nix setup entirely.
+    # The `changes` job is not reused here: its filter targets nix/Go sources
+    # broadly, whereas this job needs docs plus the specific test assets
+    # test-doc-map enumerates. A job-local filter covers exactly those inputs
+    # instead, so unrelated PRs skip the nix setup entirely.
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -123,7 +123,17 @@ jobs:
               # execution environment.
               - 'dev/flake.lock'
               - 'dev/tests/**'
+              - 'dev/scripts/**'
               - '.github/workflows/test.yml'
+              # The test assets the test-doc-map contract test enumerates.
+              # Without these, adding or renaming a test file without updating
+              # its CASE would skip the job entirely and the drift would merge
+              # unnoticed — which is the whole point of the check (→ #304).
+              - '**/*_test.go'
+              - 'tests/**'
+              # Defines the flake checks the contract test matches against its
+              # static list (`checks.hm-module` and friends).
+              - 'flake.nix'
 
       - name: Setup Nix
         if: steps.filter.outputs.relevant != 'false'
@@ -145,6 +155,15 @@ jobs:
       - name: Run sara-id contract test
         if: steps.filter.outputs.relevant != 'false'
         run: nix develop '.?dir=dev#sara' -c dev/tests/sara-id.sh
+
+      # The test-code ⇔ CASE mapping contract (→ #304). Purely static: it reads
+      # the file-level inventory and CASE frontmatter only, so it needs nothing
+      # beyond this devShell. Wired the same way as sara-id above — also exposed
+      # as `checks.test-doc-map` for local `nix flake check ./dev`, which CI's
+      # root-flake flake-check never reaches.
+      - name: Run test-doc-map contract test
+        if: steps.filter.outputs.relevant != 'false'
+        run: nix develop '.?dir=dev#sara' -c dev/tests/test-doc-map.sh
 
   e2e:
     needs: changes

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,16 +16,19 @@ on:
   pull_request:
   # Only `test-doc-matrix` consumes this trigger: the correspondence table is
   # generated from merged state and uploaded as an artifact (→ #304). Every
-  # other job stays PR-only via an explicit `github.event_name != 'push'`
-  # guard — the `changes` job treats any non-pull_request event as "run", so
-  # without those guards a main push would newly fire flake-check / go-coverage
-  # / e2e, which this trigger is not meant to change.
+  # other job carries a job-level `github.event_name != 'push'` guard — the
+  # `changes` job treats any non-pull_request event as "run", so without them a
+  # main push would newly fire flake-check / go-coverage / e2e / sara, which
+  # this trigger is not meant to change.
   push:
     branches:
       - main
 
 jobs:
   changes:
+    # Every consumer skips on push, so detection would only book a runner to
+    # produce an output nobody reads.
+    if: github.event_name != 'push'
     runs-on: ubuntu-latest
     outputs:
       run: ${{ steps.detect.outputs.run }}
@@ -43,6 +46,12 @@ jobs:
     # never be reported and merge would stay blocked forever. Gate at step
     # level instead: the job (and its matrix legs) always run and always
     # report, but do nothing when there's nothing relevant to check.
+    #
+    # `push` is the exception: that constraint is specific to pull_request
+    # (required contexts are only evaluated there), so a job-level guard is
+    # safe and avoids booking three runners — macOS included — to check out
+    # and exit. Only `test-doc-matrix` consumes the push trigger.
+    if: github.event_name != 'push'
     strategy:
       fail-fast: false
       matrix:
@@ -58,13 +67,13 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Nix
-        if: needs.changes.outputs.run == 'true' && github.event_name != 'push'
+        if: needs.changes.outputs.run == 'true'
         uses: ./.github/actions/setup-nix
         with:
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
       - name: Run nix flake check
-        if: needs.changes.outputs.run == 'true' && github.event_name != 'push'
+        if: needs.changes.outputs.run == 'true'
         run: nix flake check -L
 
   go-coverage:
@@ -108,17 +117,20 @@ jobs:
     # broadly, whereas this job needs docs plus the specific test assets
     # test-doc-map enumerates. A job-local filter covers exactly those inputs
     # instead, so unrelated PRs skip the nix setup entirely.
+    #
+    # Not a required context, so a job-level `push` guard costs nothing (see
+    # flake-check) — only `test-doc-matrix` serves that trigger.
+    if: github.event_name != 'push'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       # Scoped to what this job actually exercises: the documents sara scans,
       # its config, the sara-id / test-doc-map implementations, the test assets
-      # test-doc-map enumerates, and this workflow. On non-pull_request events
-      # the step is skipped and `relevant` stays empty, which the guards below
-      # treat as "run" (except on push, which only test-doc-matrix serves) —
-      # the event/filter decision lives in a single expression per step rather
-      # than being restated in a shell step.
+      # test-doc-map enumerates, and this workflow. On workflow_dispatch the
+      # step is skipped and `relevant` stays empty, which the guards below
+      # treat as "run" — the event/filter decision lives in a single expression
+      # per step rather than being restated in a shell step.
       - name: Detect sara-relevant changes
         id: filter
         if: github.event_name == 'pull_request'
@@ -147,7 +159,7 @@ jobs:
               - 'flake.nix'
 
       - name: Setup Nix
-        if: steps.filter.outputs.relevant != 'false' && github.event_name != 'push'
+        if: steps.filter.outputs.relevant != 'false'
         uses: ./.github/actions/setup-nix
         with:
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
@@ -157,14 +169,14 @@ jobs:
       # exactly this reason → 2c9f9fa). The dedicated `sara` devShell avoids
       # building nput and running the dogfood shellHook.
       - name: Run sara check
-        if: steps.filter.outputs.relevant != 'false' && github.event_name != 'push'
+        if: steps.filter.outputs.relevant != 'false'
         run: nix develop '.?dir=dev#sara' -c sara check
 
       # The numbering contract for sara-id (UUIDv4 two-tier IDs). Also exposed
       # as `checks.sara-id` for `nix flake check ./dev`, but that never runs in
       # CI because flake-check targets the root flake — hence this explicit step.
       - name: Run sara-id contract test
-        if: steps.filter.outputs.relevant != 'false' && github.event_name != 'push'
+        if: steps.filter.outputs.relevant != 'false'
         run: nix develop '.?dir=dev#sara' -c dev/tests/sara-id.sh
 
       # The test-code ⇔ CASE mapping contract (→ #304). Purely static: it reads
@@ -173,7 +185,7 @@ jobs:
       # as `checks.test-doc-map` for local `nix flake check ./dev`, which CI's
       # root-flake flake-check never reaches.
       - name: Run test-doc-map contract test
-        if: steps.filter.outputs.relevant != 'false' && github.event_name != 'push'
+        if: steps.filter.outputs.relevant != 'false'
         run: nix develop '.?dir=dev#sara' -c dev/tests/test-doc-map.sh
 
   e2e:
@@ -200,17 +212,37 @@ jobs:
     # a generated file tracked alongside its sources drifts, and reviewing its
     # diff adds nothing the contract test does not already enforce.
     #
-    # Runs on main push and workflow_dispatch only — not per PR. Unlike the
-    # test-doc-map contract test (purely static, every PR), generation needs the
-    # `--full` inventory, which runs `go test -json` over the whole module and
-    # evaluates each nix-unit file. That cost buys a document nobody reads
-    # mid-review, so it is paid once per merge instead.
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    # Not run on every PR. Unlike the test-doc-map contract test (purely static),
+    # generation needs the `--full` inventory, which runs `go test -json` over the
+    # whole module and evaluates each nix-unit file. That cost buys a document
+    # nobody reads mid-review, so main push and workflow_dispatch pay it instead.
+    #
+    # The exception is a PR that touches generation itself: the step-level filter
+    # below runs the job when the scripts or their data files change, so a broken
+    # generator fails on its own PR rather than after landing on main.
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
+      # On push / workflow_dispatch this step is skipped and `relevant` stays
+      # empty, which the guards below treat as "run". On pull_request it decides
+      # whether this PR touches generation.
+      - name: Detect generation-relevant changes
+        id: filter
+        if: github.event_name == 'pull_request'
+        uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v4.0.1
+        with:
+          filters: |
+            relevant:
+              - 'dev/scripts/**'
+              - 'dev/tests/test-categories.tsv'
+              - 'dev/tests/test-doc-exclusions.tsv'
+              - 'dev/flake.nix'
+              - 'dev/flake.lock'
+              - '.github/workflows/test.yml'
+
       - name: Setup Nix
+        if: steps.filter.outputs.relevant != 'false'
         uses: ./.github/actions/setup-nix
         with:
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
@@ -219,9 +251,11 @@ jobs:
       # sara together. Its shellHook dogfoods `nput apply skills`, which is
       # harmless here (it places into the checkout and is allowed to no-op).
       - name: Generate correspondence table
+        if: steps.filter.outputs.relevant != 'false'
         run: nix develop ./dev -c dev/scripts/test-doc-matrix.sh test-doc-matrix.md
 
       - name: Upload correspondence table
+        if: steps.filter.outputs.relevant != 'false'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: test-doc-matrix

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,15 @@ risk を `requirement` と `design` のどちらに張るかの使い分けは `
 `docs/test/<対象>/` の `<対象>` は**機能単位の 8 区分**。requirement 単位は 130 超の REQ との
 1:N が錯綜するため採らない（→ Issue #273 の決定事項）。
 
+**区分の一覧と並び順の規範は `dev/tests/test-categories.tsv`**（機械可読・契約テストと対応表
+生成が共用する SSOT → Issue #304）。下の表はそれに test_plan 列を添えた読み物で、区分を
+増減するときはデータファイル・`docs/test/` のディレクトリ・この表の 3 つを揃える
+（前 2 つのずれは `dev/tests/test-doc-map.sh` が検出する）。
+
+個々のテスト資産がどの区分に属するかは**どの表でも持たない**。CASE ファイルの置き場所
+（`docs/test/<区分>/`）から導く。パス prefix では決まらない（`internal/engine/*_test.go` は
+5 区分・`tests/e2e/scenarios/*` は 4 区分へ割れる）ため、prefix 表を持つと二重管理になる。
+
 右端は各区分の CASE の上に立つ test_plan（逆算の起点。複数あるものは担当が分属する）。
 
 | `<対象>` | 含むテスト資産 | 上位の test_plan |
@@ -59,12 +68,16 @@ risk を `requirement` と `design` のどちらに張るかの使い分けは `
 | `integration` | `checks.hm-module`、e2e `01-project` / `05-hm` / `06-init-templates` / `07-legacy`、`internal/gitutil/`、`internal/manifest/` | TP-229b69c0 / TP-0734996e / TP-e7c25263（`internal/` の Go テスト）|
 
 区分外: `go-vet` / `golangci-lint` / カバレッジ計測は quality の担当。`dev/tests/sara-id.sh` は
-test_plan（TP-d7da4065）のみを持ち、TC / CASE へは展開しない（理由は同 item）。
+test_plan（TP-d7da4065）のみを持ち、TC / CASE へは展開しない（理由は同 item）。**CASE を
+持たないテスト資産の規範は `dev/tests/test-doc-exclusions.tsv`**（除外理由付き。ここに無い
+資産が CASE 無しで現れると契約テストが落ちる）。
 
 **逆算階層の粒度**（既存のテスト実装から item を起こすときの単位）:
 
-- **CASE** = テストファイル / e2e シナリオ / flake check 単位。本文に対象ファイルパスと
-  主な検証内容（テスト関数のテーマ列挙）を書く。テスト関数単位には割らない
+- **CASE** = テストファイル / e2e シナリオ / flake check 単位。frontmatter の `target`
+  （必須・単一値）に対象を正準表記で書き、本文の `## 対象` 節に人間向けの補足を書く。
+  主な検証内容（テスト関数のテーマ列挙）も本文へ。テスト関数単位には割らない。
+  CASE ⟷ テスト資産の 1:1 は `dev/tests/test-doc-map.sh` が強制する
 - **TC** = 検証テーマ単位（対象あたり数件）。同じ不変条件・観点を検証する CASE 群を束ねる
 - **RISK** = TC を束ねる脅威単位（対象あたり 2〜5 件）。「このテーマが壊れると何が起きるか」を
   requirement / design への `threatens` で表す
@@ -119,6 +132,11 @@ nix flake check          # 評価エラー・型チェック
 nix build .#<package>    # パッケージビルド
 nix run .#<script>       # activation スクリプト実行
 nix develop ./dev --command sara check   # ドキュメントグラフの検証
+
+# テストコード ⇔ CASE 対応（→ Issue #304）
+nix develop '.?dir=dev#sara' -c dev/tests/test-doc-map.sh   # 契約テスト（純静的・毎 PR で回る）
+nix develop ./dev -c dev/scripts/test-inventory.sh --static # テスト資産の列挙（ファイル粒度）
+nix develop ./dev -c dev/scripts/test-doc-matrix.sh out.md  # 対応表の生成（重い・CI は main push）
 ```
 
 ## 規約

--- a/dev/flake.nix
+++ b/dev/flake.nix
@@ -200,6 +200,12 @@
               # uuidgen -r の供給元（util-linux）は sara-id の runtimeInputs で
               # wrapper の PATH に前置されるため、devShell 側には載せない。
               sara-id
+              # dev/tests/test-doc-map.sh・dev/scripts/test-doc-matrix.sh が CASE
+              # frontmatter を読むのに使う yq-go（mikefarah/yq v4）。載せないと
+              # ambient PATH の python-yq（別実装・別構文）を拾って黙って空を返す。
+              yq-go
+              # test-doc-matrix.sh が sara report matrix --format json を整形するのに使う。
+              jq
               go
               gopls
               # ローカルでカバレッジ計測する coverage ツール（go test -coverprofile + go tool cover）。

--- a/dev/flake.nix
+++ b/dev/flake.nix
@@ -257,11 +257,53 @@
                 touch "$out"
               '';
 
+          # テストコード ⇔ CASE 対応の契約テスト（dev/tests/test-doc-map.sh）。
+          # checks.sara-id と同じ二重化の意図で 2 経路から走らせる:
+          #
+          # - この checks 派生: ローカルの `nix flake check ./dev` に載せる
+          # - CI: .github/workflows/test.yml の sara job が devShells.sara 経由で実行し、
+          #   PR での退行検知を担保する（flake-check job はルート flake が対象なので
+          #   この派生は CI では回らない）
+          #
+          # テストは docs/ と実際のテスト資産（cmd/ internal/ tests/）の両方を走査する。
+          # サンドボックスに作業ツリーは無く、テスト側の git ルート解決も効かないため、
+          # ルート flake の store path（inputs.root。dev/flake.nix の path:../ 入力）を
+          # 書き込み可能な場所へ複製し、その中で走らせる。dev/ 配下のスクリプト・
+          # データファイルは store の dev flake 側から重ねる（ルート flake の store path は
+          # dev/ を含むが、そちらは編集中の内容と一致しない可能性がある）。
+          checks.test-doc-map =
+            pkgs.runCommandLocal "test-doc-map"
+              {
+                nativeBuildInputs = [
+                  pkgs.yq-go
+                  pkgs.git
+                  pkgs.coreutils
+                  pkgs.gnused
+                  pkgs.gnugrep
+                  pkgs.diffutils
+                  pkgs.findutils
+                ];
+              }
+              ''
+                cp -r ${inputs.root} repo
+                chmod -R u+w repo
+                rm -rf repo/dev/scripts repo/dev/tests
+                mkdir -p repo/dev
+                cp -r ${./scripts} repo/dev/scripts
+                cp -r ${./tests} repo/dev/tests
+                chmod -R u+w repo/dev
+                cd repo
+                # テスト側の走査基点はカレントへフォールバックする（git 管理外のため）。
+                bash dev/tests/test-doc-map.sh
+                touch "$out"
+              '';
+
           # CI の sara check 専用シェル。default devShell は nput のビルドと
           # dogfood の shellHook（nput apply skills）を伴うため、docs 変更だけの PR で
           # それらを走らせないよう sara 単体に絞る。NUR 由来の store path を
           # yasunori0418.cachix.org から引くだけで済む。
-          # CI からは sara check と dev/tests/sara-id.sh の両方をこのシェルで実行する。
+          # CI からは sara check・dev/tests/sara-id.sh・dev/tests/test-doc-map.sh を
+          # このシェルで実行する。
           devShells.sara = pkgs.mkShell {
             packages = [
               inputs'.nur.packages.sara
@@ -272,6 +314,10 @@
               pkgs.git
               pkgs.gnused
               pkgs.coreutils
+              # dev/tests/test-doc-map.sh が CASE frontmatter の target を読むのに使う。
+              # yq-go（mikefarah/yq v4）。nixpkgs の `yq` は python-yq（別実装・別構文）
+              # なので取り違えないこと。テスト側も実装を確認して落とす。
+              pkgs.yq-go
             ];
             env.TERM = "dumb";
           };

--- a/dev/scripts/lib-testdoc.sh
+++ b/dev/scripts/lib-testdoc.sh
@@ -1,0 +1,45 @@
+# テストドキュメント対応の 3 スクリプト（test-inventory.sh / test-doc-map.sh /
+# test-doc-matrix.sh）が共有する処理（→ Issue #304、epic #283）。
+#
+# source 専用で、直接実行しない。呼び出し側は自分の位置から解決する:
+#
+#   . "$(dirname "$0")/lib-testdoc.sh"          # dev/scripts/ から
+#   . "$(dirname "$0")/../scripts/lib-testdoc.sh"  # dev/tests/ から
+#
+# ここに置くのは「同一の知識」を表現する処理だけ（データファイルのコメント様式・
+# 走査基点の解決規則・yq 実装の前提）。スクリプト固有のロジックは各々が持つ。
+#
+# 注: dev/flake.nix の checks.test-doc-map はサンドボックスへ dev/scripts と dev/tests を
+# 重ねて配置する。このファイルが dev/scripts/ に居るのはその複製範囲に収めるため。
+
+# データファイル（TSV）の実データだけを読む。行頭 # のコメントと空行を落とす。
+read_tsv() { grep -v '^[[:space:]]*#' "$1" | grep -v '^[[:space:]]*$'; }
+
+# 走査基点をリポジトリルートへ解決する。git 管理外ではカレント基準へフォールバックする
+# （checks 派生のサンドボックスは作業ツリーを持たないためこの経路を通る）。
+testdoc_repo_root() { git rev-parse --show-toplevel 2>/dev/null || printf '.'; }
+
+# yq が mikefarah/yq（Go 実装・v4）であることを確かめる。nixpkgs の `yq` と ambient PATH の
+# python-yq（v2/v3 系）は別実装・別構文で、取り違えると eval が黙って空を返す
+# （CASE 0 件の対応表が出る事故を実際に踏んだ）。第 1 引数は診断メッセージ用のスクリプト名。
+require_yq_go() {
+  local caller=${1:-yq}
+  if ! yq --version 2>&1 | grep -q 'mikefarah\|version v4'; then
+    echo "$caller: mikefarah/yq v4 が要る（実際: $(yq --version 2>&1)）" >&2
+    return 1
+  fi
+}
+
+# 必須コマンドの存在確認。第 1 引数は診断メッセージ用のスクリプト名、以降が必須コマンド。
+require_commands() {
+  local caller=$1
+  shift
+  local cmd missing=0
+  for cmd in "$@"; do
+    if ! command -v "$cmd" >/dev/null 2>&1; then
+      echo "$caller: $cmd が要る" >&2
+      missing=1
+    fi
+  done
+  return "$missing"
+}

--- a/dev/scripts/test-doc-matrix.sh
+++ b/dev/scripts/test-doc-matrix.sh
@@ -109,8 +109,10 @@ jq -r '
 # 目に付く形へ置き換える。
 short_id() {
   local id=$1
-  if [[ "$id" =~ ^[A-Z]+-[0-9a-f]{8} ]]; then
-    printf '%s\n' "$id" | sed -E 's/^([A-Z]+)-([0-9a-f]{8}).*/\1-\2/'
+  # 正準形の知識を 1 箇所に留めるため、判定と切り出しを同じ正規表現で行う
+  # （BASH_REMATCH の捕獲を使う。sed と二重に書くと片方だけ変える事故が起きる）。
+  if [[ "$id" =~ ^([A-Z]+)-([0-9a-f]{8}) ]]; then
+    printf '%s-%s\n' "${BASH_REMATCH[1]}" "${BASH_REMATCH[2]}"
   else
     printf '(ID 不正: %s)\n' "${id:-空}"
   fi
@@ -162,11 +164,24 @@ names_block() {
 cut -f1 "$work/inventory" | LC_ALL=C sort -u > "$work/assets"
 
 # cases（<target>\t<id>\t<name>\t<区分>）を資産側から引ける形へ並べ替える。
-# inventory に無い target（CASE 側のリネーム追従漏れ）は落とし、下の未分類検査で拾う。
 awk -F'\t' -v OFS='\t' '
   NR == FNR { asset[$1] = 1; next }
   $1 in asset { print $4, $1, $2, $3 }
 ' "$work/assets" "$work/cases" | LC_ALL=C sort > "$work/asset-rows"
+
+# inventory に無い target を指す CASE（リネーム / 削除の追従漏れ）は上の join で落ちる。
+# 「未分類」節はこれを拾わない（あちらは資産側から見た CASE 無し）。落ちた CASE が対応表の
+# どこにも現れないまま無警告になるのを避けるため、ここで別途 stderr へ出す
+# （test-doc-map.sh §1 が本来落とすが、sara ジョブは required check ではない → ADR-0050）。
+dangling_cases=$(awk -F'\t' '
+  NR == FNR { asset[$1] = 1; next }
+  !($1 in asset) { print $2 " → " $1 }
+' "$work/assets" "$work/cases")
+
+if [ -n "$dangling_cases" ]; then
+  echo "test-doc-matrix.sh: 警告: 実在しない資産を指す CASE がある（対応表から落ちる）:" >&2
+  printf '  %s\n' "$dangling_cases" >&2
+fi
 
 # --- 生成 --------------------------------------------------------------------
 

--- a/dev/scripts/test-doc-matrix.sh
+++ b/dev/scripts/test-doc-matrix.sh
@@ -190,9 +190,16 @@ fi
 # --- 生成 --------------------------------------------------------------------
 
 emit_header() {
-  local asset_total case_total
+  local asset_total case_total trailing_note=""
   asset_total=$(wc -l < "$work/assets")
   case_total=$(wc -l < "$work/cases")
+
+  # 異常系の節はヘッダから索引する。CASE 総数には dangling も含むため、本体の行数と
+  # 合わない理由をヘッダ側から辿れないと読み手が迷う。
+  if [ -s "$work/dangling-cases" ]; then
+    trailing_note=$(printf -- '- 実在しない資産を指す CASE が %d 件ある。末尾の「実在しない資産を指す CASE」を参照\n' \
+      "$(wc -l < "$work/dangling-cases")")
+  fi
 
   cat <<EOF
 # テストコード ⇔ テストドキュメント対応表
@@ -204,7 +211,7 @@ emit_header() {
 - 区分（セクション）は CASE の置き場所 \`docs/test/<区分>/\` 由来
 - ID は散文用の省略形（\`<PREFIX>-<前方 8 文字>\`）。フル ID は各 item の frontmatter を参照
 - CASE を持たない資産は末尾の「CASE を持たないテスト資産」を参照
-
+${trailing_note}
 EOF
 }
 
@@ -298,7 +305,13 @@ emit_dangling() {
   printf '| CASE | target |\n'
   printf '| --- | --- |\n'
   while IFS=$'\t' read -r file target; do
-    printf '| `%s` | `%s` |\n' "$file" "$target"
+    # 「(target 空)」は人間向けの注記なのでバッククォートで囲まない
+    # （コードリテラルとして描画されると実在する値に見える）。
+    if [ "$target" = "(target 空)" ]; then
+      printf '| `%s` | %s |\n' "$file" "$target"
+    else
+      printf '| `%s` | `%s` |\n' "$file" "$target"
+    fi
   done < "$work/dangling-cases"
   printf '\n'
 }

--- a/dev/scripts/test-doc-matrix.sh
+++ b/dev/scripts/test-doc-matrix.sh
@@ -1,0 +1,247 @@
+#!/usr/bin/env bash
+# テスト資産 ⇔ CASE ⇔ TC ⇔ RISK の対応表を Markdown 1 枚で生成する
+# （→ Issue #304、epic #283）。
+#
+# 実行:
+#   nix develop ./dev -c dev/scripts/test-doc-matrix.sh [出力パス]
+#
+# 出力パス省略時は stdout。CI は main push / workflow_dispatch のジョブで生成し
+# artifact へ上げる。**リポジトリへはコミットしない**（生成物とソースのドリフト回避）。
+#
+# ## 入力
+#
+#   - dev/scripts/test-inventory.sh --full        テスト資産とテスト名（go test -json 実行ベース）
+#   - sara report matrix --format json            CASE→TC / TC→RISK の全関係を 1 回で取得
+#   - CASE frontmatter の target（yq）            資産 → CASE の join キー
+#   - dev/tests/test-categories.tsv               区分のセクション順
+#   - dev/tests/test-doc-exclusions.tsv           CASE を持たない資産の理由
+#
+# 区分（8 区分）は CASE ファイルの置き場所 docs/test/<区分>/ から導く。パス prefix では
+# 決まらない（同 prefix が複数区分へ割れる → test-categories.tsv の注記）。
+#
+# ## 出力形式
+#
+# 区分ごとにセクションを切り、行 = テスト資産、列 = CASE（省略形 + name）/ covers する TC /
+# 上流 RISK。Go サブテスト・nix-unit attr の内訳は <details> で折りたたむ。
+# CASE を持たない資産（除外リスト）は末尾に別表で理由付きで載せる。
+
+set -uo pipefail
+
+if [ "$#" -gt 1 ]; then
+  cat >&2 <<'EOF'
+usage: test-doc-matrix.sh [出力パス]
+
+  出力パス  省略時は stdout へ書く
+EOF
+  exit 2
+fi
+
+out=${1-}
+
+for cmd in yq jq git sara; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "test-doc-matrix.sh: $cmd が要る（nix develop ./dev から実行する）" >&2
+    exit 1
+  fi
+done
+
+# yq は mikefarah/yq（Go 実装・v4）を前提にする。ambient PATH の python-yq（v2/v3 系）を
+# 拾うと構文違いで黙って空を返し、CASE 0 件の対応表が出る（実際に踏んだ）。
+if ! yq --version 2>&1 | grep -q 'mikefarah\|version v4'; then
+  echo "test-doc-matrix.sh: mikefarah/yq v4 が要る（実際: $(yq --version 2>&1)）" >&2
+  exit 1
+fi
+
+repo_root=$(git rev-parse --show-toplevel 2>/dev/null || printf '.')
+cd "$repo_root" || exit 1
+
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+
+read_tsv() { grep -v '^[[:space:]]*#' "$1" | grep -v '^[[:space:]]*$'; }
+
+# --- 入力の収集 --------------------------------------------------------------
+
+bash dev/scripts/test-inventory.sh --full > "$work/inventory" || {
+  echo "test-doc-matrix.sh: test-inventory.sh --full が失敗した" >&2
+  exit 1
+}
+
+sara report matrix --format json > "$work/matrix.json" 2>/dev/null || {
+  echo "test-doc-matrix.sh: sara report matrix が失敗した" >&2
+  exit 1
+}
+
+# CASE: <target>\t<CASE フル ID>\t<name>
+: > "$work/cases"
+while IFS= read -r file; do
+  yq --front-matter=extract -r \
+    '[(.target // ""), (.id // ""), (.name // "")] | @tsv' "$file" 2>/dev/null |
+    awk -F'\t' -v OFS='\t' '{ print $1, $2, $3 }' >> "$work/cases"
+done < <(grep -rl '^type: test_case' docs/test/ | LC_ALL=C sort)
+
+# CASE の区分（置き場所 docs/test/<区分>/ 由来）: <CASE フル ID>\t<区分>
+: > "$work/case-categories"
+while IFS= read -r file; do
+  id=$(yq --front-matter=extract -r '.id // ""' "$file" 2>/dev/null)
+  category=$(printf '%s\n' "$file" | cut -d/ -f3)
+  printf '%s\t%s\n' "$id" "$category" >> "$work/case-categories"
+done < <(grep -rl '^type: test_case' docs/test/ | LC_ALL=C sort)
+
+# CASE → TC: <CASE フル ID>\t<TC フル ID>\t<TC name>
+jq -r '
+  .rows[]
+  | select(.source_type == "Test Case")
+  | .source_id as $case
+  | .targets[]
+  | select(.target_type == "Test Condition")
+  | [$case, .id, .name] | @tsv
+' "$work/matrix.json" > "$work/case-tc"
+
+# TC → RISK: <TC フル ID>\t<RISK フル ID>\t<RISK name>
+jq -r '
+  .rows[]
+  | select(.source_type == "Test Condition")
+  | .source_id as $tc
+  | .targets[]
+  | select(.target_type == "Risk")
+  | [$tc, .id, .name] | @tsv
+' "$work/matrix.json" > "$work/tc-risk"
+
+# --- 部品 --------------------------------------------------------------------
+
+# フル ID → 散文用の省略形（<PREFIX>-<前方 8 文字>）。
+short_id() {
+  printf '%s\n' "$1" | sed -E 's/^([A-Z]+)-([0-9a-f]{8}).*/\1-\2/'
+}
+
+lookup_case() { awk -F'\t' -v t="$1" '$1 == t { print $2 "\t" $3 }' "$work/cases"; }
+lookup_category() { awk -F'\t' -v id="$1" '$1 == id { print $2 }' "$work/case-categories"; }
+
+# セル内で使う <br> 区切りの箇条書き（Markdown の表はセル内改行を許さない）。
+join_br() { paste -sd'@' - | sed 's/@/<br>/g'; }
+
+# CASE の covers する TC を「TC-xxxxxxxx name」の <br> 区切りで返す。
+tc_cell() {
+  awk -F'\t' -v id="$1" '$1 == id { print $2 "\t" $3 }' "$work/case-tc" |
+    while IFS=$'\t' read -r tc_id tc_name; do
+      printf '`%s` %s\n' "$(short_id "$tc_id")" "$tc_name"
+    done | join_br
+}
+
+# CASE の上流 RISK（covers する TC が mitigates するもの）を重複排除して返す。
+risk_cell() {
+  awk -F'\t' -v id="$1" '$1 == id { print $2 }' "$work/case-tc" |
+    while IFS= read -r tc_id; do
+      awk -F'\t' -v t="$tc_id" '$1 == t { print $2 "\t" $3 }' "$work/tc-risk"
+    done | LC_ALL=C sort -u |
+    while IFS=$'\t' read -r risk_id risk_name; do
+      printf '`%s` %s\n' "$(short_id "$risk_id")" "$risk_name"
+    done | join_br
+}
+
+# 資産のテスト名内訳。1 件でもあれば <details> で折りたたむ。
+names_block() {
+  local asset=$1
+  local names
+  names=$(awk -F'\t' -v a="$asset" '$1 == a && $3 != "" { print $3 }' "$work/inventory" | LC_ALL=C sort)
+  if [ -z "$names" ]; then
+    return
+  fi
+  printf '<details><summary>テスト名 %d 件</summary>\n\n' "$(printf '%s\n' "$names" | wc -l)"
+  printf '%s\n' "$names" | sed 's/^/- `/; s/$/`/'
+  printf '\n</details>\n'
+}
+
+# --- 生成 --------------------------------------------------------------------
+
+emit() {
+  local asset_total case_total
+  asset_total=$(cut -f1 "$work/inventory" | LC_ALL=C sort -u | wc -l)
+  case_total=$(wc -l < "$work/cases")
+
+  cat <<EOF
+# テストコード ⇔ テストドキュメント対応表
+
+テスト資産 ⇔ CASE ⇔ TC ⇔ 上流 RISK の対応。dev/scripts/test-doc-matrix.sh の生成物で、
+リポジトリへはコミットしない（CI の artifact として取得する → Issue #304）。
+
+- テスト資産: ${asset_total} 件 / CASE: ${case_total} 件
+- 区分（セクション）は CASE の置き場所 \`docs/test/<区分>/\` 由来
+- ID は散文用の省略形（\`<PREFIX>-<前方 8 文字>\`）。フル ID は各 item の frontmatter を参照
+- CASE を持たない資産は末尾の「CASE を持たないテスト資産」を参照
+
+EOF
+
+  # 区分ごとのセクション（順序は test-categories.tsv の記載順）。
+  while IFS=$'\t' read -r category description; do
+    printf '## %s\n\n%s\n\n' "$category" "$description"
+
+    # この区分に属する資産（= 区分内の CASE の target）を列挙する。
+    local rows=0
+    local buffer="$work/section"
+    : > "$buffer"
+
+    while IFS=$'\t' read -r asset _type _name; do
+      local case_row case_id case_name
+      case_row=$(lookup_case "$asset")
+      [ -z "$case_row" ] && continue
+      case_id=${case_row%%$'\t'*}
+      case_name=${case_row#*$'\t'}
+      [ "$(lookup_category "$case_id")" = "$category" ] || continue
+
+      {
+        printf '| `%s` | `%s` %s | %s | %s |\n' \
+          "$asset" "$(short_id "$case_id")" "$case_name" \
+          "$(tc_cell "$case_id")" "$(risk_cell "$case_id")"
+      } >> "$buffer"
+      rows=$((rows + 1))
+    done < <(LC_ALL=C sort -u -t$'\t' -k1,1 "$work/inventory")
+
+    if [ "$rows" -eq 0 ]; then
+      printf '（この区分に対応する CASE が無い）\n\n'
+      continue
+    fi
+
+    printf '| テスト資産 | CASE | covers する TC | 上流 RISK |\n'
+    printf '| --- | --- | --- | --- |\n'
+    cat "$buffer"
+    printf '\n'
+
+    # テスト名の内訳（表のセルに収まらないため区分ごとに続けて置く）。
+    local emitted_names=0
+    while IFS= read -r asset; do
+      local case_row case_id
+      case_row=$(lookup_case "$asset")
+      [ -z "$case_row" ] && continue
+      case_id=${case_row%%$'\t'*}
+      [ "$(lookup_category "$case_id")" = "$category" ] || continue
+
+      local block
+      block=$(names_block "$asset")
+      [ -z "$block" ] && continue
+      if [ "$emitted_names" -eq 0 ]; then
+        printf '### %s のテスト名内訳\n\n' "$category"
+        emitted_names=1
+      fi
+      printf '**`%s`**\n\n%s\n\n' "$asset" "$block"
+    done < <(cut -f1 "$work/inventory" | LC_ALL=C sort -u)
+  done < <(read_tsv dev/tests/test-categories.tsv)
+
+  # 除外リスト。CASE を持たないことが意図的な資産。
+  printf '## CASE を持たないテスト資産\n\n'
+  printf 'dev/tests/test-doc-exclusions.tsv（契約テストの逆方向除外リスト）の内容。\n\n'
+  printf '| テスト資産 | 除外理由 |\n'
+  printf '| --- | --- |\n'
+  read_tsv dev/tests/test-doc-exclusions.tsv |
+    while IFS=$'\t' read -r asset reason; do
+      printf '| `%s` | %s |\n' "$asset" "$reason"
+    done
+}
+
+if [ -n "$out" ]; then
+  emit > "$out" || exit 1
+  echo "test-doc-matrix: $out を生成した" >&2
+else
+  emit
+fi

--- a/dev/scripts/test-doc-matrix.sh
+++ b/dev/scripts/test-doc-matrix.sh
@@ -38,27 +38,16 @@ fi
 
 out=${1-}
 
-for cmd in yq jq git sara; do
-  if ! command -v "$cmd" >/dev/null 2>&1; then
-    echo "test-doc-matrix.sh: $cmd が要る（nix develop ./dev から実行する）" >&2
-    exit 1
-  fi
-done
+# shellcheck source=dev/scripts/lib-testdoc.sh
+. "$(dirname "$0")/lib-testdoc.sh"
 
-# yq は mikefarah/yq（Go 実装・v4）を前提にする。ambient PATH の python-yq（v2/v3 系）を
-# 拾うと構文違いで黙って空を返し、CASE 0 件の対応表が出る（実際に踏んだ）。
-if ! yq --version 2>&1 | grep -q 'mikefarah\|version v4'; then
-  echo "test-doc-matrix.sh: mikefarah/yq v4 が要る（実際: $(yq --version 2>&1)）" >&2
-  exit 1
-fi
+require_commands "test-doc-matrix.sh（nix develop ./dev から実行する）" yq jq git sara || exit 1
+require_yq_go test-doc-matrix.sh || exit 1
 
-repo_root=$(git rev-parse --show-toplevel 2>/dev/null || printf '.')
-cd "$repo_root" || exit 1
+cd "$(testdoc_repo_root)" || exit 1
 
 work=$(mktemp -d)
 trap 'rm -rf "$work"' EXIT
-
-read_tsv() { grep -v '^[[:space:]]*#' "$1" | grep -v '^[[:space:]]*$'; }
 
 # --- 入力の収集 --------------------------------------------------------------
 
@@ -72,21 +61,26 @@ sara report matrix --format json > "$work/matrix.json" 2>/dev/null || {
   exit 1
 }
 
-# CASE: <target>\t<CASE フル ID>\t<name>
+# CASE: <target>\t<CASE フル ID>\t<name>\t<区分>
+#
+# 1 ファイル 1 回の yq で 4 列すべてを採る。区分は置き場所（docs/test/<区分>/）から
+# 導けるので yq には要らない。ループを 2 本に割ると同じ入力に対する grep 条件が
+# 2 箇所へ散り、片方だけ変えたときに両者の集合がずれる。
 : > "$work/cases"
 while IFS= read -r file; do
-  yq --front-matter=extract -r \
-    '[(.target // ""), (.id // ""), (.name // "")] | @tsv' "$file" 2>/dev/null |
-    awk -F'\t' -v OFS='\t' '{ print $1, $2, $3 }' >> "$work/cases"
+  category=$(printf '%s\n' "$file" | cut -d/ -f3)
+  if ! row=$(yq --front-matter=extract -r \
+    '[(.target // ""), (.id // ""), (.name // "")] | @tsv' "$file" 2>/dev/null); then
+    echo "test-doc-matrix.sh: 警告: $file の frontmatter を読めなかった（対応表から落ちる）" >&2
+    continue
+  fi
+  printf '%s\t%s\n' "$row" "$category" >> "$work/cases"
 done < <(grep -rl '^type: test_case' docs/test/ | LC_ALL=C sort)
 
-# CASE の区分（置き場所 docs/test/<区分>/ 由来）: <CASE フル ID>\t<区分>
-: > "$work/case-categories"
-while IFS= read -r file; do
-  id=$(yq --front-matter=extract -r '.id // ""' "$file" 2>/dev/null)
-  category=$(printf '%s\n' "$file" | cut -d/ -f3)
-  printf '%s\t%s\n' "$id" "$category" >> "$work/case-categories"
-done < <(grep -rl '^type: test_case' docs/test/ | LC_ALL=C sort)
+if [ ! -s "$work/cases" ]; then
+  echo "test-doc-matrix.sh: CASE を 1 件も読めなかった" >&2
+  exit 1
+fi
 
 # CASE → TC: <CASE フル ID>\t<TC フル ID>\t<TC name>
 jq -r '
@@ -110,13 +104,17 @@ jq -r '
 
 # --- 部品 --------------------------------------------------------------------
 
-# フル ID → 散文用の省略形（<PREFIX>-<前方 8 文字>）。
+# フル ID → 散文用の省略形（<PREFIX>-<前方 8 文字>）。形式に合わない入力（空文字・
+# 8 文字 hex でない ID）はそのまま通すと空のコードスパンとして表に出て不整合が見えないため、
+# 目に付く形へ置き換える。
 short_id() {
-  printf '%s\n' "$1" | sed -E 's/^([A-Z]+)-([0-9a-f]{8}).*/\1-\2/'
+  local id=$1
+  if [[ "$id" =~ ^[A-Z]+-[0-9a-f]{8} ]]; then
+    printf '%s\n' "$id" | sed -E 's/^([A-Z]+)-([0-9a-f]{8}).*/\1-\2/'
+  else
+    printf '(ID 不正: %s)\n' "${id:-空}"
+  fi
 }
-
-lookup_case() { awk -F'\t' -v t="$1" '$1 == t { print $2 "\t" $3 }' "$work/cases"; }
-lookup_category() { awk -F'\t' -v id="$1" '$1 == id { print $2 }' "$work/case-categories"; }
 
 # セル内で使う <br> 区切りの箇条書き（Markdown の表はセル内改行を許さない）。
 join_br() { paste -sd'@' - | sed 's/@/<br>/g'; }
@@ -153,11 +151,28 @@ names_block() {
   printf '\n</details>\n'
 }
 
+# --- 行の事前計算 ------------------------------------------------------------
+#
+# 区分 × 資産の対応を 1 度だけ計算して両セクション（表・テスト名内訳）が共有する。
+# 区分ごとに資産を走査して都度 lookup すると、同じフィルタ条件が 2 箇所に散って
+# 片方だけ直したときに対象集合がずれ、awk のフルスキャンも資産数 × 区分数だけ走る。
+#
+# $work/asset-rows: <区分>\t<資産>\t<CASE フル ID>\t<CASE name>
+# $work/assets:     資産の一意リスト（inventory 由来）
+cut -f1 "$work/inventory" | LC_ALL=C sort -u > "$work/assets"
+
+# cases（<target>\t<id>\t<name>\t<区分>）を資産側から引ける形へ並べ替える。
+# inventory に無い target（CASE 側のリネーム追従漏れ）は落とし、下の未分類検査で拾う。
+awk -F'\t' -v OFS='\t' '
+  NR == FNR { asset[$1] = 1; next }
+  $1 in asset { print $4, $1, $2, $3 }
+' "$work/assets" "$work/cases" | LC_ALL=C sort > "$work/asset-rows"
+
 # --- 生成 --------------------------------------------------------------------
 
-emit() {
+emit_header() {
   local asset_total case_total
-  asset_total=$(cut -f1 "$work/inventory" | LC_ALL=C sort -u | wc -l)
+  asset_total=$(wc -l < "$work/assets")
   case_total=$(wc -l < "$work/cases")
 
   cat <<EOF
@@ -172,63 +187,47 @@ emit() {
 - CASE を持たない資産は末尾の「CASE を持たないテスト資産」を参照
 
 EOF
+}
 
-  # 区分ごとのセクション（順序は test-categories.tsv の記載順）。
-  while IFS=$'\t' read -r category description; do
-    printf '## %s\n\n%s\n\n' "$category" "$description"
+# 区分 1 つ分の対応表。行が無ければその旨を書く。
+emit_category_table() {
+  local category=$1 description=$2
+  printf '## %s\n\n%s\n\n' "$category" "$description"
 
-    # この区分に属する資産（= 区分内の CASE の target）を列挙する。
-    local rows=0
-    local buffer="$work/section"
-    : > "$buffer"
+  if ! awk -F'\t' -v c="$category" '$1 == c { found = 1 } END { exit !found }' "$work/asset-rows"; then
+    printf '（この区分に対応する CASE が無い）\n\n'
+    return
+  fi
 
-    while IFS=$'\t' read -r asset _type _name; do
-      local case_row case_id case_name
-      case_row=$(lookup_case "$asset")
-      [ -z "$case_row" ] && continue
-      case_id=${case_row%%$'\t'*}
-      case_name=${case_row#*$'\t'}
-      [ "$(lookup_category "$case_id")" = "$category" ] || continue
+  printf '| テスト資産 | CASE | covers する TC | 上流 RISK |\n'
+  printf '| --- | --- | --- | --- |\n'
+  awk -F'\t' -v c="$category" -v OFS='\t' '$1 == c { print $2, $3, $4 }' "$work/asset-rows" |
+    while IFS=$'\t' read -r asset case_id case_name; do
+      printf '| `%s` | `%s` %s | %s | %s |\n' \
+        "$asset" "$(short_id "$case_id")" "$case_name" \
+        "$(tc_cell "$case_id")" "$(risk_cell "$case_id")"
+    done
+  printf '\n'
+}
 
-      {
-        printf '| `%s` | `%s` %s | %s | %s |\n' \
-          "$asset" "$(short_id "$case_id")" "$case_name" \
-          "$(tc_cell "$case_id")" "$(risk_cell "$case_id")"
-      } >> "$buffer"
-      rows=$((rows + 1))
-    done < <(LC_ALL=C sort -u -t$'\t' -k1,1 "$work/inventory")
-
-    if [ "$rows" -eq 0 ]; then
-      printf '（この区分に対応する CASE が無い）\n\n'
-      continue
+# 区分 1 つ分のテスト名内訳（表のセルに収まらないため表の後に続けて置く）。
+emit_category_names() {
+  local category=$1
+  local emitted=0
+  while IFS= read -r asset; do
+    local block
+    block=$(names_block "$asset")
+    [ -z "$block" ] && continue
+    if [ "$emitted" -eq 0 ]; then
+      printf '### %s のテスト名内訳\n\n' "$category"
+      emitted=1
     fi
+    printf '**`%s`**\n\n%s\n\n' "$asset" "$block"
+  done < <(awk -F'\t' -v c="$category" '$1 == c { print $2 }' "$work/asset-rows")
+}
 
-    printf '| テスト資産 | CASE | covers する TC | 上流 RISK |\n'
-    printf '| --- | --- | --- | --- |\n'
-    cat "$buffer"
-    printf '\n'
-
-    # テスト名の内訳（表のセルに収まらないため区分ごとに続けて置く）。
-    local emitted_names=0
-    while IFS= read -r asset; do
-      local case_row case_id
-      case_row=$(lookup_case "$asset")
-      [ -z "$case_row" ] && continue
-      case_id=${case_row%%$'\t'*}
-      [ "$(lookup_category "$case_id")" = "$category" ] || continue
-
-      local block
-      block=$(names_block "$asset")
-      [ -z "$block" ] && continue
-      if [ "$emitted_names" -eq 0 ]; then
-        printf '### %s のテスト名内訳\n\n' "$category"
-        emitted_names=1
-      fi
-      printf '**`%s`**\n\n%s\n\n' "$asset" "$block"
-    done < <(cut -f1 "$work/inventory" | LC_ALL=C sort -u)
-  done < <(read_tsv dev/tests/test-categories.tsv)
-
-  # 除外リスト。CASE を持たないことが意図的な資産。
+# 除外リスト。CASE を持たないことが意図的な資産。
+emit_exclusions() {
   printf '## CASE を持たないテスト資産\n\n'
   printf 'dev/tests/test-doc-exclusions.tsv（契約テストの逆方向除外リスト）の内容。\n\n'
   printf '| テスト資産 | 除外理由 |\n'
@@ -237,6 +236,46 @@ EOF
     while IFS=$'\t' read -r asset reason; do
       printf '| `%s` | %s |\n' "$asset" "$reason"
     done
+  printf '\n'
+}
+
+# CASE も除外行も持たない資産。契約テストが本来落とす状態だが、sara ジョブは required
+# status check ではない（→ ADR-0050）ため FAIL のまま main へ入りうる。対応表が「全資産を
+# 映す」成果物である以上、黙って落とさず節として明示し stderr へも警告する。
+emit_unclassified() {
+  cut -f2 "$work/asset-rows" | LC_ALL=C sort -u > "$work/covered"
+  read_tsv dev/tests/test-doc-exclusions.tsv | cut -f1 | LC_ALL=C sort -u > "$work/excluded"
+
+  local unclassified
+  unclassified=$(LC_ALL=C comm -23 "$work/assets" <(LC_ALL=C sort -u "$work/covered" "$work/excluded"))
+
+  if [ -z "$unclassified" ]; then
+    return
+  fi
+
+  echo "test-doc-matrix.sh: 警告: CASE も除外行も持たない資産がある（対応表の「未分類」節を参照）:" >&2
+  printf '  %s\n' "$unclassified" >&2
+
+  printf '## 未分類のテスト資産\n\n'
+  printf 'CASE も除外行も持たない資産。dev/tests/test-doc-map.sh が落とすべき状態で、\n'
+  printf 'CASE を起こすか dev/tests/test-doc-exclusions.tsv へ除外理由を書く。\n\n'
+  printf '| テスト資産 |\n'
+  printf '| --- |\n'
+  printf '%s\n' "$unclassified" | sed 's/^/| `/; s/$/` |/'
+  printf '\n'
+}
+
+emit() {
+  emit_header
+
+  # 区分ごとのセクション（順序は test-categories.tsv の記載順）。
+  while IFS=$'\t' read -r category description; do
+    emit_category_table "$category" "$description"
+    emit_category_names "$category"
+  done < <(read_tsv dev/tests/test-categories.tsv)
+
+  emit_exclusions
+  emit_unclassified
 }
 
 if [ -n "$out" ]; then

--- a/dev/scripts/test-doc-matrix.sh
+++ b/dev/scripts/test-doc-matrix.sh
@@ -61,11 +61,11 @@ sara report matrix --format json > "$work/matrix.json" 2>/dev/null || {
   exit 1
 }
 
-# CASE: <target>\t<CASE フル ID>\t<name>\t<区分>
+# CASE: <target>\t<CASE フル ID>\t<name>\t<区分>\t<ファイルパス>
 #
-# 1 ファイル 1 回の yq で 4 列すべてを採る。区分は置き場所（docs/test/<区分>/）から
-# 導けるので yq には要らない。ループを 2 本に割ると同じ入力に対する grep 条件が
-# 2 箇所へ散り、片方だけ変えたときに両者の集合がずれる。
+# 1 ファイル 1 回の yq で frontmatter の 3 列を採る。区分とファイルパスは置き場所
+# （docs/test/<区分>/…）から導けるので yq には要らない。ループを 2 本に割ると同じ入力に
+# 対する grep 条件が 2 箇所へ散り、片方だけ変えたときに両者の集合がずれる。
 : > "$work/cases"
 while IFS= read -r file; do
   category=$(printf '%s\n' "$file" | cut -d/ -f3)
@@ -74,7 +74,7 @@ while IFS= read -r file; do
     echo "test-doc-matrix.sh: 警告: $file の frontmatter を読めなかった（対応表から落ちる）" >&2
     continue
   fi
-  printf '%s\t%s\n' "$row" "$category" >> "$work/cases"
+  printf '%s\t%s\t%s\n' "$row" "$category" "$file" >> "$work/cases"
 done < <(grep -rl '^type: test_case' docs/test/ | LC_ALL=C sort)
 
 if [ ! -s "$work/cases" ]; then
@@ -163,7 +163,7 @@ names_block() {
 # $work/assets:     資産の一意リスト（inventory 由来）
 cut -f1 "$work/inventory" | LC_ALL=C sort -u > "$work/assets"
 
-# cases（<target>\t<id>\t<name>\t<区分>）を資産側から引ける形へ並べ替える。
+# cases（<target>\t<id>\t<name>\t<区分>\t<ファイル>）を資産側から引ける形へ並べ替える。
 awk -F'\t' -v OFS='\t' '
   NR == FNR { asset[$1] = 1; next }
   $1 in asset { print $4, $1, $2, $3 }
@@ -171,16 +171,20 @@ awk -F'\t' -v OFS='\t' '
 
 # inventory に無い target を指す CASE（リネーム / 削除の追従漏れ）は上の join で落ちる。
 # 「未分類」節はこれを拾わない（あちらは資産側から見た CASE 無し）。落ちた CASE が対応表の
-# どこにも現れないまま無警告になるのを避けるため、ここで別途 stderr へ出す
-# （test-doc-map.sh §1 が本来落とすが、sara ジョブは required check ではない → ADR-0050）。
-dangling_cases=$(awk -F'\t' '
+# どこにも現れないまま無警告になるのを避けるため、stderr へ警告し末尾の節にも載せる
+# （test-doc-map.sh §1 が本来落とすが、sara ジョブは required check ではない → ADR-0050。
+# 未分類節と同じ扱いに揃える）。
+#
+# 診断は CASE のフル ID ではなくファイルパスで出す（追従漏れを直す人が開く対象）。
+# target が空の CASE もここに落ちるので、空は別表記にして調査先を曖昧にしない。
+awk -F'\t' -v OFS='\t' '
   NR == FNR { asset[$1] = 1; next }
-  !($1 in asset) { print $2 " → " $1 }
-' "$work/assets" "$work/cases")
+  !($1 in asset) { print $5, ($1 == "" ? "(target 空)" : $1) }
+' "$work/assets" "$work/cases" > "$work/dangling-cases"
 
-if [ -n "$dangling_cases" ]; then
-  echo "test-doc-matrix.sh: 警告: 実在しない資産を指す CASE がある（対応表から落ちる）:" >&2
-  printf '  %s\n' "$dangling_cases" >&2
+if [ -s "$work/dangling-cases" ]; then
+  echo "test-doc-matrix.sh: 警告: 実在しない資産を指す CASE がある（対応表の「実在しない資産を指す CASE」節を参照）:" >&2
+  sed 's/^/  /; s/\t/ → /' "$work/dangling-cases" >&2
 fi
 
 # --- 生成 --------------------------------------------------------------------
@@ -269,7 +273,7 @@ emit_unclassified() {
   fi
 
   echo "test-doc-matrix.sh: 警告: CASE も除外行も持たない資産がある（対応表の「未分類」節を参照）:" >&2
-  printf '  %s\n' "$unclassified" >&2
+  printf '%s\n' "$unclassified" | sed 's/^/  /' >&2
 
   printf '## 未分類のテスト資産\n\n'
   printf 'CASE も除外行も持たない資産。dev/tests/test-doc-map.sh が落とすべき状態で、\n'
@@ -277,6 +281,25 @@ emit_unclassified() {
   printf '| テスト資産 |\n'
   printf '| --- |\n'
   printf '%s\n' "$unclassified" | sed 's/^/| `/; s/$/` |/'
+  printf '\n'
+}
+
+# 実在しない資産を指す CASE。上の join で対応表の本体から落ちるため、成果物側にも節を
+# 出す（stderr 警告だけだと artifact を読む人には落ちた CASE が見えず、ヘッダの件数と
+# 本体の行数が合わない理由が分からない）。未分類節と同じ扱い。
+emit_dangling() {
+  if [ ! -s "$work/dangling-cases" ]; then
+    return
+  fi
+
+  printf '## 実在しない資産を指す CASE\n\n'
+  printf 'target が inventory に無い CASE。リネーム / 削除の追従漏れで、対応表の本体からは\n'
+  printf '落ちている。dev/tests/test-doc-map.sh §1 が落とすべき状態。\n\n'
+  printf '| CASE | target |\n'
+  printf '| --- | --- |\n'
+  while IFS=$'\t' read -r file target; do
+    printf '| `%s` | `%s` |\n' "$file" "$target"
+  done < "$work/dangling-cases"
   printf '\n'
 }
 
@@ -291,6 +314,7 @@ emit() {
 
   emit_exclusions
   emit_unclassified
+  emit_dangling
 }
 
 if [ -n "$out" ]; then

--- a/dev/scripts/test-inventory.sh
+++ b/dev/scripts/test-inventory.sh
@@ -181,7 +181,7 @@ unbuilt=$(LC_ALL=C comm -13 "$work/go-ran-packages" "$work/go-failed-packages")
 if [ -n "$unbuilt" ]; then
   echo "test-inventory.sh: テストを 1 件も走らせずに失敗したパッケージがある" >&2
   echo "  （ビルド失敗、または TestMain / init の異常終了）:" >&2
-  printf '  %s\n' "$unbuilt" >&2
+  printf '%s\n' "$unbuilt" | sed 's/^/  /' >&2
   echo "test-inventory.sh: 列挙が不完全なので中断する（go test <パッケージ> で原因を確認する）" >&2
   exit 1
 fi

--- a/dev/scripts/test-inventory.sh
+++ b/dev/scripts/test-inventory.sh
@@ -169,9 +169,9 @@ if [ ! -s "$work/go-names" ]; then
   exit 1
 fi
 
-# ビルド失敗の検出。go test は失敗パッケージへ Action=fail を出し、ビルドエラー本文は
-# output イベントとして流れる。テスト自体の fail と区別するため、run イベントを 1 つも
-# 持たないまま fail したパッケージだけを拾う。
+# 列挙が不完全になる失敗の検出。テストを 1 件も走らせずに fail したパッケージを拾う。
+# ビルド失敗のほか TestMain / init の異常終了も同じ形（Action=fail・Test=null・run
+# イベント無し）で出るため、診断は両義に留める（どちらでも列挙は欠ける）。
 jq -r 'select(.Action == "run" and .Package != null) | .Package' "$work/go-json" |
   LC_ALL=C sort -u > "$work/go-ran-packages"
 jq -r 'select(.Action == "fail" and .Package != null and .Test == null) | .Package' "$work/go-json" |
@@ -179,9 +179,10 @@ jq -r 'select(.Action == "fail" and .Package != null and .Test == null) | .Packa
 
 unbuilt=$(LC_ALL=C comm -13 "$work/go-ran-packages" "$work/go-failed-packages")
 if [ -n "$unbuilt" ]; then
-  echo "test-inventory.sh: テストを 1 件も走らせずに失敗したパッケージがある（ビルド失敗の疑い）:" >&2
+  echo "test-inventory.sh: テストを 1 件も走らせずに失敗したパッケージがある" >&2
+  echo "  （ビルド失敗、または TestMain / init の異常終了）:" >&2
   printf '  %s\n' "$unbuilt" >&2
-  echo "test-inventory.sh: 列挙が不完全なので中断する（go build ./... で原因を確認する）" >&2
+  echo "test-inventory.sh: 列挙が不完全なので中断する（go test <パッケージ> で原因を確認する）" >&2
   exit 1
 fi
 

--- a/dev/scripts/test-inventory.sh
+++ b/dev/scripts/test-inventory.sh
@@ -28,46 +28,59 @@
 
 set -uo pipefail
 
+# shellcheck source=dev/scripts/lib-testdoc.sh
+. "$(dirname "$0")/lib-testdoc.sh"
+
 usage() {
   cat >&2 <<'EOF'
-usage: test-inventory.sh (--static | --full)
+usage: test-inventory.sh (--static | --full | --module-generated-checks)
 
   --static  ファイル粒度で列挙する（fd / glob のみ。go test も nix eval も呼ばない）
   --full    テスト名粒度で列挙する（go test -json + nix eval を呼ぶため重い）
+  --module-generated-checks
+            flakeModule 由来（flake ファイルに定義行を持たない）check だけを列挙する。
+            契約テストが flake ⟷ 静的リストの grep 突合から除くために使う
 
 出力は TSV。詳細はスクリプト冒頭のコメントを参照。
 EOF
 }
 
-case "${1-}" in
+# 引数個数は mode 判定より先に見る（`--help extra` も `--static extra` も同じく exit 2）。
+if [ "$#" -ne 1 ]; then
+  usage
+  exit 2
+fi
+
+case "$1" in
   -h | --help)
     usage
     exit 0
     ;;
   --static) mode=static ;;
   --full) mode=full ;;
+  --module-generated-checks) mode=module-generated-checks ;;
   *)
     usage
     exit 2
     ;;
 esac
 
-if [ "$#" -ne 1 ]; then
-  usage
-  exit 2
-fi
-
 # 走査はリポジトリルート基準で行う（dev/ 等から叩いても同じ結果を出す）。
-repo_root=$(git rev-parse --show-toplevel 2>/dev/null || printf '.')
-cd "$repo_root" || exit 1
+cd "$(testdoc_repo_root)" || exit 1
 
 # flake check の静的リスト。`nix eval` を避けるため列挙を持つ（--static が毎 PR で
 # 回る契約テストの入力であり、flake 評価を挟むと sara ジョブに nix ビルドが要る）。
 #
-# ここは flake.nix / dev/flake.nix の checks 定義と手で揃える契約。CI の path filter が
-# flake.nix を含むため、check を増減して当リストを更新し忘れると契約テストが落ちる
-# （除外リストにも CASE にも無い check が現れる / 消えた check の CASE が残る）。
-# treefmt は treefmt-nix flakeModule が自動生成する。
+# ここは flake.nix / dev/flake.nix の checks 定義と揃える契約で、その突合は
+# dev/tests/test-doc-map.sh の §5 が機械的に行う（flake ファイルから `checks.<name> =`
+# の定義名を grep して当リストと集合比較する）。**この突合が無いと片側更新漏れは
+# 検知できない**: check を flake へ足して当リストへ足し忘れると、その check は列挙に
+# 現れないので順方向・逆方向のどちらも触れず黙って緑になる（実際に踏んだ →
+# review 2026-08-11）。逆向き（リストに残った消えた check）も、対応する CASE / 除外行が
+# 一緒に残っていれば通ってしまう。
+#
+# MODULE_GENERATED_CHECKS は flakeModule が生成し flake ファイルに定義行を持たないため
+# grep 突合の対象外にする。こちらは手で揃えるほか手段が無い。
 FLAKE_CHECKS=(
   checks.go-vet
   checks.golangci-lint
@@ -77,6 +90,15 @@ FLAKE_CHECKS=(
   checks.nput
   checks.treefmt
   dev:checks.sara-id
+  dev:checks.test-doc-map
+)
+
+# flakeModule 由来（flake ファイルに `checks.<name> =` の定義行が無い）check。
+# nix-unit は nix-unit の flakeModule、treefmt は treefmt-nix の flakeModule が生む。
+# 契約テストの §5 はこの 2 件を grep 突合から除く。
+MODULE_GENERATED_CHECKS=(
+  checks.nix-unit
+  checks.treefmt
 )
 
 # --- 列挙（ファイル粒度） ----------------------------------------------------
@@ -93,10 +115,11 @@ list_nix_unit_files() {
 
 # namaka はスナップショット実体（tests/namaka/_snapshots/）と expr.nix が対になるため、
 # CASE の粒度はディレクトリ（末尾スラッシュ）。`_` 始まりの内部ディレクトリは除く。
+# 除外は find の -name で行う（basename だけを見る）。`grep -v '/_'` はパス中のどの位置の
+# `/_` にも当たるため、走査基点が変わると意図より広く落とす。
 list_namaka_dirs() {
-  find tests/namaka -mindepth 1 -maxdepth 1 -type d 2>/dev/null |
+  find tests/namaka -mindepth 1 -maxdepth 1 -type d -not -name '_*' 2>/dev/null |
     sed 's|^\./||' |
-    grep -v '/_' |
     sed 's|$|/|'
 }
 
@@ -112,6 +135,11 @@ emit_static() {
   printf '%s\tflake-check\n' "${FLAKE_CHECKS[@]}"
 }
 
+if [ "$mode" = module-generated-checks ]; then
+  printf '%s\n' "${MODULE_GENERATED_CHECKS[@]}" | LC_ALL=C sort
+  exit 0
+fi
+
 if [ "$mode" = static ]; then
   emit_static | LC_ALL=C sort
   exit 0
@@ -119,25 +147,41 @@ fi
 
 # --- 列挙（テスト名粒度・--full のみ） ---------------------------------------
 
-for cmd in go nix jq; do
-  if ! command -v "$cmd" >/dev/null 2>&1; then
-    echo "test-inventory.sh: --full は $cmd を要する（nix develop ./dev から実行する）" >&2
-    exit 1
-  fi
-done
+require_commands "test-inventory.sh --full（nix develop ./dev から実行する）" go nix jq || exit 1
 
 work=$(mktemp -d)
 trap 'rm -rf "$work"' EXIT
 
 # Go: 実行ベースでテスト名を採る（サブテスト込み）。`go test -json` の run イベントを
-# 集め、`Test` を取り出す。ビルド失敗・テスト失敗でも run イベントは出るため、
-# 終了コードは見ない（列挙が目的で合否判定ではない）。
-go test -json ./... 2>/dev/null |
-  jq -r 'select(.Action == "run" and .Test != null) | .Test' |
+# 集め、`Test` を取り出す。テスト失敗でも run イベントは出るため終了コードは見ない
+# （列挙が目的で合否判定ではない）。
+#
+# ただしビルド失敗は別扱いにする。ビルドできなかったパッケージは run イベントを 1 つも
+# 出さないので、他パッケージが成功していれば全体は非空のまま**一部だけ静かに欠ける**。
+# 欠けた対応表を artifact として出すより、列挙が不完全であることを報告して落とす。
+go test -json ./... 2>/dev/null > "$work/go-json"
+
+jq -r 'select(.Action == "run" and .Test != null) | .Test' "$work/go-json" |
   LC_ALL=C sort -u > "$work/go-names"
 
 if [ ! -s "$work/go-names" ]; then
   echo "test-inventory.sh: go test -json からテスト名を採れなかった" >&2
+  exit 1
+fi
+
+# ビルド失敗の検出。go test は失敗パッケージへ Action=fail を出し、ビルドエラー本文は
+# output イベントとして流れる。テスト自体の fail と区別するため、run イベントを 1 つも
+# 持たないまま fail したパッケージだけを拾う。
+jq -r 'select(.Action == "run" and .Package != null) | .Package' "$work/go-json" |
+  LC_ALL=C sort -u > "$work/go-ran-packages"
+jq -r 'select(.Action == "fail" and .Package != null and .Test == null) | .Package' "$work/go-json" |
+  LC_ALL=C sort -u > "$work/go-failed-packages"
+
+unbuilt=$(LC_ALL=C comm -13 "$work/go-ran-packages" "$work/go-failed-packages")
+if [ -n "$unbuilt" ]; then
+  echo "test-inventory.sh: テストを 1 件も走らせずに失敗したパッケージがある（ビルド失敗の疑い）:" >&2
+  printf '  %s\n' "$unbuilt" >&2
+  echo "test-inventory.sh: 列挙が不完全なので中断する（go build ./... で原因を確認する）" >&2
   exit 1
 fi
 

--- a/dev/scripts/test-inventory.sh
+++ b/dev/scripts/test-inventory.sh
@@ -1,0 +1,200 @@
+#!/usr/bin/env bash
+# テスト資産の列挙を一元化する（→ Issue #304、epic #283）。
+#
+# 実行:
+#   dev/scripts/test-inventory.sh --static   # ファイル粒度（契約テストが使う）
+#   dev/scripts/test-inventory.sh --full     # テスト名粒度（対応表生成が使う）
+#
+# 出力（TSV・1 行 1 レコード・資産識別子でソート）:
+#   --static: <資産識別子>\t<種別>
+#   --full:   <資産識別子>\t<種別>\t<テスト名>
+#             テスト名を持たない種別（e2e / namaka / flake-check）は 3 列目が空。
+#
+# 資産識別子の正準表記は CASE frontmatter の target と同一の 2 規則:
+#   - 実在するファイル → リポジトリ相対パス（namaka だけは末尾スラッシュのディレクトリ）
+#   - flake check      → checks.<name> 形式（dev flake は dev:checks.<name>）
+#
+# ## 2 モードの役割分担
+#
+# --static はファイル走査（fd / glob）だけで完結し、go test も nix eval も呼ばない。
+# 契約テストは毎 PR で回るため、Go のビルドや flake 評価に依存させない（sara ジョブは
+# sara devShell だけで完結する）。flake check の一覧は静的リストで持つ（下記）。
+#
+# --full は Go のテスト名を `go test -json` の実行ベースで採る（サブテスト込み。
+# 静的 AST 解析は採らない → grilling 2026-08-11 で確定）。テスト名 → ファイルの
+# 帰属は `^func Test` の grep で決め、サブテストは親のファイルへ寄せる。
+# nix-unit は per-file の `builtins.attrNames` を引く。どちらも重いため、
+# 対応表生成（main push / workflow_dispatch）でのみ使う。
+
+set -uo pipefail
+
+usage() {
+  cat >&2 <<'EOF'
+usage: test-inventory.sh (--static | --full)
+
+  --static  ファイル粒度で列挙する（fd / glob のみ。go test も nix eval も呼ばない）
+  --full    テスト名粒度で列挙する（go test -json + nix eval を呼ぶため重い）
+
+出力は TSV。詳細はスクリプト冒頭のコメントを参照。
+EOF
+}
+
+case "${1-}" in
+  -h | --help)
+    usage
+    exit 0
+    ;;
+  --static) mode=static ;;
+  --full) mode=full ;;
+  *)
+    usage
+    exit 2
+    ;;
+esac
+
+if [ "$#" -ne 1 ]; then
+  usage
+  exit 2
+fi
+
+# 走査はリポジトリルート基準で行う（dev/ 等から叩いても同じ結果を出す）。
+repo_root=$(git rev-parse --show-toplevel 2>/dev/null || printf '.')
+cd "$repo_root" || exit 1
+
+# flake check の静的リスト。`nix eval` を避けるため列挙を持つ（--static が毎 PR で
+# 回る契約テストの入力であり、flake 評価を挟むと sara ジョブに nix ビルドが要る）。
+#
+# ここは flake.nix / dev/flake.nix の checks 定義と手で揃える契約。CI の path filter が
+# flake.nix を含むため、check を増減して当リストを更新し忘れると契約テストが落ちる
+# （除外リストにも CASE にも無い check が現れる / 消えた check の CASE が残る）。
+# treefmt は treefmt-nix flakeModule が自動生成する。
+FLAKE_CHECKS=(
+  checks.go-vet
+  checks.golangci-lint
+  checks.hm-module
+  checks.namaka
+  checks.nix-unit
+  checks.nput
+  checks.treefmt
+  dev:checks.sara-id
+)
+
+# --- 列挙（ファイル粒度） ----------------------------------------------------
+#
+# fd ではなく find + glob を使う。契約テストは sara devShell（fd 無し）から走るため。
+
+list_go_files() {
+  find cmd internal -name '*_test.go' -type f 2>/dev/null | sed 's|^\./||'
+}
+
+list_nix_unit_files() {
+  find tests/nix-unit -maxdepth 1 -name '*.nix' -type f 2>/dev/null | sed 's|^\./||'
+}
+
+# namaka はスナップショット実体（tests/namaka/_snapshots/）と expr.nix が対になるため、
+# CASE の粒度はディレクトリ（末尾スラッシュ）。`_` 始まりの内部ディレクトリは除く。
+list_namaka_dirs() {
+  find tests/namaka -mindepth 1 -maxdepth 1 -type d 2>/dev/null |
+    sed 's|^\./||' |
+    grep -v '/_' |
+    sed 's|$|/|'
+}
+
+list_e2e_files() {
+  find tests/e2e/scenarios -name '*.sh' -type f 2>/dev/null | sed 's|^\./||'
+}
+
+emit_static() {
+  list_go_files | sed 's|$|\tgo|'
+  list_nix_unit_files | sed 's|$|\tnix-unit|'
+  list_namaka_dirs | sed 's|$|\tnamaka|'
+  list_e2e_files | sed 's|$|\te2e|'
+  printf '%s\tflake-check\n' "${FLAKE_CHECKS[@]}"
+}
+
+if [ "$mode" = static ]; then
+  emit_static | LC_ALL=C sort
+  exit 0
+fi
+
+# --- 列挙（テスト名粒度・--full のみ） ---------------------------------------
+
+for cmd in go nix jq; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "test-inventory.sh: --full は $cmd を要する（nix develop ./dev から実行する）" >&2
+    exit 1
+  fi
+done
+
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+
+# Go: 実行ベースでテスト名を採る（サブテスト込み）。`go test -json` の run イベントを
+# 集め、`Test` を取り出す。ビルド失敗・テスト失敗でも run イベントは出るため、
+# 終了コードは見ない（列挙が目的で合否判定ではない）。
+go test -json ./... 2>/dev/null |
+  jq -r 'select(.Action == "run" and .Test != null) | .Test' |
+  LC_ALL=C sort -u > "$work/go-names"
+
+if [ ! -s "$work/go-names" ]; then
+  echo "test-inventory.sh: go test -json からテスト名を採れなかった" >&2
+  exit 1
+fi
+
+# テスト名 → ファイルの帰属表。トップレベル関数は `^func Test` の grep で決まる。
+# 同名のトップレベル関数はパッケージを跨いでも Go の慣習上まず衝突しないが、
+# 万一衝突したら両ファイルへ出す（列挙の欠落より重複のほうが害が小さい）。
+: > "$work/func-map"
+while IFS= read -r file; do
+  grep -oE '^func (Test[A-Za-z0-9_]*)' "$file" |
+    sed 's/^func //' |
+    while IFS= read -r fn; do
+      printf '%s\t%s\n' "$fn" "$file" >> "$work/func-map"
+    done
+done < <(list_go_files)
+
+# サブテスト（Parent/Sub）は親のファイルへ寄せる。
+while IFS= read -r name; do
+  toplevel=${name%%/*}
+  files=$(awk -F'\t' -v fn="$toplevel" '$1 == fn { print $2 }' "$work/func-map")
+  if [ -z "$files" ]; then
+    # 帰属先不明。列挙から落とすと対応表が黙って欠けるため、識別子を空にせず報告する。
+    echo "test-inventory.sh: 警告: テスト $name の定義ファイルを特定できなかった" >&2
+    continue
+  fi
+  while IFS= read -r file; do
+    printf '%s\tgo\t%s\n' "$file" "$name"
+  done <<< "$files"
+done < "$work/go-names" > "$work/go-rows"
+
+# nix-unit: per-file の attrNames。アグリゲータ（tests/nix-unit.nix）は各ファイルを
+# `{ lib, nput }` で import して `//` マージするだけなので、同じシグネチャで直接呼ぶ。
+# getFlake のため --impure が要る（--full は対応表生成専用なので許容する）。
+: > "$work/nix-unit-rows"
+while IFS= read -r file; do
+  names=$(nix eval --impure --json --expr "
+    let
+      flake = builtins.getFlake (builtins.toString ./.);
+      lib = flake.inputs.nixpkgs.lib;
+      nput = import ./lib;
+    in
+    builtins.attrNames (import ./$file { inherit lib nput; })
+  " 2>/dev/null | jq -r '.[]')
+  if [ -z "$names" ]; then
+    echo "test-inventory.sh: 警告: $file から nix-unit のテスト名を採れなかった" >&2
+    printf '%s\tnix-unit\t\n' "$file" >> "$work/nix-unit-rows"
+    continue
+  fi
+  while IFS= read -r name; do
+    printf '%s\tnix-unit\t%s\n' "$file" "$name" >> "$work/nix-unit-rows"
+  done <<< "$names"
+done < <(list_nix_unit_files)
+
+# e2e / namaka / flake check は static と同粒度（テスト名の内訳を持たない）。
+{
+  cat "$work/go-rows"
+  cat "$work/nix-unit-rows"
+  list_namaka_dirs | sed 's|$|\tnamaka\t|'
+  list_e2e_files | sed 's|$|\te2e\t|'
+  printf '%s\tflake-check\t\n' "${FLAKE_CHECKS[@]}"
+} | LC_ALL=C sort

--- a/dev/tests/test-categories.tsv
+++ b/dev/tests/test-categories.tsv
@@ -1,0 +1,22 @@
+# テスト資産の 8 区分（docs/test/<対象>/ のディレクトリ名）の正本。
+#
+# この表が「どの区分が存在するか」と「対応表でどの順に並べるか」の SSOT
+# （→ Issue #304、epic #283）。CLAUDE.md の 8 区分表は読み物としての要約で、
+# 規範はこちら。区分を増減するときはここと docs/test/ のディレクトリを揃える。
+#
+# **個々のテスト資産がどの区分に属するかはこの表では持たない**。区分は CASE
+# ファイルの置き場所（docs/test/<区分>/）から導く。パス prefix では決まらない
+# （internal/engine/*_test.go は 5 区分・tests/e2e/scenarios/* は 4 区分へ割れる）
+# ため、prefix 表を持つと CASE の置き場所との二重管理になる。
+#
+# 形式: <区分>\t<説明>
+# 行頭 # はコメント、空行は無視。列の区切りはタブ 1 個。
+# 区分の並び順 = 対応表のセクション順（この表の記載順）。
+manifest-eval	nix-unit 全 7 + namaka manifest-project（manifest の純評価）
+engine-core	internal/engine の engine / dryrun / preflight、internal/planner
+copy	copytree / copy、e2e 04-copy
+migration-stale	preremove_generalization / staleremove、e2e 03-stale
+atomicity	undo / undo_journal / backup、engine の lock + internal/lock
+generations	generations / reset / result_extensions / drift、internal/paths、e2e 02-home
+cli-json	cmd/nput/ の全テストファイル
+integration	checks.hm-module、e2e 01/05/06/07、internal/gitutil、internal/manifest

--- a/dev/tests/test-doc-exclusions.tsv
+++ b/dev/tests/test-doc-exclusions.tsv
@@ -19,3 +19,4 @@ checks.treefmt	フォーマッタ検査（treefmt-nix が自動生成）。quali
 checks.namaka	namaka アグリゲータ。leaf の tests/namaka/<name>/ を CASE が持つ
 checks.nix-unit	nix-unit アグリゲータ。leaf の tests/nix-unit/*.nix を CASE が持つ
 dev:checks.sara-id	sara-id の採番契約。TP-d7da4065 のみを持ち TC / CASE へ展開しない
+dev:checks.test-doc-map	CASE ⇔ テストコード対応の契約テスト自身。自分を CASE で覆うと循環する

--- a/dev/tests/test-doc-exclusions.tsv
+++ b/dev/tests/test-doc-exclusions.tsv
@@ -1,0 +1,21 @@
+# 逆方向の照合（テスト資産 → CASE）から除外するテスト資産の正本。
+#
+# 契約テスト（dev/tests/test-doc-map.sh）は「全テスト資産に CASE がある」ことを
+# 検証するが、CASE を持たないことが意図的な資産をここへ列挙する
+# （→ Issue #304、epic #283）。
+#
+# 形式: <資産識別子>\t<除外理由>
+# 行頭 # はコメント、空行は無視。列の区切りはタブ 1 個。
+# 資産識別子の正準表記は CASE frontmatter の target と同じ 2 規則
+# （実在するファイルはリポジトリ相対パス / flake check は checks.<name>）。
+#
+# ここに載せるのは「テスト資産として列挙されるが CASE を持たない」ものだけ。
+# そもそも inventory が列挙しないもの（go-coverage = quality 担当のカバレッジ計測で
+# check として存在しない、等）は列挙不要。
+checks.go-vet	静的解析（ビルド健全性）。テスト資産ではなく quality の担当
+checks.golangci-lint	静的 lint。テスト資産ではなく quality の担当
+checks.nput	buildGoModule のビルド + go test 実行。個々の *_test.go を CASE が持つ
+checks.treefmt	フォーマッタ検査（treefmt-nix が自動生成）。quality の担当
+checks.namaka	namaka アグリゲータ。leaf の tests/namaka/<name>/ を CASE が持つ
+checks.nix-unit	nix-unit アグリゲータ。leaf の tests/nix-unit/*.nix を CASE が持つ
+dev:checks.sara-id	sara-id の採番契約。TP-d7da4065 のみを持ち TC / CASE へ展開しない

--- a/dev/tests/test-doc-exclusions.tsv
+++ b/dev/tests/test-doc-exclusions.tsv
@@ -10,8 +10,11 @@
 # （実在するファイルはリポジトリ相対パス / flake check は checks.<name>）。
 #
 # ここに載せるのは「テスト資産として列挙されるが CASE を持たない」ものだけ。
-# そもそも inventory が列挙しないもの（go-coverage = quality 担当のカバレッジ計測で
-# check として存在しない、等）は列挙不要。
+# そもそも inventory が列挙しないものは列挙不要:
+#   - go-coverage（quality 担当のカバレッジ計測。flake check として存在しない）
+#   - dev/scripts/*.sh（inventory / 対応表生成の実装。テスト資産ではなく道具）
+#   - dev/tests/*.sh 自体（契約テストの実装。flake check 経由の dev:checks.* として
+#     列挙されるぶんは下に載っている）
 checks.go-vet	静的解析（ビルド健全性）。テスト資産ではなく quality の担当
 checks.golangci-lint	静的 lint。テスト資産ではなく quality の担当
 checks.nput	buildGoModule のビルド + go test 実行。個々の *_test.go を CASE が持つ

--- a/dev/tests/test-doc-map.sh
+++ b/dev/tests/test-doc-map.sh
@@ -13,8 +13,8 @@
 #       除外リストが実在する資産だけを挙げている
 #   5.  静的リストの健全性 — test-inventory.sh の FLAKE_CHECKS が flake ファイルの
 #       checks 定義と一致する（片側更新漏れの検出）
-#   6.  自己検証 — §1〜§3 が呼ぶ judge_* 関数そのものを合成フィクスチャへ当て、
-#       違反なしで真・違反ありで偽の両側へ倒れることを確かめる
+#   6.  自己検証 — §1〜§3 が呼ぶ judge_* と、その結果を pass / fault へ振り分ける
+#       run_judge を合成フィクスチャへ当て、期待どおりに振る舞うことを確かめる
 #
 # ## 純静的であること
 #
@@ -68,6 +68,11 @@ bash "$inventory_sh" --static > "$work/inventory" || {
   exit 1
 }
 cut -f1 "$work/inventory" | LC_ALL=C sort > "$work/assets"
+
+# 逆方向（§2）の走査対象。§4 の stale 除外検査も同じ変数を読み、「除外リストは走査対象の
+# 部分集合である」という同じ契約を両者が共有することを配線で示す（契約そのものの検査は
+# judge_reverse 内で行う。そちらが引数配線の取り違えを検知する → 4 周目のレビュー）。
+reverse_scan=$work/assets
 
 if [ ! -s "$work/assets" ]; then
   echo "test-doc-map.sh: テスト資産を 1 件も列挙できなかった" >&2
@@ -130,14 +135,26 @@ judge_forward() {
   return "$violated"
 }
 
-# 逆方向: assets の各要素が covered か exclusions のどちらかに在るか。
-# 第 1 引数は「走査対象」、第 2・第 3 は「そこに在れば違反を消す集合」。取り違えると
-# covered ⊆ assets が常に成り立つため判定が永久に緑になるので、実データ経路の配線を
-# §6 が別途固定する（→ 3 周目のレビュー）。
+# 逆方向: scan_target の各要素が covered か exclusions のどちらかに在るか。
+# 第 1 引数は「走査対象」、第 2・第 3 は「そこに在れば違反を消す集合」。
 # 第 4 引数は診断メッセージに載せる除外リストのパス（案内文にのみ使う）。
 judge_reverse() {
   local scan_target=$1 covered=$2 exclusions=$3 exclusions_hint=${4:-$3}
   local violated=0 asset
+
+  # 引数配線の自己防衛。免除集合（covered / exclusions）は走査対象の部分集合でなければ
+  # 意味を成さない（走査対象に居ない要素を免除しても効かない）。走査対象と免除集合を
+  # 取り違えると判定は恒常 green へ縮退し、データの性質を見るアサーションでは恒真に
+  # なって検知できない（→ 4 周目のレビューで実証）。契約を関数内で主張すれば、
+  # 取り違えは縮退ではなく違反として現れる。
+  local stray
+  stray=$(LC_ALL=C comm -23 <(LC_ALL=C sort -u "$covered" "$exclusions") \
+    <(LC_ALL=C sort -u "$scan_target"))
+  if [ -n "$stray" ]; then
+    echo "逆方向: 免除集合が走査対象の部分集合でない（引数配線の誤り。走査対象に無い: $(printf '%s' "$stray" | tr '\n' ' ')）"
+    return 1
+  fi
+
   while IFS= read -r asset; do
     if grep -qxF "$asset" "$covered"; then
       continue
@@ -201,7 +218,7 @@ run_judge "全 CASE の target が実在するテスト資産を指す" \
 cut -f2 "$work/case-targets" | grep -v '^$' | LC_ALL=C sort -u > "$work/covered"
 
 run_judge "全テスト資産に CASE がある（除外リストを除く）" \
-  judge_reverse "$work/assets" "$work/covered" "$work/exclusions" "$exclusions_tsv"
+  judge_reverse "$reverse_scan" "$work/covered" "$work/exclusions" "$exclusions_tsv"
 
 # --- 3. 1:1 一意性 -----------------------------------------------------------
 
@@ -238,7 +255,7 @@ fi
 # 同名の資産を後で追加したときに CASE 無しのまま黙って通る。
 stale_exclusion=0
 while IFS= read -r asset; do
-  if ! grep -qxF "$asset" "$work/assets"; then
+  if ! grep -qxF "$asset" "$reverse_scan"; then
     fault "除外リストの '$asset' は列挙されるテスト資産に無い（stale な除外）"
     stale_exclusion=1
   fi
@@ -368,8 +385,11 @@ printf 'CASE-a.md\tgone_test.go\n' > "$self/case-targets-dangling"
 # 分岐の生死が見えない）。
 printf 'CASE-b.md\t\n' > "$self/case-targets-empty"
 printf '\na_test.go\n' > "$self/assets-with-empty"
-# 逆方向: covered にも exclusions にも無い資産。
+# 逆方向: covered にも exclusions にも無い資産（c_test.go）。免除集合は走査対象の
+# 部分集合に保つ（そうしないと judge_reverse の部分集合契約が先に発火して、
+# 意図した未カバー判定の分岐を踏まない）。
 printf 'a_test.go\nc_test.go\n' > "$self/assets-uncovered"
+printf 'a_test.go\n' > "$self/covered-subset"
 # 逆方向: 除外リストだけで消える資産（除外経路の単独検証用）。
 printf 'c_test.go\n' > "$self/assets-c-only"
 # 1:1: 同じ target を 2 CASE が張る。
@@ -419,7 +439,17 @@ printf 'c_test.go\n' > "$self/exclusions-c"
 expect_judge_pass "judge_reverse（除外リスト経路）" \
   judge_reverse "$self/assets-c-only" "$self/covered-empty" "$self/exclusions-c"
 expect_judge_fail "judge_reverse（どちらにも無い）" \
-  judge_reverse "$self/assets-uncovered" "$self/covered-ok" "$self/exclusions-empty"
+  judge_reverse "$self/assets-uncovered" "$self/covered-subset" "$self/exclusions-empty"
+# 部分集合契約。走査対象に無い要素を免除集合が含む配線（引数の取り違えがこの形になる）で
+# 落ちること。診断が未カバー判定ではなく配線の誤りを指すことも固定する。
+expect_judge_fail "judge_reverse（走査対象と免除集合の取り違え）" \
+  judge_reverse "$self/covered-ok" "$self/assets-uncovered" "$self/exclusions-c"
+
+wiring_diagnostic=$(judge_reverse "$self/covered-ok" "$self/assets-uncovered" "$self/exclusions-c")
+if ! printf '%s' "$wiring_diagnostic" | grep -q '引数配線の誤り'; then
+  fault "自己検証: judge_reverse（部分集合契約）— 配線の誤りを指す診断が出ない（実際: ${wiring_diagnostic:-空}）"
+  self_fail=1
+fi
 
 expect_judge_pass "judge_unique" \
   judge_unique "$self/case-targets-ok"
@@ -443,12 +473,12 @@ probe_run_judge() {
   run_judge "probe" "$@" >/dev/null 2>&1
   local status=$?
 
-  # 呼び出し側へ戻す前に本来の実装を復帰させる。
-  unset -f pass fault
   printf '%d\t%d\t%d\n' "$pass_count" "$fault_count" "$status"
 }
 
-# run_judge は関数定義を上書きするため、サブシェルで走らせて本体へ漏らさない。
+# probe_run_judge は pass / fault を差し替えるため、必ずコマンド置換（サブシェル）で
+# 呼ぶ。本体の定義はサブシェル内でしか隠れないので、終了と同時に元へ戻る。直接呼ぶと
+# 以降の pass / fault が失われ、アサーションが黙って出力から消える。
 probe_ok=$(probe_run_judge judge_always_ok)
 probe_violation=$(probe_run_judge judge_always_violates)
 probe_silent=$(probe_run_judge judge_violates_silently)
@@ -471,14 +501,6 @@ check_probe "違反なし" "$probe_ok" 1 0 0
 check_probe "違反あり" "$probe_violation" 0 1 1
 # 違反ありだが診断行が空 → 黙って通さず fault へ倒す。
 check_probe "違反ありで診断が空" "$probe_silent" 0 1 1
-
-# 実データ経路の引数配線。judge_reverse の走査対象と免除集合を取り違えると、
-# covered ⊆ assets が常に成り立つため判定が永久に緑になる（縮退が矛盾として現れない）。
-# 「covered は assets の部分集合である」を前提として明示し、取り違えを検出可能にする。
-if [ -n "$(LC_ALL=C comm -23 "$work/covered" "$work/assets")" ]; then
-  fault "自己検証: covered ⊄ assets（§2 の引数配線が取り違えられている可能性がある）"
-  self_fail=1
-fi
 
 # 実データ側の入力の非空性。assets / covered が空だと §1〜§3 が空虚に真になる
 # （exclusions は空でも §2 が単に厳しく判定するだけなので、ここには含めない）。

--- a/dev/tests/test-doc-map.sh
+++ b/dev/tests/test-doc-map.sh
@@ -13,7 +13,8 @@
 #       除外リストが実在する資産だけを挙げている
 #   5.  静的リストの健全性 — test-inventory.sh の FLAKE_CHECKS が flake ファイルの
 #       checks 定義と一致する（片側更新漏れの検出）
-#   6.  自己検証 — 合成フィクスチャで §1〜§3 のアサーションが期待どおり FAIL する
+#   6.  自己検証 — §1〜§3 が呼ぶ judge_* 関数そのものを合成フィクスチャへ当て、
+#       違反なしで真・違反ありで偽の両側へ倒れることを確かめる
 #
 # ## 純静的であること
 #
@@ -102,62 +103,99 @@ fi
 
 read_tsv "$exclusions_tsv" | cut -f1 | LC_ALL=C sort > "$work/exclusions"
 
+# --- 判定（§1〜§3 の本体。§6 が同じ関数を合成フィクスチャで叩く） --------------
+#
+# 判定を関数へ切り出して §1〜§3 と §6 の双方から呼ぶ。§6 が判定を再実装すると
+# 「アサーションが常に真を返す退行」を検知できない（プリミティブの動作確認になるだけで、
+# §1 の条件を `if false` へ差し替えても緑のまま通る → review 2 周目で実証された）。
+#
+# 各関数は診断行を stdout へ出し、違反があれば 1 を返す。呼び出し側が pass / fault へ
+# 振り分ける。ファイルパスを引数で受けるので、実データでも合成フィクスチャでも同じ経路。
+
+# 順方向: case_targets（<ファイル>\t<target>）の target が assets に在るか。
+# $3 は診断メッセージ用の除外リストパス（案内文にのみ使う）。
+judge_forward() {
+  local case_targets=$1 assets=$2
+  local violated=0 file target
+  while IFS=$'\t' read -r file target; do
+    if [ -z "$target" ]; then
+      echo "順方向: $file に target が無い（docs/model.yaml で required なので sara check も落ちる）"
+      violated=1
+      continue
+    fi
+    if ! grep -qxF "$target" "$assets"; then
+      echo "順方向: $file の target '$target' に対応するテスト資産が無い（リネーム / 削除の追従漏れ）"
+      violated=1
+    fi
+  done < "$case_targets"
+  return "$violated"
+}
+
+# 逆方向: assets の各要素が covered か exclusions のどちらかに在るか。
+judge_reverse() {
+  local assets=$1 covered=$2 exclusions=$3 exclusions_hint=${4:-$3}
+  local violated=0 asset
+  while IFS= read -r asset; do
+    if grep -qxF "$asset" "$covered"; then
+      continue
+    fi
+    if grep -qxF "$asset" "$exclusions"; then
+      continue
+    fi
+    echo "逆方向: テスト資産 '$asset' に CASE が無い（CASE を起こすか $exclusions_hint へ除外理由付きで追加する）"
+    violated=1
+  done < "$assets"
+  return "$violated"
+}
+
+# 1:1: case_targets の target に重複が無いか。
+judge_unique() {
+  local case_targets=$1
+  local dups target owners
+  dups=$(cut -f2 "$case_targets" | grep -v '^$' | LC_ALL=C sort | uniq -d)
+  if [ -z "$dups" ]; then
+    return 0
+  fi
+  while IFS= read -r target; do
+    owners=$(awk -F'\t' -v t="$target" '$2 == t { printf "%s ", $1 }' "$case_targets")
+    echo "1:1 違反: '$target' に複数の CASE が張られている（$owners）"
+  done <<< "$dups"
+  return 1
+}
+
+# 判定関数を実データへ当て、診断行を fault へ流す。
+run_judge() {
+  local ok_message=$1
+  shift
+  local diagnostics
+  if diagnostics=$("$@"); then
+    pass "$ok_message"
+    return 0
+  fi
+  while IFS= read -r line; do
+    [ -n "$line" ] && fault "$line"
+  done <<< "$diagnostics"
+  return 1
+}
+
 # --- 1. 順方向（CASE の target が実在する） ----------------------------------
 
-missing_target=0
-dangling=0
-while IFS=$'\t' read -r file target; do
-  if [ -z "$target" ]; then
-    fault "順方向: $file に target が無い（docs/model.yaml で required なので sara check も落ちる）"
-    missing_target=1
-    continue
-  fi
-  if ! grep -qxF "$target" "$work/assets"; then
-    fault "順方向: $file の target '$target' に対応するテスト資産が無い（リネーム / 削除の追従漏れ）"
-    dangling=1
-  fi
-done < "$work/case-targets"
-
-if [ "$missing_target" -eq 0 ]; then
-  pass "全 CASE が target を持つ"
-fi
-if [ "$dangling" -eq 0 ]; then
-  pass "全 CASE の target が実在するテスト資産を指す"
-fi
+run_judge "全 CASE の target が実在するテスト資産を指す" \
+  judge_forward "$work/case-targets" "$work/assets"
 
 # --- 2. 逆方向（全テスト資産に CASE がある） ---------------------------------
 
 cut -f2 "$work/case-targets" | grep -v '^$' | LC_ALL=C sort -u > "$work/covered"
 
-uncovered=0
-while IFS= read -r asset; do
-  if grep -qxF "$asset" "$work/covered"; then
-    continue
-  fi
-  if grep -qxF "$asset" "$work/exclusions"; then
-    continue
-  fi
-  fault "逆方向: テスト資産 '$asset' に CASE が無い（CASE を起こすか $exclusions_tsv へ除外理由付きで追加する）"
-  uncovered=1
-done < "$work/assets"
-
-if [ "$uncovered" -eq 0 ]; then
-  pass "全テスト資産に CASE がある（除外リストを除く）"
-fi
+run_judge "全テスト資産に CASE がある（除外リストを除く）" \
+  judge_reverse "$work/assets" "$work/covered" "$work/exclusions" "$exclusions_tsv"
 
 # --- 3. 1:1 一意性 -----------------------------------------------------------
 
 # 順方向の 1:1（1 CASE = 1 target）は frontmatter が単一 text であることで型に担保
 # されている（!list text ではない）。ここで見るのは逆方向の重複だけ。
-dup_targets=$(cut -f2 "$work/case-targets" | grep -v '^$' | LC_ALL=C sort | uniq -d)
-if [ -z "$dup_targets" ]; then
-  pass "1 テスト資産に張られた CASE は高々 1 件（1:1）"
-else
-  while IFS= read -r target; do
-    owners=$(awk -F'\t' -v t="$target" '$2 == t { printf "%s ", $1 }' "$work/case-targets")
-    fault "1:1 違反: '$target' に複数の CASE が張られている（$owners）"
-  done <<< "$dup_targets"
-fi
+run_judge "1 テスト資産に張られた CASE は高々 1 件（1:1）" \
+  judge_unique "$work/case-targets"
 
 # --- 4. データファイルの健全性 -----------------------------------------------
 
@@ -221,13 +259,16 @@ fi
 # 黙って緑になる（実際に踏んだ）。sara-id.sh §6b が prefix マップを model.yaml と
 # 突合するのと同じ発想で、flake ファイルの定義行を grep して集合比較する。
 
-# 静的リストから flake check の識別子を採る。`dev:` 接頭辞で flake ファイルを振り分ける。
-bash "$inventory_sh" --static |
-  awk -F'\t' '$2 == "flake-check" { print $1 }' |
+# 静的リストの flake check 識別子。冒頭で保存した --static の出力から採る
+# （再実行すると終了ステータスの扱いが冒頭と二重になる）。
+awk -F'\t' '$2 == "flake-check" { print $1 }' "$work/inventory" |
   LC_ALL=C sort > "$work/listed-checks"
 
 # flakeModule 生成分（flake ファイルに定義行が無い）は grep 突合の対象外。
-bash "$inventory_sh" --module-generated-checks | LC_ALL=C sort > "$work/module-checks"
+bash "$inventory_sh" --module-generated-checks | LC_ALL=C sort > "$work/module-checks" || {
+  echo "test-doc-map.sh: $inventory_sh --module-generated-checks が失敗した" >&2
+  exit 1
+}
 
 # flake ファイル側の定義。`checks.<name> =` の行から名前を採る。
 extract_checks() {
@@ -246,7 +287,13 @@ else
   # 静的リスト（module 生成分を除く）⟷ flake の定義。
   LC_ALL=C comm -23 "$work/listed-checks" "$work/module-checks" > "$work/listed-hand"
 
-  only_flake=$(LC_ALL=C comm -13 "$work/listed-hand" "$work/defined-checks" | tr '\n' ' ')
+  # module 生成分は only_flake から除く。除かないと「flake に在るが FLAKE_CHECKS に無い
+  # → 追加せよ」と出るが、実際は既に FLAKE_CHECKS に在るので指示に従っても直らない
+  # （正しい診断は下の wrongly_module 側が出す）。
+  LC_ALL=C comm -13 "$work/listed-hand" "$work/defined-checks" |
+    LC_ALL=C comm -23 - "$work/module-checks" > "$work/only-flake"
+
+  only_flake=$(tr '\n' ' ' < "$work/only-flake")
   only_list=$(LC_ALL=C comm -23 "$work/listed-hand" "$work/defined-checks" | tr '\n' ' ')
 
   if [ -z "$only_flake" ] && [ -z "$only_list" ]; then
@@ -268,47 +315,102 @@ else
   fi
 fi
 
-# --- 6. 自己検証（アサーションが本当に落ちるか） -----------------------------
-
-# §1〜§3 は「今のリポジトリが正しい」ことだけを見るため、アサーションが誤って常に真を
-# 返す退行が起きても緑のまま通る。合成フィクスチャで各判定ロジックが期待どおり FAIL 側へ
-# 倒れることを確かめる（リポジトリの実ファイルには一切触らない）。
+# --- 6. 自己検証（判定関数が両側へ倒れるか） ---------------------------------
 #
-# ここで検証するのは判定の骨（grep -qxF による集合演算・uniq -d による重複検出）で、
-# §1〜§3 が使っているものと同じ手段を同じ向きで叩く。
+# §1〜§3 は「今のリポジトリが正しい」ことだけを見るため、判定が誤って常に真を返す退行が
+# 起きても緑のまま通る。ここでは §1〜§3 が実際に呼んでいる judge_* 関数そのものを、
+# 合成フィクスチャ（$work/self/ 配下・リポジトリの実ファイルには触らない）へ当てて、
+# 違反なしで真・違反ありで偽の**両側へ**倒れることを確かめる。
+#
+# 判定を §6 内で再実装してはいけない。再実装すると grep / uniq の動作確認になるだけで、
+# §1 の条件を `if false` へ差し替えても緑のまま通る（2 周目のレビューで実証された）。
+
+self=$work/self
+mkdir -p "$self"
+
+# 違反のないフィクスチャ。
+printf 'a_test.go\nb_test.go\n' > "$self/assets-ok"
+printf 'CASE-a.md\ta_test.go\nCASE-b.md\tb_test.go\n' > "$self/case-targets-ok"
+printf 'a_test.go\nb_test.go\n' > "$self/covered-ok"
+printf '\n' > "$self/exclusions-empty"
+
+# 違反のあるフィクスチャ。判定内の分岐ごとに 1 つずつ用意する。1 つのフィクスチャで
+# 複数の分岐を同時に踏ませると、片方の分岐が死んでももう片方が違反を返して緑になり、
+# 「常に真になる退行」を取りこぼす（実際に踏んだ）。
+# 順方向 (a): 実在しない target を指す。
+printf 'CASE-a.md\tgone_test.go\n' > "$self/case-targets-dangling"
+# 順方向 (b): target が空。
+printf 'CASE-b.md\t\n' > "$self/case-targets-empty"
+# 逆方向: covered にも exclusions にも無い資産。
+printf 'a_test.go\nc_test.go\n' > "$self/assets-uncovered"
+# 逆方向: 除外リストだけで消える資産（除外経路の単独検証用）。
+printf 'c_test.go\n' > "$self/assets-c-only"
+# 1:1: 同じ target を 2 CASE が張る。
+printf 'CASE-a.md\ta_test.go\nCASE-b.md\ta_test.go\n' > "$self/case-targets-dup"
 
 self_fail=0
 
-# 順方向: 実在しない target が assets に無いと判定されること。
-if grep -qxF 'internal/does/not/exist_test.go' "$work/assets"; then
-  fault "自己検証: 実在しない target が資産として在ると判定された"
-  self_fail=1
-fi
+# 期待どおりに真（違反なし）を返すか。
+expect_judge_pass() {
+  local label=$1
+  shift
+  if ! "$@" >/dev/null; then
+    fault "自己検証: $label — 違反のないフィクスチャで偽を返した（判定が過剰）"
+    self_fail=1
+  fi
+}
 
-# 逆方向: 除外にも CASE にも無い架空の資産が未カバーと判定されること。
-if grep -qxF 'internal/phantom/phantom_test.go' "$work/covered" ||
-  grep -qxF 'internal/phantom/phantom_test.go' "$work/exclusions"; then
-  fault "自己検証: 架空の資産がカバー済み / 除外済みと判定された"
-  self_fail=1
-fi
+# 期待どおりに偽（違反あり）を返し、診断行を出すか。
+expect_judge_fail() {
+  local label=$1
+  shift
+  local diagnostics
+  if diagnostics=$("$@"); then
+    fault "自己検証: $label — 違反のあるフィクスチャで真を返した（判定が常に真になる退行）"
+    self_fail=1
+  elif [ -z "$diagnostics" ]; then
+    fault "自己検証: $label — 偽を返したが診断行が空（失敗の原因が報告されない）"
+    self_fail=1
+  fi
+}
 
-# 1:1: 同じ target を 2 度並べたら uniq -d が拾うこと。
-synthetic_dup=$(printf 'a\na\nb\n' | LC_ALL=C sort | uniq -d)
-if [ "$synthetic_dup" != "a" ]; then
-  fault "自己検証: 重複検出（uniq -d）が機能していない（実際: $synthetic_dup）"
-  self_fail=1
-fi
+expect_judge_pass "judge_forward" \
+  judge_forward "$self/case-targets-ok" "$self/assets-ok"
+expect_judge_fail "judge_forward（実在しない target）" \
+  judge_forward "$self/case-targets-dangling" "$self/assets-ok"
+# target が空の分岐は下の grep 分岐と重なる（空文字は assets にも無いので、この分岐が
+# 死んでも違反自体は報告される。失われるのは「target が無い」という具体的な診断だけ）。
+# よってこのアサーションは分岐の生死ではなく、空 target が違反として扱われることを固定する。
+expect_judge_fail "judge_forward（target が空）" \
+  judge_forward "$self/case-targets-empty" "$self/assets-ok"
 
-# 入力の非空性: 検査対象の 3 集合が空だと全アサーションが空虚に真になる。
-for name in assets covered exclusions; do
+# 逆方向は「covered に在る」「exclusions に在る」の 2 経路で違反を消す。両経路を
+# それぞれ単独で確かめる（片方が死んでももう片方が拾って緑になるのを防ぐ）。
+expect_judge_pass "judge_reverse（covered 経路）" \
+  judge_reverse "$self/assets-ok" "$self/covered-ok" "$self/exclusions-empty"
+printf 'c_test.go\n' > "$self/exclusions-c"
+printf '\n' > "$self/covered-empty"
+expect_judge_pass "judge_reverse（除外リスト経路）" \
+  judge_reverse "$self/assets-c-only" "$self/covered-empty" "$self/exclusions-c"
+expect_judge_fail "judge_reverse（どちらにも無い）" \
+  judge_reverse "$self/assets-uncovered" "$self/covered-ok" "$self/exclusions-empty"
+
+expect_judge_pass "judge_unique" \
+  judge_unique "$self/case-targets-ok"
+expect_judge_fail "judge_unique" \
+  judge_unique "$self/case-targets-dup"
+
+# 実データ側の入力の非空性。assets / covered が空だと §1〜§3 が空虚に真になる
+# （exclusions は空でも §2 が単に厳しく判定するだけなので、ここには含めない）。
+for name in assets covered case-targets; do
   if [ ! -s "$work/$name" ]; then
-    fault "自己検証: $name が空（アサーションが空虚に真になる）"
+    fault "自己検証: $name が空（§1〜§3 が空虚に真になる）"
     self_fail=1
   fi
 done
 
 if [ "$self_fail" -eq 0 ]; then
-  pass "自己検証: 判定ロジックが合成フィクスチャで期待どおり倒れる"
+  pass "自己検証: judge_* が合成フィクスチャで真偽の両側へ倒れる"
 fi
 
 # --- 結果 -------------------------------------------------------------------

--- a/dev/tests/test-doc-map.sh
+++ b/dev/tests/test-doc-map.sh
@@ -11,6 +11,9 @@
 #   3.  1:1 一意性 — 1 資産に 2 つ以上の CASE が張られていない
 #   4.  データファイルの健全性 — 区分表が docs/test/ のディレクトリと一致し、
 #       除外リストが実在する資産だけを挙げている
+#   5.  静的リストの健全性 — test-inventory.sh の FLAKE_CHECKS が flake ファイルの
+#       checks 定義と一致する（片側更新漏れの検出）
+#   6.  自己検証 — 合成フィクスチャで §1〜§3 のアサーションが期待どおり FAIL する
 #
 # ## 純静的であること
 #
@@ -35,22 +38,13 @@ fault() {
   fail=1
 }
 
-for cmd in yq git; do
-  if ! command -v "$cmd" >/dev/null 2>&1; then
-    echo "test-doc-map.sh: $cmd が要る（nix develop '.?dir=dev#sara' から実行する）" >&2
-    exit 1
-  fi
-done
+# shellcheck source=dev/scripts/lib-testdoc.sh
+. "$(dirname "$0")/../scripts/lib-testdoc.sh"
 
-# yq は mikefarah/yq（Go 実装・v4）を前提にする。python-yq（v2/v3 系）が PATH に
-# 居ると eval コマンドの構文が違って黙って空を返すため、実装を明示的に確かめる。
-if ! yq --version 2>&1 | grep -q 'mikefarah\|version v4'; then
-  echo "test-doc-map.sh: mikefarah/yq v4 が要る（実際: $(yq --version 2>&1)）" >&2
-  exit 1
-fi
+require_commands "test-doc-map.sh（nix develop '.?dir=dev#sara' から実行する）" yq git || exit 1
+require_yq_go test-doc-map.sh || exit 1
 
-repo_root=$(git rev-parse --show-toplevel 2>/dev/null || printf '.')
-cd "$repo_root" || exit 1
+cd "$(testdoc_repo_root)" || exit 1
 
 inventory_sh=dev/scripts/test-inventory.sh
 categories_tsv=dev/tests/test-categories.tsv
@@ -65,9 +59,6 @@ done
 
 work=$(mktemp -d)
 trap 'rm -rf "$work"' EXIT
-
-# コメント・空行を落として TSV の実データだけを読む。
-read_tsv() { grep -v '^[[:space:]]*#' "$1" | grep -v '^[[:space:]]*$'; }
 
 # --- 入力の収集 --------------------------------------------------------------
 
@@ -85,15 +76,28 @@ fi
 # CASE の <ファイルパス>\t<target> 表。frontmatter の target を yq で読む
 # （sara report matrix --format json は関係だけを返し、カスタムフィールドを含まない）。
 # ファイルごとに yq を起こすのは 47 件規模なら実用上のコストにならない。
+#
+# yq の失敗（frontmatter が壊れている等）と「target が空」は区別する。畳むと
+# 「target が無い（model.yaml で required なので sara check も落ちる）」と診断されて、
+# sara check が実は緑な状況で誤った調査先へ案内してしまう。
 : > "$work/case-targets"
+unreadable=0
 while IFS= read -r file; do
-  target=$(yq --front-matter=extract '.target // ""' "$file" 2>/dev/null)
+  if ! target=$(yq --front-matter=extract '.target // ""' "$file" 2>/dev/null); then
+    fault "入力: $file の frontmatter を yq で読めなかった（YAML の構文を確認する）"
+    unreadable=1
+    continue
+  fi
   printf '%s\t%s\n' "$file" "$target" >> "$work/case-targets"
 done < <(grep -rl '^type: test_case' docs/test/ | LC_ALL=C sort)
 
 if [ ! -s "$work/case-targets" ]; then
   echo "test-doc-map.sh: CASE を 1 件も読めなかった" >&2
   exit 1
+fi
+
+if [ "$unreadable" -eq 0 ]; then
+  pass "全 CASE の frontmatter を読める"
 fi
 
 read_tsv "$exclusions_tsv" | cut -f1 | LC_ALL=C sort > "$work/exclusions"
@@ -207,6 +211,104 @@ if [ -z "$both" ]; then
   pass "除外リストと CASE の target が排他である"
 else
   fault "除外されているのに CASE がある（$both）"
+fi
+
+# --- 5. 静的リストの健全性（FLAKE_CHECKS ⟷ flake ファイル） ------------------
+
+# test-inventory.sh は flake check の一覧を静的リストで持つ（--static を純ファイル走査に
+# 保つため nix eval を呼べない）。この突合が無いと片側更新漏れが検知できない: check を
+# flake へ足してリストへ足し忘れると列挙に現れず、順方向・逆方向のどちらも触れないまま
+# 黙って緑になる（実際に踏んだ）。sara-id.sh §6b が prefix マップを model.yaml と
+# 突合するのと同じ発想で、flake ファイルの定義行を grep して集合比較する。
+
+# 静的リストから flake check の識別子を採る。`dev:` 接頭辞で flake ファイルを振り分ける。
+bash "$inventory_sh" --static |
+  awk -F'\t' '$2 == "flake-check" { print $1 }' |
+  LC_ALL=C sort > "$work/listed-checks"
+
+# flakeModule 生成分（flake ファイルに定義行が無い）は grep 突合の対象外。
+bash "$inventory_sh" --module-generated-checks | LC_ALL=C sort > "$work/module-checks"
+
+# flake ファイル側の定義。`checks.<name> =` の行から名前を採る。
+extract_checks() {
+  grep -oE '^[[:space:]]*checks\.[A-Za-z0-9_-]+[[:space:]]*=' "$1" |
+    sed -E 's/^[[:space:]]*checks\.([A-Za-z0-9_-]+)[[:space:]]*=.*/\1/'
+}
+
+{
+  extract_checks flake.nix | sed 's|^|checks.|'
+  extract_checks dev/flake.nix | sed 's|^|dev:checks.|'
+} | LC_ALL=C sort -u > "$work/defined-checks"
+
+if [ ! -s "$work/defined-checks" ]; then
+  fault "静的リスト: flake ファイルから checks 定義を 1 件も抽出できなかった（grep の前提が崩れた）"
+else
+  # 静的リスト（module 生成分を除く）⟷ flake の定義。
+  LC_ALL=C comm -23 "$work/listed-checks" "$work/module-checks" > "$work/listed-hand"
+
+  only_flake=$(LC_ALL=C comm -13 "$work/listed-hand" "$work/defined-checks" | tr '\n' ' ')
+  only_list=$(LC_ALL=C comm -23 "$work/listed-hand" "$work/defined-checks" | tr '\n' ' ')
+
+  if [ -z "$only_flake" ] && [ -z "$only_list" ]; then
+    pass "FLAKE_CHECKS が flake ファイルの checks 定義と一致する"
+  fi
+  if [ -n "$only_flake" ]; then
+    fault "静的リスト: flake に在るが FLAKE_CHECKS に無い（$only_flake）— $inventory_sh へ追加する"
+  fi
+  if [ -n "$only_list" ]; then
+    fault "静的リスト: FLAKE_CHECKS に在るが flake の定義に無い（$only_list）— 消えた check の残骸か、flakeModule 生成分なら --module-generated-checks 側へ移す"
+  fi
+
+  # module 生成分は逆に flake ファイルへ定義行を持たないはず（持つなら手書き側の管理へ移す）。
+  wrongly_module=$(LC_ALL=C comm -12 "$work/module-checks" "$work/defined-checks" | tr '\n' ' ')
+  if [ -z "$wrongly_module" ]; then
+    pass "flakeModule 生成分が flake ファイルに定義行を持たない"
+  else
+    fault "静的リスト: flakeModule 生成分として除外しているが flake に定義行がある（$wrongly_module）"
+  fi
+fi
+
+# --- 6. 自己検証（アサーションが本当に落ちるか） -----------------------------
+
+# §1〜§3 は「今のリポジトリが正しい」ことだけを見るため、アサーションが誤って常に真を
+# 返す退行が起きても緑のまま通る。合成フィクスチャで各判定ロジックが期待どおり FAIL 側へ
+# 倒れることを確かめる（リポジトリの実ファイルには一切触らない）。
+#
+# ここで検証するのは判定の骨（grep -qxF による集合演算・uniq -d による重複検出）で、
+# §1〜§3 が使っているものと同じ手段を同じ向きで叩く。
+
+self_fail=0
+
+# 順方向: 実在しない target が assets に無いと判定されること。
+if grep -qxF 'internal/does/not/exist_test.go' "$work/assets"; then
+  fault "自己検証: 実在しない target が資産として在ると判定された"
+  self_fail=1
+fi
+
+# 逆方向: 除外にも CASE にも無い架空の資産が未カバーと判定されること。
+if grep -qxF 'internal/phantom/phantom_test.go' "$work/covered" ||
+  grep -qxF 'internal/phantom/phantom_test.go' "$work/exclusions"; then
+  fault "自己検証: 架空の資産がカバー済み / 除外済みと判定された"
+  self_fail=1
+fi
+
+# 1:1: 同じ target を 2 度並べたら uniq -d が拾うこと。
+synthetic_dup=$(printf 'a\na\nb\n' | LC_ALL=C sort | uniq -d)
+if [ "$synthetic_dup" != "a" ]; then
+  fault "自己検証: 重複検出（uniq -d）が機能していない（実際: $synthetic_dup）"
+  self_fail=1
+fi
+
+# 入力の非空性: 検査対象の 3 集合が空だと全アサーションが空虚に真になる。
+for name in assets covered exclusions; do
+  if [ ! -s "$work/$name" ]; then
+    fault "自己検証: $name が空（アサーションが空虚に真になる）"
+    self_fail=1
+  fi
+done
+
+if [ "$self_fail" -eq 0 ]; then
+  pass "自己検証: 判定ロジックが合成フィクスチャで期待どおり倒れる"
 fi
 
 # --- 結果 -------------------------------------------------------------------

--- a/dev/tests/test-doc-map.sh
+++ b/dev/tests/test-doc-map.sh
@@ -147,12 +147,18 @@ judge_reverse() {
   # 取り違えると判定は恒常 green へ縮退し、データの性質を見るアサーションでは恒真に
   # なって検知できない（→ 4 周目のレビューで実証）。契約を関数内で主張すれば、
   # 取り違えは縮退ではなく違反として現れる。
+  #
+  # ただし **early return しない**。covered は CASE の target 由来なので、テスト資産の
+  # リネーム / 削除に CASE が追従していないと（＝配線が正しくても）データ起因で
+  # 非部分集合になる。抜けると (1) 診断が存在しない配線バグを指し (2) 同じ PR に入った
+  # 未カバー資産が 1 件も報告されない（→ 5 周目のレビューで実証）。違反として記録した
+  # うえで走査は続け、両方の診断を出す。
   local stray
   stray=$(LC_ALL=C comm -23 <(LC_ALL=C sort -u "$covered" "$exclusions") \
     <(LC_ALL=C sort -u "$scan_target"))
   if [ -n "$stray" ]; then
-    echo "逆方向: 免除集合が走査対象の部分集合でない（引数配線の誤り。走査対象に無い: $(printf '%s' "$stray" | tr '\n' ' ')）"
-    return 1
+    echo "逆方向: 免除集合が走査対象の部分集合でない（引数配線の誤り、または CASE / 除外リストが走査対象へ追従していない。走査対象に無い: $(printf '%s' "$stray" | tr '\n' ' ')）"
+    violated=1
   fi
 
   while IFS= read -r asset; do

--- a/dev/tests/test-doc-map.sh
+++ b/dev/tests/test-doc-map.sh
@@ -113,7 +113,6 @@ read_tsv "$exclusions_tsv" | cut -f1 | LC_ALL=C sort > "$work/exclusions"
 # 振り分ける。ファイルパスを引数で受けるので、実データでも合成フィクスチャでも同じ経路。
 
 # 順方向: case_targets（<ファイル>\t<target>）の target が assets に在るか。
-# $3 は診断メッセージ用の除外リストパス（案内文にのみ使う）。
 judge_forward() {
   local case_targets=$1 assets=$2
   local violated=0 file target
@@ -132,8 +131,12 @@ judge_forward() {
 }
 
 # 逆方向: assets の各要素が covered か exclusions のどちらかに在るか。
+# 第 1 引数は「走査対象」、第 2・第 3 は「そこに在れば違反を消す集合」。取り違えると
+# covered ⊆ assets が常に成り立つため判定が永久に緑になるので、実データ経路の配線を
+# §6 が別途固定する（→ 3 周目のレビュー）。
+# 第 4 引数は診断メッセージに載せる除外リストのパス（案内文にのみ使う）。
 judge_reverse() {
-  local assets=$1 covered=$2 exclusions=$3 exclusions_hint=${4:-$3}
+  local scan_target=$1 covered=$2 exclusions=$3 exclusions_hint=${4:-$3}
   local violated=0 asset
   while IFS= read -r asset; do
     if grep -qxF "$asset" "$covered"; then
@@ -144,7 +147,7 @@ judge_reverse() {
     fi
     echo "逆方向: テスト資産 '$asset' に CASE が無い（CASE を起こすか $exclusions_hint へ除外理由付きで追加する）"
     violated=1
-  done < "$assets"
+  done < "$scan_target"
   return "$violated"
 }
 
@@ -163,18 +166,28 @@ judge_unique() {
   return 1
 }
 
-# 判定関数を実データへ当て、診断行を fault へ流す。
+# 判定関数を実データへ当て、診断行を fault へ流す。§6 がこの関数自体も検証する
+# （ここが壊れると判定が正しくても pass / fault の振り分けが失われ、違反があるのに
+# 緑で通る。2 周目の穴が判定から 1 段外側へ移っただけになる → 3 周目のレビュー）。
 run_judge() {
   local ok_message=$1
   shift
-  local diagnostics
+  local diagnostics emitted=0 line
   if diagnostics=$("$@"); then
     pass "$ok_message"
     return 0
   fi
   while IFS= read -r line; do
-    [ -n "$line" ] && fault "$line"
+    if [ -n "$line" ]; then
+      fault "$line"
+      emitted=1
+    fi
   done <<< "$diagnostics"
+  # 非ゼロを返したのに診断行が無いと pass も fault も出ず、アサーションが出力から
+  # 静かに消えて fail=0 のまま通る。判定側の実装漏れを緑にしないため必ず 1 件は出す。
+  if [ "$emitted" -eq 0 ]; then
+    fault "$ok_message — 判定が違反を返したが診断行が空（判定側の実装漏れ）"
+  fi
   return 1
 }
 
@@ -306,6 +319,16 @@ else
     fault "静的リスト: FLAKE_CHECKS に在るが flake の定義に無い（$only_list）— 消えた check の残骸か、flakeModule 生成分なら --module-generated-checks 側へ移す"
   fi
 
+  # MODULE_GENERATED_CHECKS ⊆ FLAKE_CHECKS。包含が崩れると 3 判定すべてが空になり、
+  # その check が列挙から静かに落ちる（f4c7a49 が塞いだ片側更新漏れと同型の穴が
+  # module 生成分側に残る → 3 周目のレビュー）。
+  not_listed=$(LC_ALL=C comm -13 "$work/listed-checks" "$work/module-checks" | tr '\n' ' ')
+  if [ -z "$not_listed" ]; then
+    pass "flakeModule 生成分が FLAKE_CHECKS にも載っている"
+  else
+    fault "静的リスト: flakeModule 生成分として挙げているが FLAKE_CHECKS に無い（$not_listed）— 列挙から落ちる"
+  fi
+
   # module 生成分は逆に flake ファイルへ定義行を持たないはず（持つなら手書き側の管理へ移す）。
   wrongly_module=$(LC_ALL=C comm -12 "$work/module-checks" "$work/defined-checks" | tr '\n' ' ')
   if [ -z "$wrongly_module" ]; then
@@ -328,19 +351,23 @@ fi
 self=$work/self
 mkdir -p "$self"
 
-# 違反のないフィクスチャ。
+# 違反のないフィクスチャ。空集合は真に空にする（実データ側の exclusions / covered は
+# read_tsv / grep -v が空行を落とすため、空行 1 行を含むファイルは形が乖離する）。
 printf 'a_test.go\nb_test.go\n' > "$self/assets-ok"
 printf 'CASE-a.md\ta_test.go\nCASE-b.md\tb_test.go\n' > "$self/case-targets-ok"
 printf 'a_test.go\nb_test.go\n' > "$self/covered-ok"
-printf '\n' > "$self/exclusions-empty"
+: > "$self/exclusions-empty"
 
 # 違反のあるフィクスチャ。判定内の分岐ごとに 1 つずつ用意する。1 つのフィクスチャで
 # 複数の分岐を同時に踏ませると、片方の分岐が死んでももう片方が違反を返して緑になり、
 # 「常に真になる退行」を取りこぼす（実際に踏んだ）。
 # 順方向 (a): 実在しない target を指す。
 printf 'CASE-a.md\tgone_test.go\n' > "$self/case-targets-dangling"
-# 順方向 (b): target が空。
+# 順方向 (b): target が空。空 target 分岐だけを踏ませるため、assets 側に空行を含める
+# （含めないと grep 分岐も同時に違反を返し、空 target 分岐を殺しても偽が返って
+# 分岐の生死が見えない）。
 printf 'CASE-b.md\t\n' > "$self/case-targets-empty"
+printf '\na_test.go\n' > "$self/assets-with-empty"
 # 逆方向: covered にも exclusions にも無い資産。
 printf 'a_test.go\nc_test.go\n' > "$self/assets-uncovered"
 # 逆方向: 除外リストだけで消える資産（除外経路の単独検証用）。
@@ -378,18 +405,17 @@ expect_judge_pass "judge_forward" \
   judge_forward "$self/case-targets-ok" "$self/assets-ok"
 expect_judge_fail "judge_forward（実在しない target）" \
   judge_forward "$self/case-targets-dangling" "$self/assets-ok"
-# target が空の分岐は下の grep 分岐と重なる（空文字は assets にも無いので、この分岐が
-# 死んでも違反自体は報告される。失われるのは「target が無い」という具体的な診断だけ）。
-# よってこのアサーションは分岐の生死ではなく、空 target が違反として扱われることを固定する。
+# 空 target 分岐は assets-with-empty（空行を含む）と組ませることで単独に踏ませる。
+# この組では grep 分岐が空文字を「在る」と判定するため、空 target 分岐だけが違反を返す。
 expect_judge_fail "judge_forward（target が空）" \
-  judge_forward "$self/case-targets-empty" "$self/assets-ok"
+  judge_forward "$self/case-targets-empty" "$self/assets-with-empty"
 
 # 逆方向は「covered に在る」「exclusions に在る」の 2 経路で違反を消す。両経路を
 # それぞれ単独で確かめる（片方が死んでももう片方が拾って緑になるのを防ぐ）。
 expect_judge_pass "judge_reverse（covered 経路）" \
   judge_reverse "$self/assets-ok" "$self/covered-ok" "$self/exclusions-empty"
 printf 'c_test.go\n' > "$self/exclusions-c"
-printf '\n' > "$self/covered-empty"
+: > "$self/covered-empty"
 expect_judge_pass "judge_reverse（除外リスト経路）" \
   judge_reverse "$self/assets-c-only" "$self/covered-empty" "$self/exclusions-c"
 expect_judge_fail "judge_reverse（どちらにも無い）" \
@@ -399,6 +425,60 @@ expect_judge_pass "judge_unique" \
   judge_unique "$self/case-targets-ok"
 expect_judge_fail "judge_unique" \
   judge_unique "$self/case-targets-dup"
+
+# run_judge 自体の検証。judge_* が正しくても、この関数が pass / fault の振り分けを
+# 誤れば違反があるのに緑で通る（判定を直しただけでは穴が 1 段外側へ移るだけ）。
+# pass / fault を数える版へ一時的に差し替えて、呼ばれ方を観測する。
+judge_always_ok() { return 0; }
+judge_always_violates() { echo "合成の違反診断"; return 1; }
+judge_violates_silently() { return 1; }
+
+probe_run_judge() {
+  local pass_count=0 fault_count=0
+  # shellcheck disable=SC2317  # 差し替え後に run_judge から呼ばれる
+  pass() { pass_count=$((pass_count + 1)); }
+  # shellcheck disable=SC2317
+  fault() { fault_count=$((fault_count + 1)); }
+
+  run_judge "probe" "$@" >/dev/null 2>&1
+  local status=$?
+
+  # 呼び出し側へ戻す前に本来の実装を復帰させる。
+  unset -f pass fault
+  printf '%d\t%d\t%d\n' "$pass_count" "$fault_count" "$status"
+}
+
+# run_judge は関数定義を上書きするため、サブシェルで走らせて本体へ漏らさない。
+probe_ok=$(probe_run_judge judge_always_ok)
+probe_violation=$(probe_run_judge judge_always_violates)
+probe_silent=$(probe_run_judge judge_violates_silently)
+
+check_probe() {
+  local label=$1 actual=$2 want_pass=$3 want_fault_min=$4 want_status=$5
+  local got_pass got_fault got_status
+  IFS=$'\t' read -r got_pass got_fault got_status <<< "$actual"
+  if [ "$got_pass" != "$want_pass" ] ||
+    [ "$got_fault" -lt "$want_fault_min" ] ||
+    [ "$got_status" != "$want_status" ]; then
+    fault "自己検証: run_judge（$label）— pass=$got_pass fault=$got_fault exit=$got_status（期待: pass=$want_pass fault>=$want_fault_min exit=$want_status）"
+    self_fail=1
+  fi
+}
+
+# 違反なし → pass 1 回・fault 0 回・exit 0。
+check_probe "違反なし" "$probe_ok" 1 0 0
+# 違反あり → pass 0 回・fault 1 回以上・exit 1。
+check_probe "違反あり" "$probe_violation" 0 1 1
+# 違反ありだが診断行が空 → 黙って通さず fault へ倒す。
+check_probe "違反ありで診断が空" "$probe_silent" 0 1 1
+
+# 実データ経路の引数配線。judge_reverse の走査対象と免除集合を取り違えると、
+# covered ⊆ assets が常に成り立つため判定が永久に緑になる（縮退が矛盾として現れない）。
+# 「covered は assets の部分集合である」を前提として明示し、取り違えを検出可能にする。
+if [ -n "$(LC_ALL=C comm -23 "$work/covered" "$work/assets")" ]; then
+  fault "自己検証: covered ⊄ assets（§2 の引数配線が取り違えられている可能性がある）"
+  self_fail=1
+fi
 
 # 実データ側の入力の非空性。assets / covered が空だと §1〜§3 が空虚に真になる
 # （exclusions は空でも §2 が単に厳しく判定するだけなので、ここには含めない）。
@@ -410,7 +490,7 @@ for name in assets covered case-targets; do
 done
 
 if [ "$self_fail" -eq 0 ]; then
-  pass "自己検証: judge_* が合成フィクスチャで真偽の両側へ倒れる"
+  pass "自己検証: judge_* と run_judge が合成フィクスチャで期待どおり振る舞う"
 fi
 
 # --- 結果 -------------------------------------------------------------------

--- a/dev/tests/test-doc-map.sh
+++ b/dev/tests/test-doc-map.sh
@@ -1,0 +1,222 @@
+#!/usr/bin/env bash
+# テストコード ⇔ テストドキュメント（CASE）対応の契約テスト（→ Issue #304、epic #283）。
+#
+# 実行:
+#   nix develop '.?dir=dev#sara' -c dev/tests/test-doc-map.sh   # devShell / CI から直接
+#   nix flake check ./dev                                        # checks.test-doc-map 経由
+#
+# 検証対象。番号は下の節見出しに対応する:
+#   1.  順方向 — 全 CASE の target が実在するテスト資産を指す
+#   2.  逆方向 — 全テスト資産に CASE がある（除外リストにあるものを除く）
+#   3.  1:1 一意性 — 1 資産に 2 つ以上の CASE が張られていない
+#   4.  データファイルの健全性 — 区分表が docs/test/ のディレクトリと一致し、
+#       除外リストが実在する資産だけを挙げている
+#
+# ## 純静的であること
+#
+# この検証は毎 PR で回る（CI の sara ジョブ）。入力は dev/scripts/test-inventory.sh
+# --static（find / glob のみ）と CASE frontmatter（yq）だけで、go test も nix eval も
+# 呼ばない。sara devShell（sara / yq / git 等）だけで完結する。
+#
+# ## 規範は frontmatter にある
+#
+# CASE 本文の「## 対象」節は人間向けの補足で、ここでは照合しない。照合するのは
+# frontmatter の target（docs/model.yaml で required: true）。
+
+# -e は使わない（sara-id.sh と同じ理由）。このテストは「1 回の実行で全失敗を報告する」
+# 集計方式で、-e があると最初の非ゼロ終了で以降のアサーションが走らず、退行時の診断が
+# 先頭 1 件で切れる。
+set -uo pipefail
+
+fail=0
+pass() { printf 'ok   - %s\n' "$1"; }
+fault() {
+  printf 'FAIL - %s\n' "$1"
+  fail=1
+}
+
+for cmd in yq git; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "test-doc-map.sh: $cmd が要る（nix develop '.?dir=dev#sara' から実行する）" >&2
+    exit 1
+  fi
+done
+
+# yq は mikefarah/yq（Go 実装・v4）を前提にする。python-yq（v2/v3 系）が PATH に
+# 居ると eval コマンドの構文が違って黙って空を返すため、実装を明示的に確かめる。
+if ! yq --version 2>&1 | grep -q 'mikefarah\|version v4'; then
+  echo "test-doc-map.sh: mikefarah/yq v4 が要る（実際: $(yq --version 2>&1)）" >&2
+  exit 1
+fi
+
+repo_root=$(git rev-parse --show-toplevel 2>/dev/null || printf '.')
+cd "$repo_root" || exit 1
+
+inventory_sh=dev/scripts/test-inventory.sh
+categories_tsv=dev/tests/test-categories.tsv
+exclusions_tsv=dev/tests/test-doc-exclusions.tsv
+
+for f in "$inventory_sh" "$categories_tsv" "$exclusions_tsv"; do
+  if [ ! -f "$f" ]; then
+    echo "test-doc-map.sh: $f が無い" >&2
+    exit 1
+  fi
+done
+
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+
+# コメント・空行を落として TSV の実データだけを読む。
+read_tsv() { grep -v '^[[:space:]]*#' "$1" | grep -v '^[[:space:]]*$'; }
+
+# --- 入力の収集 --------------------------------------------------------------
+
+bash "$inventory_sh" --static > "$work/inventory" || {
+  echo "test-doc-map.sh: $inventory_sh --static が失敗した" >&2
+  exit 1
+}
+cut -f1 "$work/inventory" | LC_ALL=C sort > "$work/assets"
+
+if [ ! -s "$work/assets" ]; then
+  echo "test-doc-map.sh: テスト資産を 1 件も列挙できなかった" >&2
+  exit 1
+fi
+
+# CASE の <ファイルパス>\t<target> 表。frontmatter の target を yq で読む
+# （sara report matrix --format json は関係だけを返し、カスタムフィールドを含まない）。
+# ファイルごとに yq を起こすのは 47 件規模なら実用上のコストにならない。
+: > "$work/case-targets"
+while IFS= read -r file; do
+  target=$(yq --front-matter=extract '.target // ""' "$file" 2>/dev/null)
+  printf '%s\t%s\n' "$file" "$target" >> "$work/case-targets"
+done < <(grep -rl '^type: test_case' docs/test/ | LC_ALL=C sort)
+
+if [ ! -s "$work/case-targets" ]; then
+  echo "test-doc-map.sh: CASE を 1 件も読めなかった" >&2
+  exit 1
+fi
+
+read_tsv "$exclusions_tsv" | cut -f1 | LC_ALL=C sort > "$work/exclusions"
+
+# --- 1. 順方向（CASE の target が実在する） ----------------------------------
+
+missing_target=0
+dangling=0
+while IFS=$'\t' read -r file target; do
+  if [ -z "$target" ]; then
+    fault "順方向: $file に target が無い（docs/model.yaml で required なので sara check も落ちる）"
+    missing_target=1
+    continue
+  fi
+  if ! grep -qxF "$target" "$work/assets"; then
+    fault "順方向: $file の target '$target' に対応するテスト資産が無い（リネーム / 削除の追従漏れ）"
+    dangling=1
+  fi
+done < "$work/case-targets"
+
+if [ "$missing_target" -eq 0 ]; then
+  pass "全 CASE が target を持つ"
+fi
+if [ "$dangling" -eq 0 ]; then
+  pass "全 CASE の target が実在するテスト資産を指す"
+fi
+
+# --- 2. 逆方向（全テスト資産に CASE がある） ---------------------------------
+
+cut -f2 "$work/case-targets" | grep -v '^$' | LC_ALL=C sort -u > "$work/covered"
+
+uncovered=0
+while IFS= read -r asset; do
+  if grep -qxF "$asset" "$work/covered"; then
+    continue
+  fi
+  if grep -qxF "$asset" "$work/exclusions"; then
+    continue
+  fi
+  fault "逆方向: テスト資産 '$asset' に CASE が無い（CASE を起こすか $exclusions_tsv へ除外理由付きで追加する）"
+  uncovered=1
+done < "$work/assets"
+
+if [ "$uncovered" -eq 0 ]; then
+  pass "全テスト資産に CASE がある（除外リストを除く）"
+fi
+
+# --- 3. 1:1 一意性 -----------------------------------------------------------
+
+# 順方向の 1:1（1 CASE = 1 target）は frontmatter が単一 text であることで型に担保
+# されている（!list text ではない）。ここで見るのは逆方向の重複だけ。
+dup_targets=$(cut -f2 "$work/case-targets" | grep -v '^$' | LC_ALL=C sort | uniq -d)
+if [ -z "$dup_targets" ]; then
+  pass "1 テスト資産に張られた CASE は高々 1 件（1:1）"
+else
+  while IFS= read -r target; do
+    owners=$(awk -F'\t' -v t="$target" '$2 == t { printf "%s ", $1 }' "$work/case-targets")
+    fault "1:1 違反: '$target' に複数の CASE が張られている（$owners）"
+  done <<< "$dup_targets"
+fi
+
+# --- 4. データファイルの健全性 -----------------------------------------------
+
+# 区分表 ⟷ docs/test/ のディレクトリ。区分を増減したときの片側更新漏れを検出する。
+read_tsv "$categories_tsv" | cut -f1 | LC_ALL=C sort > "$work/categories"
+find docs/test -mindepth 1 -maxdepth 1 -type d 2>/dev/null |
+  sed 's|.*/||' |
+  LC_ALL=C sort > "$work/case-dirs"
+
+if diff -q "$work/categories" "$work/case-dirs" >/dev/null 2>&1; then
+  pass "区分表が docs/test/ のディレクトリと一致する"
+else
+  only_table=$(comm -23 "$work/categories" "$work/case-dirs" | tr '\n' ' ')
+  only_dirs=$(comm -13 "$work/categories" "$work/case-dirs" | tr '\n' ' ')
+  fault "区分表と docs/test/ が不一致（表のみ: ${only_table:-なし}/ ディレクトリのみ: ${only_dirs:-なし}）"
+fi
+
+# 区分表の 2 列目（説明）が空でないこと。区分名だけの行は表の意味を成さない。
+empty_desc=$(read_tsv "$categories_tsv" | awk -F'\t' 'NF < 2 || $2 == "" { print $1 }' | tr '\n' ' ')
+if [ -z "$empty_desc" ]; then
+  pass "区分表の全行が説明を持つ"
+else
+  fault "区分表に説明の無い行がある（$empty_desc）"
+fi
+
+# 除外リストが実在する資産だけを挙げていること。消えた資産の除外が残ると、
+# 同名の資産を後で追加したときに CASE 無しのまま黙って通る。
+stale_exclusion=0
+while IFS= read -r asset; do
+  if ! grep -qxF "$asset" "$work/assets"; then
+    fault "除外リストの '$asset' は列挙されるテスト資産に無い（stale な除外）"
+    stale_exclusion=1
+  fi
+done < "$work/exclusions"
+
+if [ "$stale_exclusion" -eq 0 ]; then
+  pass "除外リストが実在するテスト資産だけを挙げている"
+fi
+
+# 除外リストの 2 列目（理由）が空でないこと。理由の無い除外は後から判断できない。
+empty_reason=$(read_tsv "$exclusions_tsv" | awk -F'\t' 'NF < 2 || $2 == "" { print $1 }' | tr '\n' ' ')
+if [ -z "$empty_reason" ]; then
+  pass "除外リストの全行が理由を持つ"
+else
+  fault "除外リストに理由の無い行がある（$empty_reason）"
+fi
+
+# CASE と除外リストの重複。除外しつつ CASE を持つのは意図が二重で、どちらかが古い。
+both=$(LC_ALL=C comm -12 "$work/covered" "$work/exclusions" | tr '\n' ' ')
+if [ -z "$both" ]; then
+  pass "除外リストと CASE の target が排他である"
+else
+  fault "除外されているのに CASE がある（$both）"
+fi
+
+# --- 結果 -------------------------------------------------------------------
+
+echo
+if [ "$fail" -eq 0 ]; then
+  printf 'test-doc-map: 全アサーション通過（CASE %d 件 / テスト資産 %d 件 / 除外 %d 件）\n' \
+    "$(wc -l < "$work/case-targets")" "$(wc -l < "$work/assets")" "$(wc -l < "$work/exclusions")"
+  exit 0
+fi
+
+printf 'test-doc-map: 失敗あり\n' >&2
+exit 1

--- a/docs/model.yaml
+++ b/docs/model.yaml
@@ -390,7 +390,27 @@ item_types:
     id_format: '{prefix}-{uuid}'
     parent_types:
       - test_condition
-    fields: []
+    fields:
+      # CASE が対応するテスト資産の識別子。テストコード ⇔ CASE の対応を機械照合可能に
+      # するための正準表記で、規範はここ（frontmatter）にある。本文の「## 対象」節は
+      # 人間向けの補足で、契約テスト（dev/tests/test-doc-map.sh）は照合しない
+      # （→ Issue #304、epic #283）。
+      #
+      # 正準形は 2 規則のみ:
+      #   - ファイルが実在するもの → リポジトリ相対パス
+      #     （Go = internal/engine/engine_test.go、nix-unit = tests/nix-unit/structure.nix、
+      #     e2e = tests/e2e/scenarios/03-stale.sh、
+      #     namaka = tests/namaka/manifest-project/〔末尾スラッシュ〕）
+      #   - flake check → checks.hm-module 形式（checks. 接頭辞）
+      #
+      # 単一値（!list text ではない）。粒度規約「CASE = テストファイル / シナリオ /
+      # check 単位」を型で表し、CASE ⟷ テスト資産の 1:1 を契約テストで強制する
+      # （緩める変更は容易だが逆は 47 件の掃引が要るため、厳しい側へ倒した決定）。
+      - name: target
+        display_name: Target
+        field_type: text
+        required: true
+        placeholder: internal/engine/engine_test.go
     allowed_targets:
       - relation: covers
         targets:

--- a/docs/test/atomicity/20260809-02475ac2-undo-test-go.md
+++ b/docs/test/atomicity/20260809-02475ac2-undo-test-go.md
@@ -2,6 +2,7 @@
 id: "CASE-02475ac2-5555-4fa1-a3e5-cda5015919c5"
 type: test_case
 name: "undo_test.go — 逆操作単体と unwind の順序・best-effort・journal 破棄"
+target: "internal/engine/undo_test.go"
 covers:
   - "TC-9504e908-a4bc-4d2d-80d3-af07264284f8"
   - "TC-83fe0d4a-9730-431a-b7f9-b731060b9484"

--- a/docs/test/atomicity/20260809-154af597-undo-journal-test-go.md
+++ b/docs/test/atomicity/20260809-154af597-undo-journal-test-go.md
@@ -2,6 +2,7 @@
 id: "CASE-154af597-df3e-49fb-a96b-b4f371dfcc63"
 type: test_case
 name: "undo_journal_test.go — 実 FS 故障注入による end-to-end 巻き戻しと commit 失敗の非対称性"
+target: "internal/engine/undo_journal_test.go"
 covers:
   - "TC-3b02ab58-5bfb-4ae7-9ac1-c69e2ece2722"
   - "TC-e048211f-0844-4446-9957-fb444c1da4e5"

--- a/docs/test/atomicity/20260809-2e675eea-internal-lock-test-go.md
+++ b/docs/test/atomicity/20260809-2e675eea-internal-lock-test-go.md
@@ -2,6 +2,7 @@
 id: "CASE-2e675eea-8e0e-41f6-bb94-5f2ce944255b"
 type: test_case
 name: "internal/lock/lock_test.go — flock ラッパーの try / blocking / 再取得"
+target: "internal/lock/lock_test.go"
 covers:
   - "TC-5454b99c-f274-438a-9ba9-5be09aa71c98"
 ---

--- a/docs/test/atomicity/20260809-6f6fabaa-engine-lock-test-go.md
+++ b/docs/test/atomicity/20260809-6f6fabaa-engine-lock-test-go.md
@@ -2,6 +2,7 @@
 id: "CASE-6f6fabaa-ae1e-4af5-962e-087a9064f85d"
 type: test_case
 name: "engine/lock_test.go — 公開 API 越しのロック取得モード・保持区間・sentinel 同一性"
+target: "internal/engine/lock_test.go"
 covers:
   - "TC-4b4709c9-1b7a-42f0-8430-62a26ead4eff"
 ---

--- a/docs/test/atomicity/20260809-ed4b32fd-backup-test-go.md
+++ b/docs/test/atomicity/20260809-ed4b32fd-backup-test-go.md
@@ -2,6 +2,7 @@
 id: "CASE-ed4b32fd-4f2e-497c-baa4-cc91f8a34e4a"
 type: test_case
 name: "backup_test.go — --backup の退避ライフサイクルと退避先の保護"
+target: "internal/engine/backup_test.go"
 covers:
   - "TC-ed4992c0-8513-4383-be0a-e45acbbc229f"
   - "TC-cd03ff56-6ed0-4100-9ec4-eb681ab66407"

--- a/docs/test/cli-json/20260809-020fa59e-reset-test.md
+++ b/docs/test/cli-json/20260809-020fa59e-reset-test.md
@@ -2,6 +2,7 @@
 id: "CASE-020fa59e-9aaa-498b-ad5f-dd49b8b48f78"
 type: test_case
 name: "reset_test.go — 確認ポリシーと出力ストリームの排他"
+target: "cmd/nput/reset_test.go"
 covers:
   - "TC-b0e0cdb8-0c56-4eb8-8d4e-86569af85dec"
   - "TC-b4a365cd-0b1c-40ff-92c6-91f6cffe8e98"

--- a/docs/test/cli-json/20260809-3b8d14a5-version-test.md
+++ b/docs/test/cli-json/20260809-3b8d14a5-version-test.md
@@ -2,6 +2,7 @@
 id: "CASE-3b8d14a5-192b-46ba-94bd-ce1e78c4e8de"
 type: test_case
 name: "version_test.go — バージョンの供給元一致と --version の出力書式"
+target: "cmd/nput/version_test.go"
 covers:
   - "TC-0c7281f8-cffc-4a53-8fe0-f52d9ea6bd12"
   - "TC-b4a365cd-0b1c-40ff-92c6-91f6cffe8e98"

--- a/docs/test/cli-json/20260809-5ad75041-init-test.md
+++ b/docs/test/cli-json/20260809-5ad75041-init-test.md
@@ -2,6 +2,7 @@
 id: "CASE-5ad75041-e529-4f01-a8a6-8f15e40be33e"
 type: test_case
 name: "init_test.go — テンプレート名の受理集合と subject を持たない文書形"
+target: "cmd/nput/init_test.go"
 covers:
   - "TC-0c7281f8-cffc-4a53-8fe0-f52d9ea6bd12"
   - "TC-69537269-32d7-4e04-8722-806b58e7db7a"

--- a/docs/test/cli-json/20260809-81d876af-apply-test.md
+++ b/docs/test/cli-json/20260809-81d876af-apply-test.md
@@ -2,6 +2,7 @@
 id: "CASE-81d876af-a1e3-4348-a827-81c8ba7ef39b"
 type: test_case
 name: "apply_test.go — 終了コード集約・root フィルタ・退避行の出力"
+target: "cmd/nput/apply_test.go"
 covers:
   - "TC-ddee6cc4-bc10-4107-bc7e-288a5fb62f1f"
   - "TC-0c7281f8-cffc-4a53-8fe0-f52d9ea6bd12"

--- a/docs/test/cli-json/20260809-8b3feeb2-niface-all-test.md
+++ b/docs/test/cli-json/20260809-8b3feeb2-niface-all-test.md
@@ -2,6 +2,7 @@
 id: "CASE-8b3feeb2-7b7b-482c-bba2-6db0b923647a"
 type: test_case
 name: "niface_all_test.go — --all の subject 件数不変性と部分失敗の非汚染"
+target: "cmd/nput/niface_all_test.go"
 covers:
   - "TC-1a46da17-1812-431b-966f-ec8dffd315ae"
   - "TC-733ac4ed-dac3-4bb8-9bfd-fd1cbdc300c9"

--- a/docs/test/cli-json/20260809-932e218b-niface-test.md
+++ b/docs/test/cli-json/20260809-932e218b-niface-test.md
@@ -2,6 +2,7 @@
 id: "CASE-932e218b-5bfb-4d66-98a3-41054c0d863f"
 type: test_case
 name: "niface_test.go — エンベロープ基礎形・id 導出・エラー分類・stdout 所有権"
+target: "cmd/nput/niface_test.go"
 covers:
   - "TC-1a46da17-1812-431b-966f-ec8dffd315ae"
   - "TC-733ac4ed-dac3-4bb8-9bfd-fd1cbdc300c9"

--- a/docs/test/cli-json/20260809-a9ff732c-niface-payload-test.md
+++ b/docs/test/cli-json/20260809-a9ff732c-niface-payload-test.md
@@ -2,6 +2,7 @@
 id: "CASE-a9ff732c-af30-4f13-862d-92e3074d390d"
 type: test_case
 name: "niface_payload_test.go — engine 結果からペイロードへの写像"
+target: "cmd/nput/niface_payload_test.go"
 covers:
   - "TC-cf8189c4-d680-4d7e-bcd3-810543762c50"
   - "TC-71fdbbfb-cf81-4aba-8254-59d7cb45d5ab"

--- a/docs/test/cli-json/20260809-c5c6d127-gitignore-test.md
+++ b/docs/test/cli-json/20260809-c5c6d127-gitignore-test.md
@@ -2,6 +2,7 @@
 id: "CASE-c5c6d127-c227-4f01-9a5d-fc09e7412175"
 type: test_case
 name: "gitignore_test.go — パス正規化と列挙結果の info 表現"
+target: "cmd/nput/gitignore_test.go"
 covers:
   - "TC-4e0a14d6-342c-448b-964b-b8e87520e89b"
   - "TC-1a46da17-1812-431b-966f-ec8dffd315ae"

--- a/docs/test/cli-json/20260809-cd3e3428-backup-flag-test.md
+++ b/docs/test/cli-json/20260809-cd3e3428-backup-flag-test.md
@@ -2,6 +2,7 @@
 id: "CASE-cd3e3428-3fe0-4d33-a64c-1931ac11d07d"
 type: test_case
 name: "backup_flag_test.go — 値を省略できるフラグが位置引数を飲み込まない"
+target: "cmd/nput/backup_flag_test.go"
 covers:
   - "TC-0c7281f8-cffc-4a53-8fe0-f52d9ea6bd12"
 ---

--- a/docs/test/cli-json/20260809-d0505d58-list-generations-test.md
+++ b/docs/test/cli-json/20260809-d0505d58-list-generations-test.md
@@ -2,6 +2,7 @@
 id: "CASE-d0505d58-ef48-4fe2-ab7c-77002109d1c4"
 type: test_case
 name: "list-generations_test.go — 世代一覧の info 表現と二重エンコードの禁止"
+target: "cmd/nput/list-generations_test.go"
 covers:
   - "TC-4e0a14d6-342c-448b-964b-b8e87520e89b"
   - "TC-cf8189c4-d680-4d7e-bcd3-810543762c50"

--- a/docs/test/cli-json/20260809-eec02695-nix-test.md
+++ b/docs/test/cli-json/20260809-eec02695-nix-test.md
@@ -2,6 +2,7 @@
 id: "CASE-eec02695-ac60-4ea9-a825-f23f7669d132"
 type: test_case
 name: "nix_test.go — entrypoint 探索順序と installable 引数の 2 形式"
+target: "cmd/nput/nix_test.go"
 covers:
   - "TC-69537269-32d7-4e04-8722-806b58e7db7a"
 ---

--- a/docs/test/copy/20260809-601db08c-e2e-04-copy.md
+++ b/docs/test/copy/20260809-601db08c-e2e-04-copy.md
@@ -2,6 +2,7 @@
 id: "CASE-601db08c-2323-48eb-99f5-8774bba2fa6e"
 type: test_case
 name: "tests/e2e/scenarios/04-copy.sh — 実 nix での copy place-once と out-of-store"
+target: "tests/e2e/scenarios/04-copy.sh"
 covers:
   - "TC-596d697f-4ba6-4ec1-b71e-8b5375806c08"
   - "TC-cf1b44ec-2ec4-4ee1-9a37-378e41ccb01e"
@@ -9,7 +10,9 @@ covers:
 ---
 # CASE-601db08c: e2e 04-copy
 
-対象: `tests/e2e/scenarios/04-copy.sh`
+## 対象
+
+`tests/e2e/scenarios/04-copy.sh`
 
 隔離した一時 `$HOME` の下で、`method = "copy"` の entry と `mkOutOfStoreSymlink` の entry を
 持つ fixture flake を実 nix で評価し、`nput apply` を一気通貫で回す。

--- a/docs/test/copy/20260809-82fdfb27-copytree-test-go.md
+++ b/docs/test/copy/20260809-82fdfb27-copytree-test-go.md
@@ -2,12 +2,15 @@
 id: "CASE-82fdfb27-0bea-4833-b5e9-5f9e142a08df"
 type: test_case
 name: "internal/engine/copytree_test.go — 再帰コピーの構造・mode・symlink 再現"
+target: "internal/engine/copytree_test.go"
 covers:
   - "TC-b1b8c163-9d37-47ee-9838-7168569df03a"
 ---
 # CASE-82fdfb27: copytree_test.go
 
-対象: `internal/engine/copytree_test.go`
+## 対象
+
+`internal/engine/copytree_test.go`
 
 コピーのプリミティブ（`copyTree` / `copyFile` / `copySymlink`）を実 tmpdir に対して直接
 呼び、結果のツリーを lstat / readlink で確認する。engine の配置経路を通さないため、

--- a/docs/test/copy/20260809-dcd5e7e4-copy-test-go.md
+++ b/docs/test/copy/20260809-dcd5e7e4-copy-test-go.md
@@ -2,13 +2,16 @@
 id: "CASE-dcd5e7e4-9190-4b13-9521-9b8801ec85fb"
 type: test_case
 name: "internal/engine/copy_test.go — コピー経路の syscall 失敗注入"
+target: "internal/engine/copy_test.go"
 covers:
   - "TC-4f315cfc-446c-4c3f-8dc9-c36b10073e9d"
   - "TC-d1eb1814-ac5e-4576-b092-7db4929fba43"
 ---
 # CASE-dcd5e7e4: copy_test.go
 
-対象: `internal/engine/copy_test.go`
+## 対象
+
+`internal/engine/copy_test.go`
 
 コピー経路の各 syscall を実 FS の状態（通常ファイルで経路を塞いで ENOTDIR を誘発する・
 ディレクトリを読み取り元にする等、root でも成立する条件）で失敗させ、エラーが伝播することを

--- a/docs/test/engine-core/20260809-0c2cec08-dryrun-test-go.md
+++ b/docs/test/engine-core/20260809-0c2cec08-dryrun-test-go.md
@@ -2,12 +2,15 @@
 id: "CASE-0c2cec08-db65-427c-9480-ac0dcacc8d31"
 type: test_case
 name: "internal/engine/dryrun_test.go — dryrun の無副作用と除去なしの移行判断"
+target: "internal/engine/dryrun_test.go"
 covers:
   - "TC-a5eb7de3-a1a7-41ae-8fb9-c2aa374ac894"
 ---
 # CASE-0c2cec08: dryrun_test.go
 
-対象: `internal/engine/dryrun_test.go`
+## 対象
+
+`internal/engine/dryrun_test.go`
 
 `apply --dryrun` 相当の呼び出しが実 FS へ何も残さないこと、および事前除去を伴う分類でも
 除去を実行せずに判断へ至ることを実 tmpdir で確認する。

--- a/docs/test/engine-core/20260809-31fdb776-engine-test-go.md
+++ b/docs/test/engine-core/20260809-31fdb776-engine-test-go.md
@@ -2,6 +2,7 @@
 id: "CASE-31fdb776-9650-4ff9-97f6-45d56b2e7177"
 type: test_case
 name: "internal/engine/engine_test.go — 実 tmpdir に対する apply の統合テスト"
+target: "internal/engine/engine_test.go"
 covers:
   - "TC-9df804ce-35ee-44a7-87b1-17935d53fab2"
   - "TC-405606f0-3ac8-4cc2-998e-d4759a62a171"
@@ -16,7 +17,9 @@ covers:
 ---
 # CASE-31fdb776: engine_test.go
 
-対象: `internal/engine/engine_test.go`
+## 対象
+
+`internal/engine/engine_test.go`
 
 nix を介さず実 FS（`t.TempDir()`）へ apply を回す統合テスト。link farm と manifest を
 テスト側で組み立て、配置結果を実 FS のプローブで確認する。

--- a/docs/test/engine-core/20260809-efe9e9c8-planner-test-go.md
+++ b/docs/test/engine-core/20260809-efe9e9c8-planner-test-go.md
@@ -2,6 +2,7 @@
 id: "CASE-efe9e9c8-cc0a-4b1b-bf2b-aa1d15428252"
 type: test_case
 name: "internal/planner/planner_test.go — fake FS による plan 計算の table-driven 網羅"
+target: "internal/planner/planner_test.go"
 covers:
   - "TC-b329cafd-06c3-4b87-8357-229b69e5ba5c"
   - "TC-9df804ce-35ee-44a7-87b1-17935d53fab2"
@@ -11,7 +12,9 @@ covers:
 ---
 # CASE-efe9e9c8: planner_test.go
 
-対象: `internal/planner/planner_test.go`
+## 対象
+
+`internal/planner/planner_test.go`
 
 plan 計算を fake FS（`Lstat` / `Readlink` / `ReadDir` を差し替えたマップ）に対して回す
 table-driven テスト。実 FS へ触らずに分類の全パターンを列挙できることが、この CASE の存在

--- a/docs/test/engine-core/20260809-f3a5fee2-preflight-test-go.md
+++ b/docs/test/engine-core/20260809-f3a5fee2-preflight-test-go.md
@@ -2,12 +2,15 @@
 id: "CASE-f3a5fee2-1981-42c3-ba5b-81b75fd7a3ad"
 type: test_case
 name: "internal/engine/preflight_test.go — out-of-store 配置直前検査の非 ENOENT エラー"
+target: "internal/engine/preflight_test.go"
 covers:
   - "TC-8435052a-5dcc-49e2-ac26-82f645cb6890"
 ---
 # CASE-f3a5fee2: preflight_test.go
 
-対象: `internal/engine/preflight_test.go`
+## 対象
+
+`internal/engine/preflight_test.go`
 
 配置直前検査が out-of-store marker のリンク先を lstat する際、ENOENT（不在）以外のエラーを
 不在と同一視しないことを確認する。不在は「dangling symlink を作らずに止める」というユーザー

--- a/docs/test/generations/20260809-2008a909-result-extensions-test-go.md
+++ b/docs/test/generations/20260809-2008a909-result-extensions-test-go.md
@@ -2,6 +2,7 @@
 id: "CASE-2008a909-b45e-49e1-adf1-39191a8ddd95"
 type: test_case
 name: "result_extensions_test.go — 実行結果のインベントリ・世代観測・到達状態・構造化 warning"
+target: "internal/engine/result_extensions_test.go"
 covers:
   - "TC-1d19aebc-e1e6-4d6f-9440-3efbd69b18a8"
 ---

--- a/docs/test/generations/20260809-2de3a3d8-drift-test-go.md
+++ b/docs/test/generations/20260809-2de3a3d8-drift-test-go.md
@@ -2,6 +2,7 @@
 id: "CASE-2de3a3d8-3b67-485a-8ddf-a97dd182af23"
 type: test_case
 name: "drift_test.go — 世代スキップの発火条件と lstat ドリフト修復の対象範囲"
+target: "internal/engine/drift_test.go"
 covers:
   - "TC-765858b6-d596-4428-b4da-5d432944a714"
   - "TC-1ee7a729-5629-4c92-b02a-4f6e11c0b57d"

--- a/docs/test/generations/20260809-2e7b9ea2-e2e-02-home.md
+++ b/docs/test/generations/20260809-2e7b9ea2-e2e-02-home.md
@@ -2,6 +2,7 @@
 id: "CASE-2e7b9ea2-4e4d-48ca-9e1e-0bfbb6223ff2"
 type: test_case
 name: "e2e 02-home — 実 nix での home mode 世代コミットと rollback の往復"
+target: "tests/e2e/scenarios/02-home.sh"
 covers:
   - "TC-527b5034-715a-4df1-871a-072dc9062704"
 ---

--- a/docs/test/generations/20260809-364ebb9d-generations-test-go.md
+++ b/docs/test/generations/20260809-364ebb9d-generations-test-go.md
@@ -2,6 +2,7 @@
 id: "CASE-364ebb9d-b9f8-4c79-8509-8bbf31e73698"
 type: test_case
 name: "generations_test.go — 世代一覧パース・rollback の再収束と失敗経路・root 解決"
+target: "internal/engine/generations_test.go"
 covers:
   - "TC-746cb5b9-fe27-4d09-a51d-eb03d56a93a7"
   - "TC-36ea3609-d52e-42d4-975c-40fb89b23919"

--- a/docs/test/generations/20260809-503c9021-reset-test-go.md
+++ b/docs/test/generations/20260809-503c9021-reset-test-go.md
@@ -2,6 +2,7 @@
 id: "CASE-503c9021-a43f-4c06-8ef6-8630a7d4aeac"
 type: test_case
 name: "reset_test.go — FS-only teardown の除去範囲・フィルタ・dryrun・同意"
+target: "internal/engine/reset_test.go"
 covers:
   - "TC-06052178-ed49-4800-beb2-1d7c5d696ea8"
 ---

--- a/docs/test/generations/20260809-ff4a842e-paths-test-go.md
+++ b/docs/test/generations/20260809-ff4a842e-paths-test-go.md
@@ -2,6 +2,7 @@
 id: "CASE-ff4a842e-dd25-4c75-82ef-185507781d02"
 type: test_case
 name: "paths_test.go — state 基底の解決・roothash の性質・profileDir キーイング・世代リンク名と兄弟パス"
+target: "internal/paths/paths_test.go"
 covers:
   - "TC-40b762fc-3b48-471c-b495-c5ffe1f584b5"
 ---

--- a/docs/test/integration/20260809-1fc8b8b9-e2e-01-project.md
+++ b/docs/test/integration/20260809-1fc8b8b9-e2e-01-project.md
@@ -2,6 +2,7 @@
 id: "CASE-1fc8b8b9-d8c6-45f4-96a6-862de693822e"
 type: test_case
 name: "e2e 01-project — project mode の配置と --all の部分失敗を実 nix で通す"
+target: "tests/e2e/scenarios/01-project.sh"
 covers:
   - "TC-ec0bded4-c4bc-4a61-a2b5-0b652134b223"
   - "TC-1a46da17-1812-431b-966f-ec8dffd315ae"

--- a/docs/test/integration/20260809-3d858338-e2e-05-hm.md
+++ b/docs/test/integration/20260809-3d858338-e2e-05-hm.md
@@ -2,6 +2,7 @@
 id: "CASE-3d858338-ceba-420b-87b7-995acff8a0a1"
 type: test_case
 name: "e2e 05-hm — 非 NixOS で HM configuration を実際に activate する"
+target: "tests/e2e/scenarios/05-hm.sh"
 covers:
   - "TC-2f51dc14-f938-439d-b0c8-1d535914b2d3"
   - "TC-733ac4ed-dac3-4bb8-9bfd-fd1cbdc300c9"

--- a/docs/test/integration/20260809-4179dcb2-manifest-test.md
+++ b/docs/test/integration/20260809-4179dcb2-manifest-test.md
@@ -2,6 +2,7 @@
 id: "CASE-4179dcb2-f199-4469-ae87-0927ece06e65"
 type: test_case
 name: "manifest_test.go — v1 の復元と版・未知フィールドの拒否"
+target: "internal/manifest/manifest_test.go"
 covers:
   - "TC-172548ea-154a-4e22-a169-8252a43e3781"
 ---

--- a/docs/test/integration/20260809-474dc938-e2e-06-init-templates.md
+++ b/docs/test/integration/20260809-474dc938-e2e-06-init-templates.md
@@ -2,6 +2,7 @@
 id: "CASE-474dc938-dec8-4aae-9d91-607cfcd6dec0"
 type: test_case
 name: "e2e 06-init-templates — テンプレを展開して展開物の評価が通ることを確かめる"
+target: "tests/e2e/scenarios/06-init-templates.sh"
 covers:
   - "TC-7e1e6a63-80d5-452c-bc49-81854ffac5a4"
 ---

--- a/docs/test/integration/20260809-8dd7bf87-e2e-07-legacy.md
+++ b/docs/test/integration/20260809-8dd7bf87-e2e-07-legacy.md
@@ -2,6 +2,7 @@
 id: "CASE-8dd7bf87-687b-4ff9-bea2-0c4b3088c1c2"
 type: test_case
 name: "e2e 07-legacy — 非 flake entrypoint から同じ配置と出力契約を通す"
+target: "tests/e2e/scenarios/07-legacy.sh"
 covers:
   - "TC-d9c78439-e478-4779-977c-9c4c02dd4e93"
 ---

--- a/docs/test/integration/20260809-aa967f9a-gitutil-test.md
+++ b/docs/test/integration/20260809-aa967f9a-gitutil-test.md
@@ -2,6 +2,7 @@
 id: "CASE-aa967f9a-8020-44f8-b45f-57244711e1b5"
 type: test_case
 name: "gitutil_test.go — toplevel 解決の一意性とリポジトリ外・git 不在の失敗"
+target: "internal/gitutil/gitutil_test.go"
 covers:
   - "TC-ec0bded4-c4bc-4a61-a2b5-0b652134b223"
 ---

--- a/docs/test/integration/20260809-f5fce7b7-checks-hm-module.md
+++ b/docs/test/integration/20260809-f5fce7b7-checks-hm-module.md
@@ -2,6 +2,7 @@
 id: "CASE-f5fce7b7-9780-4c8e-bf6b-f3e4b7b3bb3d"
 type: test_case
 name: "checks.hm-module — activation の配線を評価アサートで検証する flake check"
+target: "checks.hm-module"
 covers:
   - "TC-5a72b00e-2c03-4703-acdc-33cffb6fa994"
 ---

--- a/docs/test/manifest-eval/20260809-0c9d41d1-nix-unit-resolve-marker.md
+++ b/docs/test/manifest-eval/20260809-0c9d41d1-nix-unit-resolve-marker.md
@@ -2,6 +2,7 @@
 id: "CASE-0c9d41d1-33fd-4982-aed9-fa575a56ee01"
 type: test_case
 name: "nix-unit: resolve-marker.nix — src 解決と marker 判別述語"
+target: "tests/nix-unit/resolve-marker.nix"
 covers:
   - "TC-81be084d-709f-481b-9b61-5d2d11c317a0"
 ---

--- a/docs/test/manifest-eval/20260809-36b5b61a-nix-unit-escapes-base.md
+++ b/docs/test/manifest-eval/20260809-36b5b61a-nix-unit-escapes-base.md
@@ -2,6 +2,7 @@
 id: "CASE-36b5b61a-f40e-4bd5-97d9-f2b0c9284a72"
 type: test_case
 name: "nix-unit: escapes-base.nix — `..` 深さ判定の境界網羅"
+target: "tests/nix-unit/escapes-base.nix"
 covers:
   - "TC-311ca3b2-d6d1-4712-9e2a-9027941d3527"
 ---

--- a/docs/test/manifest-eval/20260809-3a1f403d-nix-unit-farm-entries.md
+++ b/docs/test/manifest-eval/20260809-3a1f403d-nix-unit-farm-entries.md
@@ -2,6 +2,7 @@
 id: "CASE-3a1f403d-3c7b-4221-a32a-2ddc272a58a3"
 type: test_case
 name: "nix-unit: farm-entries.nix — アンカー対象の抽出と anchorLines の組み立て"
+target: "tests/nix-unit/farm-entries.nix"
 covers:
   - "TC-1d69350e-db3c-4d74-a24e-7a3fabb31b0a"
 ---

--- a/docs/test/manifest-eval/20260809-59de34d4-nix-unit-defaults.md
+++ b/docs/test/manifest-eval/20260809-59de34d4-nix-unit-defaults.md
@@ -2,6 +2,7 @@
 id: "CASE-59de34d4-d9d5-4ae0-b1be-44d2e775f031"
 type: test_case
 name: "nix-unit: defaults.nix — 既定適用・明示上書き・target 辞書順"
+target: "tests/nix-unit/defaults.nix"
 covers:
   - "TC-d9175bb5-d7ec-41e0-8bee-71de928a71fb"
 ---

--- a/docs/test/manifest-eval/20260809-7a6c4957-nix-unit-structure.md
+++ b/docs/test/manifest-eval/20260809-7a6c4957-nix-unit-structure.md
@@ -2,6 +2,7 @@
 id: "CASE-7a6c4957-9365-4490-b48f-9725f42162f2"
 type: test_case
 name: "nix-unit: structure.nix — manifest 構造の不変条件"
+target: "tests/nix-unit/structure.nix"
 covers:
   - "TC-4e7cfae7-72bc-4af6-a1f5-1ead7db564b1"
 ---

--- a/docs/test/manifest-eval/20260809-7fb33044-namaka-manifest-project.md
+++ b/docs/test/manifest-eval/20260809-7fb33044-namaka-manifest-project.md
@@ -2,6 +2,7 @@
 id: "CASE-7fb33044-b68c-4518-bd93-b258072235ee"
 type: test_case
 name: "namaka: manifest-project — manifest 文書全体のスナップショット回帰"
+target: "tests/namaka/manifest-project/"
 covers:
   - "TC-de6514e2-9105-45a6-a5b9-d474911a401b"
 ---

--- a/docs/test/manifest-eval/20260809-879a93da-nix-unit-gates.md
+++ b/docs/test/manifest-eval/20260809-879a93da-nix-unit-gates.md
@@ -2,6 +2,7 @@
 id: "CASE-879a93da-d22f-4397-84da-3544f8249af1"
 type: test_case
 name: "nix-unit: gates.nix — 評価時に throw する検査ゲート群"
+target: "tests/nix-unit/gates.nix"
 covers:
   - "TC-e7ff0e6d-32d7-4ed6-8c2f-449dba34b2f6"
 ---

--- a/docs/test/manifest-eval/20260809-ead15d61-nix-unit-anchor-name.md
+++ b/docs/test/manifest-eval/20260809-ead15d61-nix-unit-anchor-name.md
@@ -2,6 +2,7 @@
 id: "CASE-ead15d61-8ca7-41fb-9121-a5d247ef727a"
 type: test_case
 name: "nix-unit: anchor-name.nix — GC アンカー名の形式と決定性"
+target: "tests/nix-unit/anchor-name.nix"
 covers:
   - "TC-a6a14739-89e5-4eba-acee-3ed5be5a0b7e"
 ---

--- a/docs/test/migration-stale/20260809-39fbf9f0-preremove-generalization-test-go.md
+++ b/docs/test/migration-stale/20260809-39fbf9f0-preremove-generalization-test-go.md
@@ -2,6 +2,7 @@
 id: "CASE-39fbf9f0-ddd6-4d57-9c77-00b4f3eae488"
 type: test_case
 name: "internal/engine/preremove_generalization_test.go — レイアウト移行と method 変更"
+target: "internal/engine/preremove_generalization_test.go"
 covers:
   - "TC-b9d4ffaf-ac91-4bf1-9f27-5ea3964466ad"
   - "TC-76597b11-8199-4682-8f53-008e5208bd9c"
@@ -10,7 +11,9 @@ covers:
 ---
 # CASE-39fbf9f0: preremove_generalization_test.go
 
-対象: `internal/engine/preremove_generalization_test.go`
+## 対象
+
+`internal/engine/preremove_generalization_test.go`
 
 配置前除去の適用範囲が「自己記録の stale な祖先 symlink」から「配置 target を占有する自己記録
 stale な FS オブジェクト全般」へ一般化されたこと（実ディレクトリ全体・method 変更）を、

--- a/docs/test/migration-stale/20260809-b5d8c327-staleremove-test-go.md
+++ b/docs/test/migration-stale/20260809-b5d8c327-staleremove-test-go.md
@@ -2,6 +2,7 @@
 id: "CASE-b5d8c327-1f52-4566-98d3-22216d609d94"
 type: test_case
 name: "internal/engine/staleremove_test.go — drift 再検証と空親剪定"
+target: "internal/engine/staleremove_test.go"
 covers:
   - "TC-8a1f4b19-0ece-4057-a8bf-f9717855cade"
   - "TC-810d661d-6d3d-4199-828f-e44adcebad5a"
@@ -9,7 +10,9 @@ covers:
 ---
 # CASE-b5d8c327: staleremove_test.go
 
-対象: `internal/engine/staleremove_test.go`
+## 対象
+
+`internal/engine/staleremove_test.go`
 
 `removeStale` / `preRemove` を Apply パイプラインを通さず直接駆動し、実 tmpdir 上で drift の
 同値類と剪定の境界を確認する。除去アクションは記録上の dest と実 FS 上の target を独立に

--- a/docs/test/migration-stale/20260809-e4683bd5-e2e-03-stale.md
+++ b/docs/test/migration-stale/20260809-e4683bd5-e2e-03-stale.md
@@ -2,12 +2,15 @@
 id: "CASE-e4683bd5-1603-41e5-81ba-98373780f47c"
 type: test_case
 name: "tests/e2e/scenarios/03-stale.sh — 実 nix での stale 除去"
+target: "tests/e2e/scenarios/03-stale.sh"
 covers:
   - "TC-d160e18b-4c0c-4531-a506-e7d00d88788a"
 ---
 # CASE-e4683bd5: e2e 03-stale
 
-対象: `tests/e2e/scenarios/03-stale.sh`
+## 対象
+
+`tests/e2e/scenarios/03-stale.sh`
 
 隔離した一時 `$HOME` / `$XDG_STATE_HOME` の下で、2 entry を持つ fixture flake を実 nix で
 評価して apply し、片方の entry を config から削除して再 apply する。設定変更から除去までを


### PR DESCRIPTION
## 概要

テストコード ⇔ テストドキュメント（CASE）の対応を機械化する。epic #283 の基盤タスク。

#273 の逆算で `docs/test/<対象>/` に TC / CASE が揃ったが、CASE とテストコードの対応は本文の
散文（しかも `対象:` 1 行形式 10 件 / `## 対象` セクション形式 37 件の 2 形式に割れていた）に
しか無く、機械照合できなかった。このため「テストファイルを追加・リネームしても CASE が追従
しない」ドリフトを検出する手段が無かった。

入れたもの:

- **`docs/model.yaml` の `test_case` へ必須の `target`**（単一 `text`・`required: true`）。正準形は
  「実在するファイルはリポジトリ相対パス」「flake check は `checks.<name>`」の 2 規則。既存 47 件へ
  掃引し、本文の対象表記は `## 対象` セクション形式へ正規化した（規範は frontmatter、本文は人間向け）
- **`dev/scripts/test-inventory.sh`** — テスト資産の列挙を一元化。`--static`（ファイル粒度・find /
  glob のみ）と `--full`（テスト名粒度・`go test -json` 実行ベース + nix-unit の per-file attrNames）
- **`dev/tests/test-doc-map.sh`** — 契約テスト。順方向 / 逆方向 / 1:1 一意性 / データファイルの健全性 /
  静的 flake check リストの突合 / 自己検証。**純静的**（`go test` も `nix eval` も呼ばない）なので
  毎 PR で回せる。`dev` flake の `checks.test-doc-map` と CI `sara` ジョブの 2 経路（`sara-id.sh` と同型）
- **`dev/scripts/test-doc-matrix.sh`** — 対応表 Markdown の生成。main push / `workflow_dispatch` で
  artifact 化し、**リポジトリへはコミットしない**（生成物とソースのドリフト回避）
- **データファイル 2 本を SSOT に**（`dev/tests/test-categories.tsv` / `test-doc-exclusions.tsv`）。
  CLAUDE.md の 8 区分表には規範がデータファイル側にある旨を注記した

区分表は「どの区分が存在するか・並び順」だけを持ち、個々の資産の区分は持たない。パス prefix では
決まらないため（`internal/engine/*_test.go` は 5 区分・`tests/e2e/scenarios/*` は 4 区分へ割れる）、
prefix 表を持つと CASE の置き場所との二重管理になる。

**動作確認**

- `sara check` 緑 / `nix flake check ./dev` 緑（`checks.test-doc-map` / `checks.sara-id` とも）
- 契約テスト全アサーション緑（CASE 47 件 / テスト資産 55 件 / 除外 8 件）
- ドリフト検出: テストファイルのリネームで exit 1（順方向・逆方向の双方が報告）/ CASE 無しの
  新規テストファイル追加で exit 1 / flake へ check を足すと静的リスト突合が FAIL / clean で exit 0
- **mutation テスト 9 点すべてが exit 1 で検知**されることを実機確認（判定 4 分岐 + `run_judge` 2 種 +
  引数入れ替え + 部分集合契約 + exclusions 分岐）
- 対応表をローカル生成し、8 区分すべてのセクションと区分ごとの CASE 件数が `docs/test/<区分>/` の
  実数と一致することを確認

**レビュー経緯**

`/review-converge` を 5 周（上限）回した。各周で両レンズ（design / test）が独立に一致する実欠陥を
検出しており、いずれも実機で再現を確認してから修正している。主要なもの:

1. `FLAKE_CHECKS` に自分が新設した `dev:checks.test-doc-map` が無く、**契約テストが防ぐはずのドリフトを
   初回コミットで自ら踏んでいた**。検知の向きも逆で、リストへ足し忘れた側が素通りしていた
2. 自己検証が判定コードを呼ばずプリミティブを再実装しており、判定を `if false` に差し替えても緑
3. 同じ穴が 1 段外側の `run_judge`（pass / fault 振り分け）へ移動
4. 3 で入れた `covered ⊆ assets` が恒真で、引数入れ替えが全緑 + 新規未カバー資産が無検知
5. 4 で入れた部分集合契約がリネーム時に早期 return し、診断が存在しない配線バグを誤指摘して
   未カバー資産を隠していた

最終周の残指摘は実質 0 件（`nit` 1 件は閾値 want の対象外）。境界外の指摘は全 5 周で 0 件。

## 関連 issue

Closes #304
Refs #283

## docs / ADR 影響

- **`docs/model.yaml`**: `test_case` へ `target` フィールドを追加（型定義の変更）
- **`docs/test/` の CASE 47 件**: `target` の付与と本文の対象セクション正規化
- **`CLAUDE.md`**: 8 区分表へデータファイルが SSOT である旨の注記、CASE 粒度規約へ `target` と
  契約テストによる 1:1 強制を追記、開発コマンドへ 3 コマンドを追記
- **concept / design / spec**: 更新なし。requirement / quality / test_plan / design item を 1 件も
  追加しておらず、プロジェクト規約で risk / TC / CASE は `docs/spec.md` へ索引しないため
- **ADR**: 追加なし。確定設計の SSOT は issue #304 本文で、既存 ADR と矛盾しない
  （sara ジョブを required にしない方針は ADR-0050 に従っている）
