### PR TITLE
docs(test): TC-40b762fc の隣接検証の参照先を CASE-31fdb776 へ差し替える

### DIFF
--- a/docs/test/generations/20260809-40b762fc-profile-path-keying.md
+++ b/docs/test/generations/20260809-40b762fc-profile-path-keying.md
@@ -44,4 +44,4 @@ roothash 階層（`<name>` dir の親）に置かれ、`<roothash>` キーのモ
 ## 対応する CASE
 
 CASE-ff4a842e（`internal/paths/paths_test.go`）。root 解決そのもの（`rootKind` と
-`--root` から絶対 root を得る側）は CASE-364ebb9d も隣接して検証する。
+`--root` から絶対 root を得る側）は CASE-31fdb776 も隣接して検証する。


### PR DESCRIPTION
## 概要

TC-40b762fc（`docs/test/generations/20260809-40b762fc-profile-path-keying.md`）の
「対応する CASE」節にある隣接検証の参照先を CASE-364ebb9d から CASE-31fdb776 へ差し替える。

issue #328 の集約（commit af11712）で `resolveRoot` を直接叩くテストは
generations_test.go から engine_test.go へ移っており、CASE-364ebb9d には
もはや `resolveRoot` の検証が無い。root 解決の隣接検証の現在の所在は
CASE-31fdb776（`internal/engine/engine_test.go`）のため、参照をそこへ揃える。
#345 の作業中に検出され、タスク境界外のため分離された参照ずれの解消（epic #283 の
七次 follow-up）。

## 関連 issue

Closes #348

## docs / ADR 影響

docs のみ（test_condition item の散文 1 行）。concept / design / spec の更新なし・ADR なし。
frontmatter は無変更。`sara check` / `dev/tests/test-doc-map.sh` とも緑を確認済み。
