### PR TITLE
docs(test): TC-b254a5a8 の条件文へ root 解決の成功経路を加え断り書きを調整する

### DIFF
--- a/docs/test/engine-core/20260809-b254a5a8-root-resolution.md
+++ b/docs/test/engine-core/20260809-b254a5a8-root-resolution.md
@@ -10,9 +10,12 @@ mitigates:
 project mode の root が git toplevel から解決されること、git repo の外で実行したときに
 engine 実行時に停止すること、および root 解決に失敗したときに配置へ進まないことを検証する。
 `fixed` で root パスが無いときに engine が拒否することも同じ条件の射程に含む。
+成功経路も同じ条件の下に置く。`rootKind=home` が `$HOME` を絶対 root として返すこと、
+`--root` 上書きが rootKind によらず優先されることを見る。
 
 profile ディレクトリの作成・backref 書き込みの失敗が握り潰されずエラーとして表面化することも
 同じ条件の下に置く。これらが黙って失敗すると、配置は進むのに逆引きできない profile が残る。
 
-home mode の root 供給元の層分けそのもの（HM モジュール経由と CLI 経由で同じ root へ落ちること）
-は `integration` 対象の担当で、ここでは engine が受け取った root を使い切ることまでを見る。
+root 供給元の層分けそのもの（HM モジュール経由と CLI 経由で同じ root へ落ちること）は
+`integration` 対象の担当で、条件の射程から外れる。engine が受け取った rootKind を絶対 root へ
+解決する分岐は、home mode 側も含めてここで見る。


### PR DESCRIPTION
## 概要

TC-b254a5a8（`docs/test/engine-core/20260809-b254a5a8-root-resolution.md`）の条件文が
project mode の git toplevel 解決・git repo 外での停止・root 解決失敗時の停止・profile 準備の失敗
という範囲で書かれており、root 解決の**成功経路**を明示していなかった。#328 で `resolveRoot` の
純引数テスト（`TestResolveRootHome` / `TestResolveRootOverrideWins`）が `engine_test.go` へ集約され、
下位の CASE-31fdb776 側には「`rootKind=home` が `$HOME` を返すこと」「`--root` 上書きが rootKind に
よらず優先されること」が追記済みで、CASE の記述が TC の射程を超過して読める状態になっていた。

加えて末尾の断り書きが「home mode の root 供給元の層分けそのものは `integration` 対象の担当で、
ここでは engine が受け取った root を使い切ることまでを見る」と書かれており、home 系の分岐を
engine 層では見ない方向にも読めた。

本 PR は条件文へ成功経路の 1 文を加え、断り書きが engine 層の純引数テストを排除しない表現へ
調整する。表現調整のみで、構造変更・新規 item の採番は行わない。責務委譲の記述は CASE 側が
持つため、この TC には重複させていない。

## 関連 issue

Closes #335

## docs / ADR 影響

- concept / design / spec の更新: なし。実装・配置動作・API に変更はなく、既存 test_condition item の
  条件文の表現調整のみのため
- ADR の追加: なし。方針転換・trade-off を伴わない

検証:

- `nix develop ./dev --command sara check` 緑（frontmatter・relation は無変更のためグラフ影響なし）
- `nix develop '.?dir=dev#sara' -c dev/tests/test-doc-map.sh` 緑

`/review-converge` は 2 周で収束（閾値 want・残指摘なし）。境界外の指摘 1 件（上位 RISK-24e0805d の
評価文が本 PR で更新した TC の射程記述と食い違う）は epic #283 の sub-issue #339 として起票済み。
