### PR TITLE
docs(test): CASE-364ebb9d の相互参照を純引数の限定緩和へ追随させる

### DIFF
--- a/docs/test/generations/20260809-364ebb9d-generations-test-go.md
+++ b/docs/test/generations/20260809-364ebb9d-generations-test-go.md
@@ -18,8 +18,9 @@ covers:
 世代リンクと profile を手で組み立ててから駆動する統合テスト。
 `ListGenerations` / `SwitchGeneration` は関数として差し替える。
 
-`resolveRoot` の純引数テストは分岐網羅を 1 ファイルで追えるよう engine_test.go へ集約した
-（→ CASE-31fdb776 / TC-b254a5a8、issue #328）。
+`resolveRoot` を直接叩くテストは分岐網羅を 1 ファイルで追えるよう engine_test.go へ集約した
+（集約先の集合は多くが純引数だが、cwd を入力に取る経路も含む。
+→ CASE-31fdb776 / TC-b254a5a8、issue #328）。
 
 ## 検証内容
 


### PR DESCRIPTION
## 概要

CASE-364ebb9d（`docs/test/generations/20260809-364ebb9d-generations-test-go.md`）の相互参照文から
「純引数」の限定を外し、集約先 CASE-31fdb776 側の現在の表現へ揃えた。

issue #328 の集約時、この対の相互参照は移動元・移動先の双方が「純引数テスト」という同じ語で
導入された。その後 #338 で移動先（CASE-31fdb776）側の断り書きが「多くは純引数だが、cwd を
入力に取る経路（相対パスの絶対化）は実ディレクトリへ `t.Chdir` して期待値を定める」へ緩められた
ため、移動元だけが古い限定を保ったまま残り、集約された内容を過小に表していた。

主語を「`resolveRoot` を直接叩くテスト」へ広げ、括弧内で「集約先の集合は多くが純引数だが、
cwd を入力に取る経路も含む」と補足している。実際に generations_test.go から移動したのは
純引数の 2 件（`TestResolveRootHome` / `TestResolveRootOverrideWins`、commit af11712）で、
cwd 経路は集約先で後から追加されたものなので、括弧の限定が「移動実績」ではなく「集約先の
集合」に係ることを明示した（review-converge の指摘対応）。

集約先の性質説明の詳細（`t.Chdir` の使用など）は CASE-31fdb776 側に一本化したまま、参照側は
リンクに留めている。相互参照文 1 箇所のみの変更で、構造変更・追記はしていない。

## 関連 issue

Closes #345

## docs / ADR 影響

docs のみの変更（test_case item の散文 1 箇所）。実装変更なし、ADR 追加なし。
concept / design / spec の更新は不要（規範的な内容には触れておらず、item 間の相互参照文の
表現整合のみ）。frontmatter（`id` / `covers` / `target`）は無変更のため sara のグラフ構造にも
影響しない。

検証:
- `nix develop ./dev --command sara check` 緑（766 items / 1681 relationships）
- `nix develop '.?dir=dev#sara' -c dev/tests/test-doc-map.sh` 緑（CASE 49 件 / テスト資産 57 件 / 除外 8 件）

作業中に検出した境界外の課題（TC-40b762fc の隣接検証の参照先が #328 の集約以降古い）は
本 PR に混ぜず、epic #283 の七次 follow-up として #348 に起票した。
