### PR TITLE
docs(test): TC-b254a5a8 の条件文へ相対 override の絶対化を加える

### DIFF
--- a/docs/test/engine-core/20260809-b254a5a8-root-resolution.md
+++ b/docs/test/engine-core/20260809-b254a5a8-root-resolution.md
@@ -11,7 +11,8 @@ project mode の root が git toplevel から解決されること、git repo �
 engine 実行時に停止すること、および root 解決に失敗したときに配置へ進まないことを検証する。
 `fixed` で root パスが無いときに engine が拒否することも同じ条件の射程に含む。
 成功経路も同じ条件の下に置く。`rootKind=home` が `$HOME` を絶対 root として返すこと、
-`--root` 上書きが rootKind によらず優先されることを見る。
+`--root` 上書きが rootKind によらず優先されること、相対で与えた override が cwd 起点で
+絶対化されて返ることを見る。
 
 profile ディレクトリの作成・backref 書き込みの失敗が握り潰されずエラーとして表面化することも
 同じ条件の下に置く。これらが黙って失敗すると、配置は進むのに逆引きできない profile が残る。


### PR DESCRIPTION
<!--
PR テンプレート（ソロ運用・最小構成）。
チェックリストは置かない。形骸化を避け、このリポジトリで実際に意味のある 3 点だけ書く。
-->

## 概要

TC-b254a5a8（`docs/test/engine-core/20260809-b254a5a8-root-resolution.md`）の条件文の成功経路の並びへ、相対で与えた `--root` が cwd 起点で絶対化されることを 1 句加える。

先行する #338 で下位の CASE-31fdb776 の「主な検証内容」へ同じ観点を書き足したが、上位の TC 側は成功経路として `rootKind=home` が `$HOME` を返すことと `--root` 上書きが rootKind によらず優先されることまでで、相対 override の絶対化に触れていなかった。#335 で TC 本文へ成功経路を書き足した運用（`b50afa8`）と揃える。

追記は 1 句のみで、frontmatter・見出し・段落構成は無変更。責務委譲の詳細（`t.Chdir` で期待値を定める等の手段）は CASE-31fdb776 が持つため、この TC には重複して書いていない。

実装変更は伴わない。

## 関連 issue

Closes #344

## docs / ADR 影響

- concept / design / spec: 更新なし。TC は `docs/spec.md` へ索引しない規約（CLAUDE.md「テスト系 item の粒度」節）のため、概要文書側の追従は不要
- ADR: なし。方針転換・trade-off を伴わない
- 上流 RISK-24e0805d の評価文は先行 PR #343（`5d60327`）で TC-b254a5a8 の現射程へ更新済みで、今回の追記による再更新は不要

検証: `nix develop ./dev --command sara check` 緑（766 items / 1681 relationships）、`nix develop '.?dir=dev#sara' -c dev/tests/test-doc-map.sh` 緑（CASE 49 件 / テスト資産 57 件 / 除外 8 件）
