### PR TITLE
test(engine): resolveRoot の override 有 × 無効 rootKind を固定する

### DIFF
--- a/docs/test/engine-core/20260809-31fdb776-engine-test-go.md
+++ b/docs/test/engine-core/20260809-31fdb776-engine-test-go.md
@@ -36,7 +36,8 @@ generations_test.go 側からもここへ集約した（→ issue #328）。cwd 
   祖先が自己記録 stale のときのみ移行（copy 子を含む）
 - **stale 除去との接続**: 記録済み entry の除去、foreign を残すこと
 - **root 解決**: `rootKind=home` が `$HOME` を返すこと、`--root` 上書きが rootKind に
-  よらず優先されること、git repo 外でのエラー、固定絶対 root の解決失敗、`fixed` でパスを省いた
+  よらず優先されること（未決（`""`）・未知の値と組んでも拒否されず override の絶対パスが
+  返る）、git repo 外でのエラー、固定絶対 root の解決失敗、`fixed` でパスを省いた
   ときの拒否（エラー本文一致。manifest 層が受理する組み合わせを engine が止める責務
   → CASE-4179dcb2 / TC-172548ea）、rootKind 未決（`""`）と未知の値の拒否（いずれも
   エラー本文一致。未知の値は `%q` のクォートまで含めて固定する。`systemRoot` は system

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -991,14 +991,31 @@ func TestResolveRootHome(t *testing.T) {
 }
 
 // TestResolveRootOverrideWins verifies that the --root override takes precedence regardless of rootKind.
+// The invalid kinds are covered here as well: resolveRoot returns on the override before it ever
+// reaches the switch, so an undetermined ("") or unknown rootKind must not turn into the rejection
+// TestResolveRootInvalidKinds pins. That precedence is the documented contract of `--root`
+// (→ resolveRoot's doc comment), and pinning it keeps a later reordering of the switch from
+// regressing the pair into an error.
 func TestResolveRootOverrideWins(t *testing.T) {
-	override := realTempDir(t)
-	got, err := resolveRoot(manifest.RootKindHome, "", override, "", nil)
-	if err != nil {
-		t.Fatalf("resolveRoot override: %v", err)
+	tests := []struct {
+		name     string
+		rootKind string
+	}{
+		{name: "home", rootKind: manifest.RootKindHome},
+		{name: "undetermined", rootKind: ""},
+		{name: "unknown", rootKind: "bogus"},
 	}
-	if got != override {
-		t.Errorf("resolveRoot override = %q, want %q", got, override)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			override := realTempDir(t)
+			got, err := resolveRoot(tt.rootKind, "", override, "", nil)
+			if err != nil {
+				t.Fatalf("resolveRoot override (rootKind=%q): %v", tt.rootKind, err)
+			}
+			if got != override {
+				t.Errorf("resolveRoot override (rootKind=%q) = %q, want %q", tt.rootKind, got, override)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## 概要

`resolveRoot`（`internal/engine/engine.go`）は switch に入る前に `rootOverride != ""` で早期 return するため、
override が指定されていれば rootKind の妥当性は一切検査されない。これは `--root` の意図した挙動
（doc comment に明記済み）だが、その優先関係自体がテストで固定されていなかった。

将来 switch を早期 return より前へ出すリファクタが入ったとき、無効 kind + override がエラーになる
退行を誰も検出できない状態だったため、既存挙動を固定するテストのみを足す。**実装変更は無い。**

- `TestResolveRootOverrideWins` を rootKind のテーブルへ拡張し、`home` に加えて未決（`""`）・
  未知の値（`bogus`）でも override の絶対パスが返ることを固定
- 置き場は `TestResolveRootInvalidKinds` 側ではなく `TestResolveRootOverrideWins` を選択。
  前者は期待値がエラー本文の拒否テストで、成功パスを混ぜると 1 テーブルが二義的になるため
- CASE-31fdb776 の「主な検証内容」へ、override が無効 kind と組んでも拒否されない旨を追記

確認: `go test ./internal/engine/...` 緑 / `sara check` 緑 / `dev/tests/test-doc-map.sh` 全 13 アサーション通過。

## 関連 issue

Closes #334

## docs / ADR 影響

- concept / design / spec: なし（実装変更を伴わないため追従不要）
- ADR: なし（設計判断の変更を含まない。既存挙動の固定のみ）
- CASE-31fdb776（`docs/test/engine-core/20260809-31fdb776-engine-test-go.md`）のみ検証内容を追記。
  TC への `covers` 追加は不要（TC-b254a5a8 が root 解決全体を射程に持つ）

なお review-converge で「override が常に絶対パスのため `filepath.Abs` の相対→絶対変換が未固定」
という want 指摘が出たが、#334 の射程外（優先関係の固定が主題）のため本 PR では対応せず、
epic #283 の sub-issue #338 として切り出した。
