### PR TITLE
docs(dev): manifest-eval 区分の件数・ファイル名の書き下しを集合参照へ改める

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,7 @@ risk を `requirement` と `design` のどちらに張るかの使い分けは `
 
 | `<対象>` | 含むテスト資産 | 上位の test_plan |
 |---|---|---|
-| `manifest-eval` | `tests/nix-unit/` 配下の全テスト + namaka `manifest-project` | TP-36e90d5d / TP-d3d06fe4 / TP-403c55c7 |
+| `manifest-eval` | `tests/nix-unit/` と `tests/namaka/` 配下の全テスト | TP-36e90d5d / TP-d3d06fe4 / TP-403c55c7 |
 | `engine-core` | `internal/engine/` の engine / dryrun / preflight、`internal/planner/` | TP-e7c25263 |
 | `copy` | copytree / copy、e2e `04-copy` | TP-e7c25263 / TP-229b69c0 |
 | `migration-stale` | preremove_generalization / staleremove、e2e `03-stale` | TP-e7c25263 / TP-229b69c0 |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,7 @@ risk を `requirement` と `design` のどちらに張るかの使い分けは `
 
 | `<対象>` | 含むテスト資産 | 上位の test_plan |
 |---|---|---|
-| `manifest-eval` | nix-unit 全 7（structure / defaults / gates / escapes-base / anchor-name / resolve-marker / farm-entries）+ namaka manifest-project | TP-36e90d5d / TP-d3d06fe4 / TP-403c55c7 |
+| `manifest-eval` | `tests/nix-unit/` 配下の全テスト + namaka `manifest-project` | TP-36e90d5d / TP-d3d06fe4 / TP-403c55c7 |
 | `engine-core` | `internal/engine/` の engine / dryrun / preflight、`internal/planner/` | TP-e7c25263 |
 | `copy` | copytree / copy、e2e `04-copy` | TP-e7c25263 / TP-229b69c0 |
 | `migration-stale` | preremove_generalization / staleremove、e2e `03-stale` | TP-e7c25263 / TP-229b69c0 |

--- a/dev/tests/test-categories.tsv
+++ b/dev/tests/test-categories.tsv
@@ -12,7 +12,7 @@
 # 形式: <区分>\t<説明>
 # 行頭 # はコメント、空行は無視。列の区切りはタブ 1 個。
 # 区分の並び順 = 対応表のセクション順（この表の記載順）。
-manifest-eval	nix-unit 全 7 + namaka manifest-project（manifest の純評価）
+manifest-eval	tests/nix-unit 配下の全テスト + namaka manifest-project（manifest の純評価）
 engine-core	internal/engine の engine / dryrun / preflight、internal/planner
 copy	copytree / copy、e2e 04-copy
 migration-stale	preremove_generalization / staleremove、e2e 03-stale

--- a/dev/tests/test-categories.tsv
+++ b/dev/tests/test-categories.tsv
@@ -12,7 +12,7 @@
 # 形式: <区分>\t<説明>
 # 行頭 # はコメント、空行は無視。列の区切りはタブ 1 個。
 # 区分の並び順 = 対応表のセクション順（この表の記載順）。
-manifest-eval	tests/nix-unit 配下の全テスト + namaka manifest-project（manifest の純評価）
+manifest-eval	tests/nix-unit と tests/namaka 配下の全テスト（manifest の純評価）
 engine-core	internal/engine の engine / dryrun / preflight、internal/planner
 copy	copytree / copy、e2e 04-copy
 migration-stale	preremove_generalization / staleremove、e2e 03-stale


### PR DESCRIPTION
## 概要

`manifest-eval` 区分の説明が持っていたテスト件数・ファイル名の書き下しを、個数に依存しない
集合参照へ改める。

`CLAUDE.md` の区分表は `nix-unit 全 7（structure / defaults / gates / escapes-base / anchor-name /
resolve-marker / farm-entries）+ namaka manifest-project`、`dev/tests/test-categories.tsv` は
`nix-unit 全 7 + namaka manifest-project` と書いていたが、実体は `tests/nix-unit/` が 9 ファイル。
`fixed-root.nix`（#288）で 7→8、`aggregator-merge.nix`（#308）で 8→9 とずれていた。

件数 9 への追随ではなく書き下し自体を落とす（Issue #321 の 2026-08-11 決着コメント = 方針 2）。
件数もファイル名もその時点のスナップショットであり、leaf を足すたびに同じドリフトが再発するため。
両ファイルとも `tests/nix-unit/` と `tests/namaka/` 配下の集合を指す表現へ改めた。

- `CLAUDE.md:61`: `` `tests/nix-unit/` と `tests/namaka/` 配下の全テスト``
- `dev/tests/test-categories.tsv:15`: `tests/nix-unit と tests/namaka 配下の全テスト（manifest の純評価）`

namaka 側の leaf 名 `manifest-project` も同型のスナップショットのため併せて落とした（レビュー指摘）。
leaf の発見は `dev/scripts/test-inventory.sh` の `maxdepth 1` 走査で nix-unit / namaka とも同じ仕組み。

対象外としたもの:

- `dev/tests/test-doc-map.sh` への件数照合の追加（Issue の決着で明示的に不採用。契約テストの
  設計変更を含みコストに見合わない）
- `dev/tests/test-categories.tsv` の区分名・並び順（SSOT 部分。変更しない）

動作確認: `nix develop '.?dir=dev#sara' -c dev/tests/test-doc-map.sh` 緑（全アサーション通過 /
CASE 49 件・テスト資産 57 件・除外 8 件）。同スクリプトは説明列を非空チェックのみ行い内容は
照合しないため、記述変更で契約は壊れない。

## 関連 issue

Closes #321 / Refs #283

レビュー収束で検出した境界外の指摘は #324 として分離済み
（`docs/test-plan/20260809-36e90d5d-nix-unit-namaka-split.md` の現況節に同型の件数書き下しが残る）。

## docs / ADR 影響

なし。配置動作・API・方針には触れず、`concept` / `design` / `spec` の更新は不要。ADR の追加も不要
（Issue #321 で決着済みの方針の適用であり、新たな trade-off の判断を含まない）。

`docs/` 配下の item も変更していない。今回触れたのは開発者向けの読み物（`CLAUDE.md` の区分表）と
契約テストが読むデータファイルの説明列のみ。
