### PR TITLE
test(engine): resolveRoot の相対 override が cwd 起点で絶対化されることを固定する

### DIFF
--- a/docs/test/engine-core/20260809-31fdb776-engine-test-go.md
+++ b/docs/test/engine-core/20260809-31fdb776-engine-test-go.md
@@ -37,7 +37,8 @@ generations_test.go 側からもここへ集約した（→ issue #328）。cwd 
 - **stale 除去との接続**: 記録済み entry の除去、foreign を残すこと
 - **root 解決**: `rootKind=home` が `$HOME` を返すこと、`--root` 上書きが rootKind に
   よらず優先されること（未決（`""`）・未知の値と組んでも拒否されず override の絶対パスが
-  返る）、git repo 外でのエラー、固定絶対 root の解決失敗、`fixed` でパスを省いた
+  返る）、相対 override が cwd 起点で絶対化されて返ること、git repo 外でのエラー、
+  固定絶対 root の解決失敗、`fixed` でパスを省いた
   ときの拒否（エラー本文一致。manifest 層が受理する組み合わせを engine が止める責務
   → CASE-4179dcb2 / TC-172548ea）、rootKind 未決（`""`）と未知の値の拒否（いずれも
   エラー本文一致。未知の値は `%q` のクォートまで含めて固定する。`systemRoot` は system

--- a/docs/test/engine-core/20260809-31fdb776-engine-test-go.md
+++ b/docs/test/engine-core/20260809-31fdb776-engine-test-go.md
@@ -24,9 +24,11 @@ covers:
 nix を介さず実 FS（`t.TempDir()`）へ apply を回す統合テスト。link farm と manifest を
 テスト側で組み立て、配置結果を実 FS のプローブで確認する。
 
-`resolveRoot` を直接叩く純引数テストだけは例外で、分岐網羅を 1 ファイルで追えるよう
-generations_test.go 側からもここへ集約した（→ issue #328）。cwd を壊して `os.Getwd` を
-失敗させる固定 root の Abs 失敗のみ、FS 誘発型として後段のセクションに残る。
+`resolveRoot` を直接叩くテストだけは例外で、分岐網羅を 1 ファイルで追えるよう
+generations_test.go 側からもここへ集約した（→ issue #328）。多くは純引数だが、cwd を
+入力に取る経路（相対パスの絶対化）は実ディレクトリへ `t.Chdir` して期待値を定める。
+cwd を壊して `os.Getwd` を失敗させる固定 root の Abs 失敗のみ、FS 誘発型として後段の
+セクションに残る。
 
 ## 主な検証内容
 

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -1019,6 +1019,26 @@ func TestResolveRootOverrideWins(t *testing.T) {
 	}
 }
 
+// TestResolveRootOverrideRelative pins that a relative --root override is absolutized
+// against the cwd. TestResolveRootOverrideWins above only ever passes absolute paths, for
+// which filepath.Abs merely cleans the input without consulting os.Getwd — so the
+// relative → absolute conversion itself goes unexercised there and an implementation
+// shrunk to `return rootOverride, nil` would still pass. Chdir'ing into a real temp dir
+// makes the expected result computable as filepath.Join(cwd, rel).
+func TestResolveRootOverrideRelative(t *testing.T) {
+	cwd := realTempDir(t)
+	t.Chdir(cwd)
+
+	const rel = "sub/dir"
+	got, err := resolveRoot(manifest.RootKindHome, "", rel, "", nil)
+	if err != nil {
+		t.Fatalf("resolveRoot relative override: %v", err)
+	}
+	if want := filepath.Join(cwd, rel); got != want {
+		t.Errorf("resolveRoot relative override = %q, want %q", got, want)
+	}
+}
+
 // TestResolveRootFixedWithoutPath pins the fixed-root rejection when no path is given.
 // The manifest layer intentionally accepts a `fixed` root document that omits the path
 // (→ CASE-4179dcb2 / TC-172548ea), so this branch is the only place the invalid pair is


### PR DESCRIPTION
<!--
PR テンプレート（ソロ運用・最小構成）。
チェックリストは置かない。形骸化を避け、このリポジトリで実際に意味のある 3 点だけ書く。
-->

## 概要

`resolveRoot`（`internal/engine/engine.go`）の override 経路は `filepath.Abs(rootOverride)` を通すが、
override 経路を直接叩く既存テスト（`TestResolveRootOverrideWins`）は `realTempDir(t)` 由来の**絶対パス**しか
渡していなかった。`filepath.Abs` は絶対パスに対しては `Clean` するだけで `os.Getwd` を通らないため、
**相対 → 絶対の変換自体が一度も発火しておらず**、実装が `return rootOverride, nil` へ縮められても
全ケース緑のまま通る状態だった。

そこで `TestResolveRootOverrideRelative` を追加し、`t.Chdir` した実 tmpdir 配下の相対名を override に
渡すと `filepath.Join(cwd, rel)` と一致する絶対パスが返ることを固定する。**実装変更は無い**（既存挙動の固定）。
`return rootOverride, nil` の変異を実装へ注入するとこのテストが落ちることは確認済み。

テーブル追加ではなく別テストにしたのは、既存テーブルが `rootKind` の軸を振る構造で、相対ケースは
`t.Chdir` と期待値の計算方法が異なり同一テーブルに入れると分岐が要るため（issue 本文が両方を許容）。

`filepath.Abs` の失敗経路は `fixed` root 側の `TestResolveRootFixedAbsFailure` が既に固定しており、
override 側で重ねて固定はしない。

## 関連 issue

Closes #338

## docs / ADR 影響

concept / design / spec の更新なし（利用者から観測できる挙動は変わらないため）。ADR 追加なし
（設計判断を伴わない既存挙動の固定のため）。

テスト系 item のみ更新: CASE-31fdb776（`docs/test/engine-core/20260809-31fdb776-engine-test-go.md`）へ
検証内容 1 行を追記し、あわせて冒頭の断り書きを実態へ揃えた（従来「`resolveRoot` を直接叩く**純引数**
テストだけを集約し、FS 誘発型は Abs 失敗のみ」と書かれていたが、追加したテストは cwd を入力に取るため
純引数ではない）。新規 item の採番はしていない。

レビューで検出した境界外の課題 2 件は本 PR に混ぜず、epic #283 の sub-issue として起票済み（#344 / #345）。
