### PR TITLE
docs(test-plan): TP-36e90d5d の現況節の件数・ファイル名書き下しを集合参照へ改める

### DIFF
--- a/docs/test-plan/20260809-36e90d5d-nix-unit-namaka-split.md
+++ b/docs/test-plan/20260809-36e90d5d-nix-unit-namaka-split.md
@@ -74,7 +74,7 @@ Issue #287 以降「一意性は規約に留めず、マージ前の重複検査
 要請の記述に留まらず強制の宣言も持つ（検査の実体は `tests/nix-unit-lib.nix` の `mergeTests`。
 → Issue #308）。
 
-この分担を実装しているテスト資産は `tests/nix-unit/` と `tests/namaka/` 配下の全テスト
-（manifest-eval 区分）。件数と leaf 名はここに書き下さない——leaf を足すたびにずれる
-スナップショットになるため（→ Issue #321 / #324）。現時点の一覧は列挙で得る
-（`dev/scripts/test-inventory.sh --static`）。
+この分担を実装しているテスト資産は `tests/nix-unit/` と `tests/namaka/` 配下の全テスト。
+件数と leaf 名はここでは集合参照に留めている（leaf を足すたびにずれるスナップショットに
+なるため。→ Issue #321 / #324）。現時点の一覧は列挙で得る
+（`dev/scripts/test-inventory.sh --static` の種別列 `nix-unit` / `namaka` の行）。

--- a/docs/test-plan/20260809-36e90d5d-nix-unit-namaka-split.md
+++ b/docs/test-plan/20260809-36e90d5d-nix-unit-namaka-split.md
@@ -74,6 +74,7 @@ Issue #287 以降「一意性は規約に留めず、マージ前の重複検査
 要請の記述に留まらず強制の宣言も持つ（検査の実体は `tests/nix-unit-lib.nix` の `mergeTests`。
 → Issue #308）。
 
-現況は nix-unit 9 ファイル（structure / defaults / gates / escapes-base / anchor-name /
-resolve-marker / farm-entries / fixed-root / aggregator-merge）+ namaka スナップショット
-1 件（manifest-project）。
+この分担を実装しているテスト資産は `tests/nix-unit/` と `tests/namaka/` 配下の全テスト
+（manifest-eval 区分）。件数と leaf 名はここに書き下さない——leaf を足すたびにずれる
+スナップショットになるため（→ Issue #321 / #324）。現時点の一覧は列挙で得る
+（`dev/scripts/test-inventory.sh --static`）。


### PR DESCRIPTION
## 概要

TP-36e90d5d（`docs/test-plan/20260809-36e90d5d-nix-unit-namaka-split.md`）の `## 出典` 節末尾が
「nix-unit 9 ファイル（structure / defaults / … / aggregator-merge）+ namaka スナップショット 1 件
（manifest-project）」と件数・leaf 名を書き下していた。leaf を足すたびにずれるスナップショットで、
実際 PR #320 で 8 → 9 へ追随させた履歴がある。

#321（PR #327）が `CLAUDE.md` の区分表と `dev/tests/test-categories.tsv` へ適用した決着
——件数への追随ではなく書き下し自体を落とす——を、同じ知識を持つ 3 箇所目である本 item へ
横展開する。落とした leaf 名の情報は `docs/test/manifest-eval/` の CASE が `target` で保持しており
（1:1 は `dev/tests/test-doc-map.sh` が機械強制）、TP 側の列挙は元々 canonical ではなかった。

2 コミット目はレビュー収束（diff-review spec レンズ）で出た want 2 件への対応。1 コミット目の
新文が (1) 区分語彙 `manifest-eval` への依存を出典節へ持ち込み、区分の改称・統廃合で機械検査の
外側に古びる箇所を新たに作っていた点、(2)「ここに書き下さない」という規範文を出典節に生やし、
規範は `specification` が持つという層構成と食い違っていた点を解消した。

規範部（frontmatter の `specification` / `specification_ja`・`## 仕様` 節）は無変更。
機械検査の追加・新規 item の採番もしていない。

確認:
- `nix develop '.?dir=dev#sara' -c dev/tests/test-doc-map.sh` — 全アサーション通過（CASE 49 / テスト資産 57 / 除外 8）
- `nix develop ./dev --command sara check` — Check passed（766 items / 1681 relationships）

## 関連 issue

Closes #324
Refs #283（epic）/ #321（同型の決着を先行適用した issue）

レビュー収束で検出した境界外の指摘（TP-d3d06fe4 の `## 出典` 節に残る同型の leaf 名書き下し。
ただし「網羅集合の宣言」ではなく「実例の列挙」という別の役割を持つため、例示と明示するか
集合参照化するかの判断が要る）は #331 として epic #283 の sub-issue に起票済み。

## docs / ADR 影響

- concept / design / spec の更新: なし。`docs/spec.md` は TP-36e90d5d をリンク 1 行で索引するのみで、
  件数・leaf 名への依存を持たない
- ADR: なし。#321 で決着済みの方針を同型の箇所へ横展開するだけで、新たな方針転換・trade-off を伴わない
