### PR TITLE
test(engine): resolveRoot の純引数テストを engine_test.go へ集約する

### DIFF
--- a/docs/test/engine-core/20260809-31fdb776-engine-test-go.md
+++ b/docs/test/engine-core/20260809-31fdb776-engine-test-go.md
@@ -24,6 +24,10 @@ covers:
 nix を介さず実 FS（`t.TempDir()`）へ apply を回す統合テスト。link farm と manifest を
 テスト側で組み立て、配置結果を実 FS のプローブで確認する。
 
+`resolveRoot` を直接叩く純引数テストだけは例外で、分岐網羅を 1 ファイルで追えるよう
+generations_test.go 側からもここへ集約した（→ issue #328）。cwd を壊して `os.Getwd` を
+失敗させる固定 root の Abs 失敗のみ、FS 誘発型として後段のセクションに残る。
+
 ## 主な検証内容
 
 - **初回配置と subpath**: project mode の初回配置、`subpath = "."` の配置
@@ -31,7 +35,8 @@ nix を介さず実 FS（`t.TempDir()`）へ apply を回す統合テスト。li
 - **上書き拒否**: target の通常ファイル占有でエラー停止、祖先 symlink でエラー停止、
   祖先が自己記録 stale のときのみ移行（copy 子を含む）
 - **stale 除去との接続**: 記録済み entry の除去、foreign を残すこと
-- **root 解決**: git repo 外でのエラー、固定絶対 root の解決失敗、`fixed` でパスを省いた
+- **root 解決**: `rootKind=home` が `$HOME` を返すこと、`--root` 上書きが rootKind に
+  よらず優先されること、git repo 外でのエラー、固定絶対 root の解決失敗、`fixed` でパスを省いた
   ときの拒否（エラー本文一致。manifest 層が受理する組み合わせを engine が止める責務
   → CASE-4179dcb2 / TC-172548ea）、rootKind 未決（`""`）と未知の値の拒否（いずれも
   エラー本文一致。未知の値は `%q` のクォートまで含めて固定する。`systemRoot` は system

--- a/docs/test/generations/20260809-364ebb9d-generations-test-go.md
+++ b/docs/test/generations/20260809-364ebb9d-generations-test-go.md
@@ -1,22 +1,25 @@
 ---
 id: "CASE-364ebb9d-b9f8-4c79-8509-8bbf31e73698"
 type: test_case
-name: "generations_test.go — 世代一覧パース・rollback の再収束と失敗経路・root 解決"
+name: "generations_test.go — 世代一覧パース・rollback の再収束と失敗経路"
 target: "internal/engine/generations_test.go"
 covers:
   - "TC-746cb5b9-fe27-4d09-a51d-eb03d56a93a7"
   - "TC-36ea3609-d52e-42d4-975c-40fb89b23919"
   - "TC-fa7911c6-7347-47ff-b121-bec53562c063"
 ---
-# CASE-364ebb9d: generations_test.go — 世代一覧パース・rollback の再収束と失敗経路・root 解決
+# CASE-364ebb9d: generations_test.go — 世代一覧パース・rollback の再収束と失敗経路
 
 ## 対象
 
 `internal/engine/generations_test.go`
 
-世代一覧のパースと root 解決はテキスト / 引数に対するユニットテスト、`Rollback` は
-tmpdir 上の実 FS へ世代リンクと profile を手で組み立ててから駆動する統合テスト。
+世代一覧のパースはテキストに対するユニットテスト、`Rollback` は tmpdir 上の実 FS へ
+世代リンクと profile を手で組み立ててから駆動する統合テスト。
 `ListGenerations` / `SwitchGeneration` は関数として差し替える。
+
+`resolveRoot` の純引数テストは分岐網羅を 1 ファイルで追えるよう engine_test.go へ集約した
+（→ CASE-31fdb776 / TC-b254a5a8、issue #328）。
 
 ## 検証内容
 
@@ -44,8 +47,3 @@ tmpdir 上の実 FS へ世代リンクと profile を手で組み立ててから
 - 前世代が無い（最古世代）・profile が無い（未 apply）はエラーで停止する
 - 戻り先の target が複数 foreign 実体で塞がれているとき、全 conflict を stderr へ
   列挙してから件数付きの集約エラーを返す（→ issue #176）
-
-**root 解決**（TC-36ea3609）
-
-- `rootKind=home` は `$HOME` を返す
-- `--root` 上書きは rootKind によらず優先される

--- a/docs/test/generations/20260809-36ea3609-rollback-reconvergence.md
+++ b/docs/test/generations/20260809-36ea3609-rollback-reconvergence.md
@@ -24,8 +24,8 @@ b が再配置され、a は据え置かれる。ポインタ移動は FS 収束
 symlink 越しに store を指して EEXIST / EROFS で落ちる（→ ADR-0046、issue #173）。
 収束後に当該パスが実ディレクトリへ戻っていることを確認する。
 
-**root 解決** — `rootKind` から絶対 root を得る側（home は `$HOME`、`--root` 上書きは
-rootKind によらず優先）も同じ層の条件として併せて検証する。
+`rootKind` から絶対 root を得る側は本条件の担当から外れる。root 解決そのものは
+TC-b254a5a8（engine-core）へ一本化した（→ issue #328）。
 
 上位の規範は TP-e7c25263（`internal/engine/` を実 FS の tmpdir で駆動する統合レベル）。
 

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -977,6 +977,31 @@ func TestApplyRecopyForeignFileOverwrites(t *testing.T) {
 	}
 }
 
+// TestResolveRootHome verifies that rootKind=home returns $HOME (root resolver unit test).
+func TestResolveRootHome(t *testing.T) {
+	home := realTempDir(t)
+	t.Setenv("HOME", home)
+	got, err := resolveRoot(manifest.RootKindHome, "", "", "", nil)
+	if err != nil {
+		t.Fatalf("resolveRoot home: %v", err)
+	}
+	if got != home {
+		t.Errorf("resolveRoot home = %q, want %q", got, home)
+	}
+}
+
+// TestResolveRootOverrideWins verifies that the --root override takes precedence regardless of rootKind.
+func TestResolveRootOverrideWins(t *testing.T) {
+	override := realTempDir(t)
+	got, err := resolveRoot(manifest.RootKindHome, "", override, "", nil)
+	if err != nil {
+		t.Fatalf("resolveRoot override: %v", err)
+	}
+	if got != override {
+		t.Errorf("resolveRoot override = %q, want %q", got, override)
+	}
+}
+
 // TestResolveRootFixedWithoutPath pins the fixed-root rejection when no path is given.
 // The manifest layer intentionally accepts a `fixed` root document that omits the path
 // (→ CASE-4179dcb2 / TC-172548ea), so this branch is the only place the invalid pair is

--- a/internal/engine/generations_test.go
+++ b/internal/engine/generations_test.go
@@ -625,28 +625,3 @@ func TestRollbackNoProfileErrors(t *testing.T) {
 		t.Fatalf("expected no-profile error, got %v", err)
 	}
 }
-
-// TestResolveRootHome verifies that rootKind=home returns $HOME (root resolver unit test).
-func TestResolveRootHome(t *testing.T) {
-	home := realTempDir(t)
-	t.Setenv("HOME", home)
-	got, err := resolveRoot(manifest.RootKindHome, "", "", "", nil)
-	if err != nil {
-		t.Fatalf("resolveRoot home: %v", err)
-	}
-	if got != home {
-		t.Errorf("resolveRoot home = %q, want %q", got, home)
-	}
-}
-
-// TestResolveRootOverrideWins verifies that the --root override takes precedence regardless of rootKind.
-func TestResolveRootOverrideWins(t *testing.T) {
-	override := realTempDir(t)
-	got, err := resolveRoot(manifest.RootKindHome, "", override, "", nil)
-	if err != nil {
-		t.Fatalf("resolveRoot override: %v", err)
-	}
-	if got != override {
-		t.Errorf("resolveRoot override = %q, want %q", got, override)
-	}
-}


### PR DESCRIPTION
## 概要

`resolveRoot` の引数レベル純ユニットテストが `generations_test.go` と `engine_test.go` の
2 ファイルに分散しており、分岐網羅を追う読み手が両方を見る必要があった。`TestResolveRootHome` /
`TestResolveRootOverrideWins` を `engine_test.go` の他の `resolveRoot` 純引数テスト群の隣へ移し、
1 ファイルで追えるようにする。テストの純移動で内容・挙動は変えていない。

cwd を壊して `os.Getwd` を失敗させる `TestResolveRootFixedAbsFailure` は FS 操作を伴い性質が
異なるため移動対象外とし、FS 誘発型セクションに残した。

移動に伴い、テスト実体とドキュメントグラフの対応を追随させている。とくに TC-36ea3609
（rollback の再収束）は root 解決を自分の条件として掲げつつ対応 CASE が CASE-364ebb9d 単独
だったため、テスト移動で条件を充足する CASE が無くなる宙吊りが生じた。条件側を落として
root 解決の担当を TC-b254a5a8（engine-core）へ一本化した。`dev/tests/test-doc-map.sh` は
CASE とテスト資産の 1:1 しか照合しないため、この種の drift は CI では検出されない。

`test-326-resolveroot-invalid-kinds` を base にした stacked PR。

## 関連 issue

Closes #328
Refs #283（epic）

レビューで検出した TC-b254a5a8 の条件文追記（root 解決の成功経路 home / `--root` 上書きの明示）は
タスク境界外のため #335 として起票済み。

## docs / ADR 影響

docs の更新あり（ADR 追加はなし。方針転換・trade-off を伴わないため）。

- `docs/test/generations/20260809-364ebb9d-generations-test-go.md` — 名前・対象節・検証内容から
  root 解決の記述を落とし、移動先への参照を残す
- `docs/test/engine-core/20260809-31fdb776-engine-test-go.md` — 対象節に純引数テスト集約の断りを
  足し、root 解決の検証内容へ home 解決と `--root` 上書きを追記
- `docs/test/generations/20260809-36ea3609-rollback-reconvergence.md` — root 解決条件を落とし、
  担当を TC-b254a5a8 へ一本化

`covers` リストは据え置き（TC-36ea3609 は rollback 再収束で CASE-364ebb9d に残り、移動先の
TC-b254a5a8 は CASE-31fdb776 が既に covers）。concept / design / spec の更新はなし。

検証: `go test ./internal/engine/...` 緑 / `sara check` 緑 / `dev/tests/test-doc-map.sh` 緑。
