### PR TITLE
test(engine): resolveRoot の undetermined / unknown rootKind 分岐を固定する

### DIFF
--- a/docs/test/engine-core/20260809-31fdb776-engine-test-go.md
+++ b/docs/test/engine-core/20260809-31fdb776-engine-test-go.md
@@ -33,7 +33,9 @@ nix を介さず実 FS（`t.TempDir()`）へ apply を回す統合テスト。li
 - **stale 除去との接続**: 記録済み entry の除去、foreign を残すこと
 - **root 解決**: git repo 外でのエラー、固定絶対 root の解決失敗、`fixed` でパスを省いた
   ときの拒否（エラー本文一致。manifest 層が受理する組み合わせを engine が止める責務
-  → CASE-4179dcb2 / TC-172548ea）、profile ディレクトリ作成失敗・backref 書き込み失敗の
+  → CASE-4179dcb2 / TC-172548ea）、rootKind 未決（`""`）と未知の値の拒否（いずれも
+  エラー本文一致。未知の値は `%q` のクォートまで含めて固定する。`systemRoot` は system
+  mode 実装で差し替わるため対象外）、profile ディレクトリ作成失敗・backref 書き込み失敗の
   エラー化
 - **out-of-store**: live symlink の配置、stale 除去、リンク先不一致時の保持、marker の
   リンク先が不在のときのエラー停止（dangling symlink を作らず target も残さないこと）

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -992,6 +992,44 @@ func TestResolveRootFixedWithoutPath(t *testing.T) {
 	}
 }
 
+// TestResolveRootInvalidKinds pins the remaining rejection branches of resolveRoot:
+// the undetermined rootKind ("" — reached when neither eval prefetch nor a manifest
+// supplied one) and any unknown value (the default arm). Both messages are asserted
+// verbatim because they are the only signal the caller gets; the unknown case is
+// formatted with %q, so the expectation carries the quotes as well.
+// RootKindSystem is deliberately left out: its rejection is a placeholder for the
+// unimplemented system mode and will be replaced along with the implementation
+// (→ #129 / #139 / #140), so pinning it now would only pin something scheduled to go.
+func TestResolveRootInvalidKinds(t *testing.T) {
+	tests := []struct {
+		name     string
+		rootKind string
+		want     string
+	}{
+		{
+			name:     "undetermined",
+			rootKind: "",
+			want:     "nput: rootKind is undetermined (eval prefetch or a manifest is required)",
+		},
+		{
+			name:     "unknown",
+			rootKind: "bogus",
+			want:     `nput: unknown rootKind: "bogus"`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := resolveRoot(tt.rootKind, "", "", "", nil)
+			if err == nil {
+				t.Fatalf("expected an error for rootKind=%q, got nil", tt.rootKind)
+			}
+			if err.Error() != tt.want {
+				t.Errorf("error = %q, want %q", err.Error(), tt.want)
+			}
+		})
+	}
+}
+
 // --- error-path coverage (engine.go:262-264, 359, 369-382) ------------------
 // These exercise the under-covered failure branches of resolveRoot (fixed-root
 // Abs), ensureProfileDir (mkdir / backref write), and cleanupPending (warn-only


### PR DESCRIPTION
<!--
PR テンプレート（ソロ運用・最小構成）。
チェックリストは置かない。形骸化を避け、このリポジトリで実際に意味のある 3 点だけ書く。
-->

## 概要

`internal/engine/engine.go` の `resolveRoot` にある拒否分岐のうち、rootKind 未決（`""`）と
未知の値（`default` arm）の 2 つはどのテストからも未到達だった。#318 で「fixed × パス無し」を
埋めた際のスコープ外として残っていた分を、同じ形（エラー本文一致）で固定する。

`TestResolveRootInvalidKinds` を追加し、2 分岐をサブテストで固定した。unknown 側は
`%q` で整形されるため、期待値にクォートまで含めている。`RootKindSystem` は system mode の
実装（#129 / #139 / #140）でテストごと差し替わるため対象外とし、その理由をテストの
コメントへ残した。

実装変更は伴わない（既存分岐の固定のみ）。

確認:

- `go test ./internal/engine/...` 緑
- `nix develop ./dev --command sara check` 緑
- `nix develop '.?dir=dev#sara' -c dev/tests/test-doc-map.sh` 緑

## 関連 issue

Closes #326
Refs #283

## docs / ADR 影響

concept / design / spec の更新: なし（実装の挙動は変えていない）。
ADR: なし（設計判断を伴わない）。

CASE-31fdb776（`docs/test/engine-core/20260809-31fdb776-engine-test-go.md`）の
「主な検証内容 > root 解決」へ、undetermined / unknown 分岐と `systemRoot` 除外の旨を追記した。
新規 item の採番はしていない。
