### PR TITLE
docs(test-plan): TP-d3d06fe4 の出典節の leaf 名列挙を性質で限定した集合参照へ改める

### DIFF
--- a/docs/test-plan/20260809-d3d06fe4-eval-test-double.md
+++ b/docs/test-plan/20260809-d3d06fe4-eval-test-double.md
@@ -49,11 +49,11 @@ specification_ja: |
 
 ## 出典
 
-現況の実装が横断的に採っているイディオムの明文化。`tests/nix-unit/` の各ファイル
-（structure / defaults / gates / resolve-marker / farm-entries）・`tests/namaka/
-manifest-project/expr.nix`・`flake.nix` の `checks.hm-module` がいずれも同形の double を
-使い、各所のコメントが「store hash 揺れを避ける」「srcType の store-backed 判定
-（`? outPath`）を通る正当な test double」と理由を述べている。
+現況の実装が横断的に採っているイディオムの明文化。`tests/nix-unit/` のうち store-backed な
+配置元を入力に要する各ファイル・`tests/namaka/manifest-project/expr.nix`・`flake.nix` の
+`checks.hm-module` がいずれも同形の double を使い、各所のコメントが「store hash 揺れを
+避ける」「srcType の store-backed 判定（`? outPath`）を通る正当な test double」と理由を
+述べている（配置元を入力に要さない純関数のテストは対象外）。
 
 > 本 item は個別のテストが何を検証するかではなく、評価レベルのテストが入力をどう用意するかの
 > 横断規約を定める。`checks.hm-module` が同じ double を使う位置づけは TP-0734996e の担当。


### PR DESCRIPTION
## 概要

TP-d3d06fe4（評価テストの store-backed 入力を固定 outPath の fake flake-input で与える規約）の
`## 出典` 節に、`tests/nix-unit/` の leaf 名の書き下し列挙（structure / defaults / gates /
resolve-marker / farm-entries）が残っていた。leaf の増減のたびにずれるドリフト源で、#321 / #324 が
`CLAUDE.md` / `dev/tests/test-categories.tsv` / TP-36e90d5d で解消したのと同型の 4 箇所目。

leaf 名の書き下しを全て落とし、「`tests/nix-unit/` のうち store-backed な配置元を入力に要する
各ファイル」という**性質で限定した集合参照**へ改めた。あわせて対象外の断り書きを添え、
「いずれも同形の double を使い」という網羅主張が限定後の文面でも真になるようにしている。

集合の外延は実測と一致する。`tests/nix-unit/` 9 ファイルのうち固定 outPath の double を持つのは
structure / defaults / gates / resolve-marker / farm-entries / fixed-root の 6 件で、
escapes-base / anchor-name / aggregator-merge の 3 件は配置元を入力に要さない純関数テスト。
旧文面の列挙 5 件は fixed-root を取りこぼしていたが、性質限定により解消した。

例示明示案（TP-deb05610:90 形式の断り書きを添えて列挙を残す）・網羅追随案（fixed-root を足して
6 件列挙する）は不採用。機械検査も追加していない。出典節は規範ではなく出所の記録であり、
個々の leaf の帰属の canonical は CASE の `target`（`dev/tests/test-doc-map.sh` が 1:1 を強制）
であるため、ここに検査を足すと二重管理になる。

確認: `dev/tests/test-doc-map.sh` 緑（CASE 49 件 / テスト資産 57 件 / 除外 8 件）、
`sara check` 緑（766 items / 1681 relationships）。

## 関連 issue

Closes #331

## docs / ADR 影響

- concept / design / spec: 更新なし。変更は test_plan item の `## 出典` 節（出所の記録）に閉じており、
  frontmatter の `specification` / `specification_ja` と `## 仕様` 節の規範文には触れていない。
  `docs/spec.md` の索引行も無変更で整合する
- ADR: なし。方針転換・trade-off を伴わない記述精度の修正のため
