### PR TITLE
test(engine): resolveRoot の fixed + パス無し拒否を固定する

### DIFF
--- a/docs/test/engine-core/20260809-31fdb776-engine-test-go.md
+++ b/docs/test/engine-core/20260809-31fdb776-engine-test-go.md
@@ -31,8 +31,10 @@ nix を介さず実 FS（`t.TempDir()`）へ apply を回す統合テスト。li
 - **上書き拒否**: target の通常ファイル占有でエラー停止、祖先 symlink でエラー停止、
   祖先が自己記録 stale のときのみ移行（copy 子を含む）
 - **stale 除去との接続**: 記録済み entry の除去、foreign を残すこと
-- **root 解決**: git repo 外でのエラー、固定絶対 root の解決失敗、profile ディレクトリ作成
-  失敗・backref 書き込み失敗のエラー化
+- **root 解決**: git repo 外でのエラー、固定絶対 root の解決失敗、`fixed` でパスを省いた
+  ときの拒否（エラー本文一致。manifest 層が受理する組み合わせを engine が止める責務
+  → CASE-4179dcb2 / TC-172548ea）、profile ディレクトリ作成失敗・backref 書き込み失敗の
+  エラー化
 - **out-of-store**: live symlink の配置、stale 除去、リンク先不一致時の保持、marker の
   リンク先が不在のときのエラー停止（dangling symlink を作らず target も残さないこと）
 - **copy 経路の呼び出し**: place-once の初回・既存保持、foreign 実ファイルの skip 警告、

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -984,6 +984,20 @@ func TestApplyRecopyForeignFileOverwrites(t *testing.T) {
 // ENOTEMPTY), not permission bits, so they reproduce under root as well and need
 // no os.Geteuid()==0 skip guard.
 
+// TestResolveRootFixedWithoutPath pins the fixed-root rejection when no path is given.
+// The manifest layer intentionally accepts a `fixed` root document that omits the path
+// (→ CASE-4179dcb2 / TC-172548ea), so this branch is the only place the invalid pair is
+// refused; the exact message is asserted because those items name it as engine's duty.
+func TestResolveRootFixedWithoutPath(t *testing.T) {
+	_, err := resolveRoot(manifest.RootKindFixed, "", "", "", nil)
+	if err == nil {
+		t.Fatal("expected an error for rootKind=fixed without a root path, got nil")
+	}
+	if want := "nput: rootKind=fixed but no root path provided"; err.Error() != want {
+		t.Errorf("error = %q, want %q", err.Error(), want)
+	}
+}
+
 // TestResolveRootFixedAbsFailure covers engine.go:359 (filepath.Abs(fixedRoot)).
 // filepath.Abs only errors when the path is relative and os.Getwd fails, which is
 // inherently environment-dependent: we induce it by chdir'ing into a directory and

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -977,17 +977,11 @@ func TestApplyRecopyForeignFileOverwrites(t *testing.T) {
 	}
 }
 
-// --- error-path coverage (engine.go:262-264, 359, 369-382) ------------------
-// These exercise the under-covered failure branches of resolveRoot (fixed-root
-// Abs), ensureProfileDir (mkdir / backref write), and cleanupPending (warn-only
-// Remove). Failures are induced by file-type conflicts (ENOTDIR / EISDIR /
-// ENOTEMPTY), not permission bits, so they reproduce under root as well and need
-// no os.Geteuid()==0 skip guard.
-
 // TestResolveRootFixedWithoutPath pins the fixed-root rejection when no path is given.
 // The manifest layer intentionally accepts a `fixed` root document that omits the path
 // (→ CASE-4179dcb2 / TC-172548ea), so this branch is the only place the invalid pair is
 // refused; the exact message is asserted because those items name it as engine's duty.
+// This is a pure argument check, so it stays outside the file-type-conflict section below.
 func TestResolveRootFixedWithoutPath(t *testing.T) {
 	_, err := resolveRoot(manifest.RootKindFixed, "", "", "", nil)
 	if err == nil {
@@ -997,6 +991,13 @@ func TestResolveRootFixedWithoutPath(t *testing.T) {
 		t.Errorf("error = %q, want %q", err.Error(), want)
 	}
 }
+
+// --- error-path coverage (engine.go:262-264, 359, 369-382) ------------------
+// These exercise the under-covered failure branches of resolveRoot (fixed-root
+// Abs), ensureProfileDir (mkdir / backref write), and cleanupPending (warn-only
+// Remove). Failures are induced by file-type conflicts (ENOTDIR / EISDIR /
+// ENOTEMPTY), not permission bits, so they reproduce under root as well and need
+// no os.Geteuid()==0 skip guard.
 
 // TestResolveRootFixedAbsFailure covers engine.go:359 (filepath.Abs(fixedRoot)).
 // filepath.Abs only errors when the path is relative and os.Getwd fails, which is


### PR DESCRIPTION
<!--
PR テンプレート（ソロ運用・最小構成）。
チェックリストは置かない。形骸化を避け、このリポジトリで実際に意味のある 3 点だけ書く。
-->

## 概要

`internal/engine/engine.go` の `resolveRoot` が持つ「`rootKind = "fixed"` でパスが空のとき
`nput: rootKind=fixed but no root path provided` で停止する」分岐に、テストが 1 件も無かった。
`resolveRoot` を直接叩くテストは home / override / fixed + 相対パスの 3 本のみで、
fixed × パス無しという無効同値クラスがどの層のテストにも属していなかった。

この穴が塞がっていないと困るのは、#309 の対処で消費側（`internal/manifest/`）が `fixed` の
パス省略を**意図的に受理する**ようになり、その拒否は engine の担当であることを
CASE-4179dcb2 / TC-172548ea の本文へ明記したため。分岐が握り潰される方向へ壊れても
manifest 層のテストは緑のまま通り、CASE / TC の記述だけが黙って偽になる。

実装変更は無く、既存分岐の固定テストのみ。エラー本文の完全一致でアサートしているのは、
TC-172548ea が「拒否する条件では、エラーが意図した検査の由来であることまで見る」と
方式を規範化しているため。

テストは FS を一切触らない純粋な引数検証なので、直下の `--- error-path coverage ---` 節
（ファイル種別衝突で失敗を誘発する前提を宣言し、それが root 実行でも `os.Geteuid()==0` の
skip guard を要さない根拠になっている）の**外**へ置いた。

確認したこと:

- `go test ./internal/engine/...` 緑
- `nix develop ./dev --command sara check` 緑
- `nix develop '.?dir=dev#sara' -c dev/tests/test-doc-map.sh` 緑

## 関連 issue

Closes #318

review-converge（design / test / spec の 3 レンズ・2 周で収束）で出た境界外の指摘は、
epic #283 の sub-issue として切り出した。

- Refs #325 — TC-b254a5a8 / RISK-24e0805d へ fixed × パス無しの拒否を追随させる
- Refs #326 — `resolveRoot` の undetermined / unknown rootKind 分岐を固定する
- Refs #328 — `resolveRoot` の純引数ユニットテストが 2 ファイルに分散している

## docs / ADR 影響

- CASE-31fdb776（`docs/test/engine-core/20260809-31fdb776-engine-test-go.md`）の
  「主な検証内容 > root 解決」へ、`fixed` でパスを省いたときの拒否を追記した。
  責務委譲を記述している CASE-4179dcb2 / TC-172548ea への参照も添えた
- concept / design / spec の更新は**なし**。実装の挙動・API・方針に変更は無く、既存分岐を
  テストで固定しただけのため
- ADR の追加も**なし**。設計判断の転換や trade-off を伴わない
