### PR TITLE
ci: 対応表を job summary へも出力する

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -276,6 +276,18 @@ jobs:
         if: steps.filter.outputs.relevant != 'false'
         run: nix develop ./dev -c dev/scripts/test-doc-matrix.sh test-doc-matrix.md
 
+      # GITHUB_STEP_SUMMARY discards the entire step summary past 1 MiB, so an
+      # oversized table falls back to a pointer at the artifact instead of
+      # silently vanishing.
+      - name: Publish correspondence table to job summary
+        if: steps.filter.outputs.relevant != 'false'
+        run: |
+          if [ "$(stat -c%s test-doc-matrix.md)" -lt 1000000 ]; then
+            cat test-doc-matrix.md >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo 'test-doc-matrix.md exceeds the 1 MiB step-summary limit; download the `test-doc-matrix` artifact instead.' >> "$GITHUB_STEP_SUMMARY"
+          fi
+
       - name: Upload correspondence table
         if: steps.filter.outputs.relevant != 'false'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1


### PR DESCRIPTION
## 概要

#304 で追加したテスト対応表（`test-doc-matrix.md`）は artifact へのアップロードのみで、読むにはダウンロード・展開の手間が要る。生成ジョブに 1 step を足し、同じ Markdown を `$GITHUB_STEP_SUMMARY` へも書き出して run ページ上で直接レンダリングされるようにする。

job summary は 1 step あたり 1 MiB を超えると summary 全体が黙って破棄されるため、超過時は本文を書かず「artifact を参照」の案内 1 行にフォールバックする。artifact アップロードは保持期間・機械処理の用途があるため従来どおり併用する。

## 関連 issue

Refs #304

## docs / ADR 影響

なし（CI 上の閲覧経路の追加のみ。生成スクリプト・契約テスト・配置動作に変更はない）
