### PR TITLE
test(dev): risk の level 導出マトリクス整合の契約テストを追加する

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -105,13 +105,14 @@ jobs:
 
   sara:
     # Knowledge-graph validation of docs/ (broken references, duplicate IDs,
-    # cycles) plus two contract tests: sara-id's numbering and test-doc-map's
-    # test-code ⇔ CASE mapping. Non-required check with no threshold gate, same
-    # policy as go-coverage: it is NOT registered as a required status check and
-    # is NOT part of the DoD, so a failure reports on the PR without blocking
-    # merge. The check itself runs strict (strict_mode = true in sara.toml, all
-    # warnings are errors) since the epic #203 migration completed; staying
-    # non-required is a recorded decision, not a deferral (→ ADR-0050).
+    # cycles) plus three contract tests: sara-id's numbering, test-doc-map's
+    # test-code ⇔ CASE mapping, and risk-matrix's level derivation. Non-required
+    # check with no threshold gate, same policy as go-coverage: it is NOT
+    # registered as a required status check and is NOT part of the DoD, so a
+    # failure reports on the PR without blocking merge. The check itself runs
+    # strict (strict_mode = true in sara.toml, all warnings are errors) since
+    # the epic #203 migration completed; staying non-required is a recorded
+    # decision, not a deferral (→ ADR-0050).
     #
     # The `changes` job is not reused here: its filter targets nix/Go sources
     # broadly, whereas this job needs docs plus the specific test assets
@@ -187,6 +188,16 @@ jobs:
       - name: Run test-doc-map contract test
         if: steps.filter.outputs.relevant != 'false'
         run: nix develop '.?dir=dev#sara' -c dev/tests/test-doc-map.sh
+
+      # The level derivation contract for risk items (→ #303): `level` must equal
+      # the matrix cell of `likelihood` × `impact` from docs/agents/sara-graph.md.
+      # `sara check` validates the enum of each field but never the relation
+      # between them. Wired the same way as the two above — also exposed as
+      # `checks.risk-matrix` for local `nix flake check ./dev`, which CI's
+      # root-flake flake-check never reaches.
+      - name: Run risk-matrix contract test
+        if: steps.filter.outputs.relevant != 'false'
+        run: nix develop '.?dir=dev#sara' -c dev/tests/risk-matrix.sh
 
   e2e:
     needs: changes

--- a/dev/flake.nix
+++ b/dev/flake.nix
@@ -329,13 +329,22 @@
                   # 実際には使われないが、`git` が無いと `git rev-parse` が
                   # command not found となり診断が濁る。
                   pkgs.git
-                  # frontmatter の抽出に使う。stdenv 既定でも PATH に載るが、暗黙依存に
-                  # すると実行条件の違うサンドボックスで踏み抜くため明示する。
-                  pkgs.gnused
+                  # frontmatter の読み取りに使う（mikefarah/yq v4）。テスト側も
+                  # require_yq_go で実装を確認して落とす。
+                  pkgs.yq-go
+                  # lib-testdoc.sh の require_yq_go が yq --version を grep する。
+                  pkgs.gnugrep
                 ];
               }
               ''
-                bash ${./tests/risk-matrix.sh}
+                # テストは dev/scripts/lib-testdoc.sh を自身からの相対パスで source する
+                # （checks.test-doc-map と同じ配置前提）。store の単体ファイルを直接
+                # 実行すると解決できないので、dev/ の木の形を作ってから走らせる。
+                mkdir -p dev
+                cp -r ${./scripts} dev/scripts
+                cp -r ${./tests} dev/tests
+                chmod -R u+w dev
+                bash dev/tests/risk-matrix.sh
                 touch "$out"
               '';
 

--- a/dev/flake.nix
+++ b/dev/flake.nix
@@ -314,16 +314,20 @@
           checks.risk-matrix =
             pkgs.runCommandLocal "risk-matrix"
               {
-                # テストが走査する risk item の正本。サンドボックスにはリポジトリの
+                # テストが読む正本 2 つ。走査対象の risk item と、マトリクス突合
+                # （テスト §1）が読む level 表の在り処。サンドボックスにはリポジトリの
                 # 作業ツリーが無く、テスト側の git ルート解決も効かないため nix から
                 # store path を渡す（checks.sara-id の SARA_MODEL_YAML と同じ手法）。
                 # devShell / CI 経路は cwd がリポジトリルートなのでテスト側の解決に任せる。
                 RISK_DOCS_DIR = ../docs/risks;
+                SARA_GRAPH_MD = ../docs/agents/sara-graph.md;
                 nativeBuildInputs = [
                   pkgs.coreutils
                   pkgs.findutils
-                  # 走査基点の解決に使う（サンドボックスでは失敗してカレントへ落ちるが、
-                  # コマンド自体が無いと診断不能な失敗になる）。
+                  pkgs.gawk
+                  # 走査基点の解決に使う。この経路では両方の環境変数が先に解決するので
+                  # 実際には使われないが、`git` が無いと `git rev-parse` が
+                  # command not found となり診断が濁る。
                   pkgs.git
                   # frontmatter の抽出に使う。stdenv 既定でも PATH に載るが、暗黙依存に
                   # すると実行条件の違うサンドボックスで踏み抜くため明示する。

--- a/dev/flake.nix
+++ b/dev/flake.nix
@@ -314,25 +314,25 @@
           checks.risk-matrix =
             pkgs.runCommandLocal "risk-matrix"
               {
-                # テストが読む正本 2 つ。走査対象の risk item と、マトリクス突合
-                # （テスト §1）が読む level 表の在り処。サンドボックスにはリポジトリの
+                # テストが走査する risk item の在り処。サンドボックスにはリポジトリの
                 # 作業ツリーが無く、テスト側の git ルート解決も効かないため nix から
                 # store path を渡す（checks.sara-id の SARA_MODEL_YAML と同じ手法）。
                 # devShell / CI 経路は cwd がリポジトリルートなのでテスト側の解決に任せる。
+                # マトリクスの正本（dev/tests/risk-matrix.tsv）は下で dev/ の木ごと
+                # 配置するので、テストがスクリプト基準で解決する。
                 RISK_DOCS_DIR = ../docs/risks;
-                SARA_GRAPH_MD = ../docs/agents/sara-graph.md;
                 nativeBuildInputs = [
                   pkgs.coreutils
                   pkgs.findutils
-                  pkgs.gawk
-                  # 走査基点の解決に使う。この経路では両方の環境変数が先に解決するので
+                  # 走査基点の解決に使う。この経路では RISK_DOCS_DIR が先に解決するので
                   # 実際には使われないが、`git` が無いと `git rev-parse` が
                   # command not found となり診断が濁る。
                   pkgs.git
                   # frontmatter の読み取りに使う（mikefarah/yq v4）。テスト側も
                   # require_yq_go で実装を確認して落とす。
                   pkgs.yq-go
-                  # lib-testdoc.sh の require_yq_go が yq --version を grep する。
+                  # lib-testdoc.sh が使う（read_tsv のコメント除去・require_yq_go の
+                  # yq --version 判定）。
                   pkgs.gnugrep
                 ];
               }

--- a/dev/flake.nix
+++ b/dev/flake.nix
@@ -304,12 +304,43 @@
                 touch "$out"
               '';
 
+          # risk の level 導出マトリクス整合の契約テスト（dev/tests/risk-matrix.sh）。
+          # checks.sara-id と同じ二重化の意図で 2 経路から走らせる:
+          #
+          # - この checks 派生: ローカルの `nix flake check ./dev` に載せる
+          # - CI: .github/workflows/test.yml の sara job が devShells.sara 経由で実行し、
+          #   PR での退行検知を担保する（flake-check job はルート flake が対象なので
+          #   この派生は CI では回らない）
+          checks.risk-matrix =
+            pkgs.runCommandLocal "risk-matrix"
+              {
+                # テストが走査する risk item の正本。サンドボックスにはリポジトリの
+                # 作業ツリーが無く、テスト側の git ルート解決も効かないため nix から
+                # store path を渡す（checks.sara-id の SARA_MODEL_YAML と同じ手法）。
+                # devShell / CI 経路は cwd がリポジトリルートなのでテスト側の解決に任せる。
+                RISK_DOCS_DIR = ../docs/risks;
+                nativeBuildInputs = [
+                  pkgs.coreutils
+                  pkgs.findutils
+                  # 走査基点の解決に使う（サンドボックスでは失敗してカレントへ落ちるが、
+                  # コマンド自体が無いと診断不能な失敗になる）。
+                  pkgs.git
+                  # frontmatter の抽出に使う。stdenv 既定でも PATH に載るが、暗黙依存に
+                  # すると実行条件の違うサンドボックスで踏み抜くため明示する。
+                  pkgs.gnused
+                ];
+              }
+              ''
+                bash ${./tests/risk-matrix.sh}
+                touch "$out"
+              '';
+
           # CI の sara check 専用シェル。default devShell は nput のビルドと
           # dogfood の shellHook（nput apply skills）を伴うため、docs 変更だけの PR で
           # それらを走らせないよう sara 単体に絞る。NUR 由来の store path を
           # yasunori0418.cachix.org から引くだけで済む。
-          # CI からは sara check・dev/tests/sara-id.sh・dev/tests/test-doc-map.sh を
-          # このシェルで実行する。
+          # CI からは sara check・dev/tests/sara-id.sh・dev/tests/test-doc-map.sh・
+          # dev/tests/risk-matrix.sh をこのシェルで実行する。
           devShells.sara = pkgs.mkShell {
             packages = [
               inputs'.nur.packages.sara

--- a/dev/scripts/test-inventory.sh
+++ b/dev/scripts/test-inventory.sh
@@ -89,6 +89,7 @@ FLAKE_CHECKS=(
   checks.nix-unit
   checks.nput
   checks.treefmt
+  dev:checks.risk-matrix
   dev:checks.sara-id
   dev:checks.test-doc-map
 )

--- a/dev/tests/risk-matrix.sh
+++ b/dev/tests/risk-matrix.sh
@@ -21,6 +21,12 @@
 # その旨を FAIL として報告する（sara check の代替をするのではなく、判定不能を黙って
 # 素通りさせないための扱い）。
 #
+# frontmatter の読み取りは yq（mikefarah/yq v4）で行う。docs/ の frontmatter を読む
+# 既存スクリプト（test-doc-map.sh・test-doc-matrix.sh）と同じ手段で、devShells.sara にも
+# 既に載っているので依存は増えない。手書きのパーサだと引用符・空白・複数行スカラといった
+# YAML の表記ゆれを自前で潰すことになり、その取りこぼしが「マトリクスのセルが無い」と
+# いう誤った診断で表面化する。
+#
 # ## なぜ機械化するか
 #
 # level 導出は `docs/agents/sara-graph.md` の規約のうち唯一「散文の解釈を伴わない
@@ -37,6 +43,12 @@ fault() {
   printf 'FAIL - %s\n' "$1"
   fail=1
 }
+
+# shellcheck source=dev/scripts/lib-testdoc.sh
+. "$(dirname "$0")/../scripts/lib-testdoc.sh"
+
+require_commands "risk-matrix.sh（nix develop '.?dir=dev#sara' から実行する）" yq || exit 1
+require_yq_go risk-matrix.sh || exit 1
 
 # level 導出マトリクス。正本は docs/agents/sara-graph.md「How a risk is scored」節の
 # `level` 表で、ここはその 9 セルを機械可読に写したもの。写しが正本とずれていないことは
@@ -76,19 +88,6 @@ if [[ ! -d "$risks_dir" ]]; then
   echo "risk-matrix.sh: risk item のディレクトリを解決できない（$risks_dir）" >&2
   exit 1
 fi
-
-# frontmatter（先頭の `---` から次の `---` まで）から 1 フィールドを取り出す。
-# yq を足さず sed で済ませる。範囲を frontmatter に限るのは予防措置で、現コーパスの
-# 本文に `^likelihood:` の形で当たる行は無い（根拠記述は「likelihood を medium と
-# するのは …」の形）。本文へその形の行が現れた時点で判定が狂うのを未然に防ぐ。
-#
-# 値は引用符と前後の空白を剥がす。剥がさないと `impact: "high"` のような表記ゆれが
-# 「マトリクスのセルが無い」として報告され、enum 違反と区別が付かなくなる。
-field_of() {
-  sed -n '1{/^---$/!q}; 1,/^---$/{ /^---$/d; s/^'"$2"':[[:space:]]*//p }' "$1" |
-    head -1 |
-    sed -e 's/[[:space:]]*$//' -e 's/^"\(.*\)"$/\1/' -e "s/^'\(.*\)'$/\1/"
-}
 
 # --- 1. LEVEL_MATRIX が sara-graph.md の level 表と一致する -------------------
 #
@@ -204,23 +203,34 @@ if [[ "${#risk_files[@]}" -eq 0 ]]; then
   exit "$fail"
 fi
 
+# 1 ファイル 1 回の yq で 3 フィールドを採る（test-doc-matrix.sh と同じ形）。32 件規模なら
+# ファイルごとに yq を起こすコストは問題にならない。
+#
+# yq の失敗（YAML が壊れている）と「値が空」は区別する。畳むと、frontmatter の構文エラーが
+# 「フィールドが無い」と診断されて調査先を誤らせる（フィールドの欠損自体は model.yaml の
+# required 宣言により sara check が落とす担当）。
 checked=0
 for f in "${risk_files[@]}"; do
   name="$(basename "$f")"
-  likelihood="$(field_of "$f" likelihood)"
-  impact="$(field_of "$f" impact)"
-  level="$(field_of "$f" level)"
+
+  if ! fields="$(yq --front-matter=extract -r \
+    '[(.likelihood // ""), (.impact // ""), (.level // "")] | @tsv' "$f" 2>/dev/null)"; then
+    fault "$name: frontmatter を yq で読めなかった（YAML の構文を確認する）"
+    continue
+  fi
+
+  IFS=$'\t' read -r likelihood impact level <<<"$fields"
 
   if [[ -z "$likelihood" || -z "$impact" || -z "$level" ]]; then
-    fault "$name: frontmatter から 3 フィールドを読めない（likelihood=$likelihood impact=$impact level=$level）"
+    fault "$name: frontmatter に 3 フィールドが揃っていない（likelihood='$likelihood' impact='$impact' level='$level'）"
     continue
   fi
 
   want="${LEVEL_MATRIX[$likelihood:$impact]:-}"
   if [[ -z "$want" ]]; then
-    # 生値を引用符で囲んで出す。enum 外の値と、剥がしきれなかった表記ゆれ
-    # （全角空白・内側の引用符など）を目視で区別できるようにする。
-    fault "$name: likelihood='$likelihood' impact='$impact' に対応するマトリクスのセルが無い（enum 外の値か表記ゆれ）"
+    # 生値を引用符で囲んで出す。enum 外の値であることを目視で確かめられるようにする
+    # （引用符・空白の表記ゆれは yq が正規化するのでここには現れない）。
+    fault "$name: likelihood='$likelihood' impact='$impact' に対応するマトリクスのセルが無い（enum 外の値）"
     continue
   fi
 

--- a/dev/tests/risk-matrix.sh
+++ b/dev/tests/risk-matrix.sh
@@ -92,51 +92,102 @@ field_of() {
 
 # --- 1. LEVEL_MATRIX が sara-graph.md の level 表と一致する -------------------
 #
-# 正本の表は 3 行 4 列の Markdown テーブルで、行頭が likelihood、以降が impact
-# high / medium / low の順に並ぶ:
+# 正本の表は Markdown テーブルで、見出しが impact の列順を、以降の各行が likelihood
+# ごとのセルを持つ:
 #
+#   | `likelihood` \ `impact` | `high` | `medium` | `low` |
 #   | **`high`** | `high` | `high` | `medium` |
 #
-# 行頭が `| **` で始まる行だけを拾えば、上の見出し行（`| `likelihood` \ …`）と
-# 区切り行（`|---|`）を巻き込まずに 3 行が取れる。バッククォート・アスタリスク・
-# パイプ・空白を落として 4 語にすると、そのまま likelihood + 3 セルになる。
+# 見出し行が impact の列順を宣言し、行頭が `| **` の 3 行が likelihood ごとのセルを
+# 持つ。列順は見出しから読む（決め打ちにすると、見出しとデータ行を揃えて列を入れ替えた
+# 表が素通りする）。行ラベルも読み取って、照合したセルの集合が LEVEL_MATRIX の 9 キーと
+# 過不足なく一致することまで確かめる（行の重複・欠落・列の増減はここで落ちる）。
+#
+# awk はタグ付きで出す: 見出しは `H <impact> …`、データ行は `R <likelihood> <cell> …`。
+# バッククォート・アスタリスク・パイプを落とすと語に割れる。見出しの第 1 セルは
+# `likelihood \ impact` なのでラベルではなく、`\` の後ろまで含めて捨てる。
 if [[ ! -f "$graph_md" ]]; then
   fault "level 表の正本を解決できない（$graph_md）"
 else
+  impact_cols=()
   matrix_rows=0
   matrix_ok=1
-  while read -r row_likelihood cell_high cell_medium cell_low; do
-    matrix_rows=$((matrix_rows + 1))
-    for impact_col in high medium low; do
-      case "$impact_col" in
-        high) doc_level="$cell_high" ;;
-        medium) doc_level="$cell_medium" ;;
-        low) doc_level="$cell_low" ;;
-      esac
-      script_level="${LEVEL_MATRIX[$row_likelihood:$impact_col]:-}"
-      if [[ "$script_level" != "$doc_level" ]]; then
-        fault "マトリクスが正本とずれている（likelihood=$row_likelihood impact=$impact_col: sara-graph.md=$doc_level スクリプト=$script_level）"
-        matrix_ok=0
-      fi
-    done
+  declare -A compared=()
+
+  while read -r kind rest; do
+    case "$kind" in
+      H)
+        # shellcheck disable=SC2206 # 語分割で列名の配列にする（値は英小文字のみ）
+        impact_cols=($rest)
+        ;;
+      R)
+        matrix_rows=$((matrix_rows + 1))
+        # shellcheck disable=SC2206
+        row=($rest)
+        row_label="${row[0]}"
+        cells=("${row[@]:1}")
+        if [[ "${#cells[@]}" -ne "${#impact_cols[@]}" ]]; then
+          fault "level 表の行 $row_label のセル数が見出しと違う（見出し ${#impact_cols[@]} 列・行 ${#cells[@]} 列）"
+          matrix_ok=0
+          continue
+        fi
+        for i in "${!impact_cols[@]}"; do
+          key="$row_label:${impact_cols[$i]}"
+          if [[ -n "${compared[$key]:-}" ]]; then
+            fault "level 表でセル $key が 2 回現れる（行ラベルか列名が重複している）"
+            matrix_ok=0
+            continue
+          fi
+          compared["$key"]=1
+          script_level="${LEVEL_MATRIX[$key]:-}"
+          if [[ "$script_level" != "${cells[$i]}" ]]; then
+            fault "マトリクスが正本とずれている（$key: sara-graph.md=${cells[$i]} スクリプト=${script_level:-（キー無し）}）"
+            matrix_ok=0
+          fi
+        done
+        ;;
+    esac
   done < <(
     awk '
       /^### `level`/ { in_section = 1; next }
       in_section && /^## / { in_section = 0 }
       !in_section        { next }
+      # 見出し行。第 1 セルの `likelihood \ impact` を捨てて impact の列名だけ出す。
+      /^\| `likelihood`/ {
+        sub(/^[^\\]*\\/, "")
+        gsub(/[`|]/, " ")
+        line = "H"
+        for (i = 2; i <= NF; i++) { line = line " " $i }
+        print line
+        next
+      }
+      # データ行。第 1 セルが likelihood のラベル。
       /^\| \*\*/ {
         gsub(/[`*|]/, " ")
-        print $1, $2, $3, $4
+        line = "R"
+        for (i = 1; i <= NF; i++) { line = line " " $i }
+        print line
       }
     ' "$graph_md"
   )
 
   # 抽出が壊れた状態で突合すると、ループが 0 周回って全て緑に見える。
-  # 表の形（3 行）を先に固定する。
-  if [[ "$matrix_rows" -ne 3 ]]; then
-    fault "sara-graph.md の level 表から 3 行を抽出できない（実際: $matrix_rows 行）"
-  elif [[ "$matrix_ok" -eq 1 ]]; then
-    pass "LEVEL_MATRIX の 9 セルが sara-graph.md の level 表と一致する"
+  # 「照合したセルの集合 == LEVEL_MATRIX のキー集合」を最後に確かめれば、
+  # 行数・列数・ラベルの取り違えが 1 つの判定に畳まれる。
+  if [[ "${#impact_cols[@]}" -eq 0 || "$matrix_rows" -eq 0 ]]; then
+    fault "sara-graph.md の level 表を抽出できない（見出し ${#impact_cols[@]} 列・データ $matrix_rows 行）"
+  elif [[ "${#compared[@]}" -ne "${#LEVEL_MATRIX[@]}" ]]; then
+    fault "level 表と照合したセルが LEVEL_MATRIX の全キーを覆っていない（照合 ${#compared[@]} セル・LEVEL_MATRIX ${#LEVEL_MATRIX[@]} セル）"
+  else
+    for key in "${!LEVEL_MATRIX[@]}"; do
+      if [[ -z "${compared[$key]:-}" ]]; then
+        fault "LEVEL_MATRIX の $key に対応するセルが level 表に無い"
+        matrix_ok=0
+      fi
+    done
+    if [[ "$matrix_ok" -eq 1 ]]; then
+      pass "LEVEL_MATRIX の ${#LEVEL_MATRIX[@]} セルが sara-graph.md の level 表と一致する"
+    fi
   fi
 fi
 

--- a/dev/tests/risk-matrix.sh
+++ b/dev/tests/risk-matrix.sh
@@ -5,9 +5,15 @@
 #   nix develop '.?dir=dev#sara' -c dev/tests/risk-matrix.sh   # devShell / CI から直接
 #   nix flake check ./dev                                       # checks.risk-matrix 経由
 #
-# 検証対象は 1 つだけ:
-#   docs/risks/*.md 全件で、frontmatter の level が likelihood × impact の
-#   マトリクス導出（下の LEVEL_MATRIX）と一致する。
+# 検証対象。番号は下の節見出しに対応する:
+#   1.  下の LEVEL_MATRIX が docs/agents/sara-graph.md の level 表と一致する（契約テスト）
+#   2.  docs/risks/*.md 全件で、frontmatter の level が likelihood × impact の
+#       マトリクス導出と一致する
+#
+# §1 が要るのは、コーパスが 9 セルのうち一部しか踏まないため。実測（2026-08-13）で
+# 32 件が踏むのは 5 セルだけで、残り 4 セルの転記を誤っても §2 は全件緑のまま通る。
+# 表の正本は散文側にあるので、その 3 行を読んで突き合わせる（sara-id.sh §6b が
+# docs/model.yaml と dev/flake.nix を突合するのと同じ構図）。
 #
 # フィールドの存在・enum 妥当性（high / medium / low のいずれか）は docs/model.yaml が
 # 宣言し `sara check` が検証する担当なので、ここでは重複させない。ここが見るのは
@@ -33,8 +39,8 @@ fault() {
 }
 
 # level 導出マトリクス。正本は docs/agents/sara-graph.md「How a risk is scored」節の
-# `level` 表で、ここはその 9 セルを機械可読に写したもの。表を変えるときは両方を同じ
-# コミットで揃える（9 セル固定・共用する消費者もいないため TSV 等へ外出ししない）。
+# `level` 表で、ここはその 9 セルを機械可読に写したもの。写しが正本とずれていないことは
+# §1 が機械的に突き合わせる（9 セル固定・共用する消費者もいないため TSV 等へ外出ししない）。
 #
 #   likelihood \ impact | high   | medium | low
 #   high                | high   | high   | medium
@@ -56,12 +62,15 @@ declare -A LEVEL_MATRIX=(
 # （checks 派生のサンドボックスは作業ツリーを持たないためこの経路を通る）。
 repo_root=$(git rev-parse --show-toplevel 2>/dev/null || printf '.')
 
-# docs/risks の在り処は 2 経路ある（sara-id.sh §6b と同じ扱い）:
-#   1. RISK_DOCS_DIR（checks.risk-matrix のサンドボックス。作業ツリーが無いので
-#      nix が store path を渡す）
+# 読む正本 2 つの在り処は 2 経路ある（sara-id.sh §6b と同じ扱い）:
+#   1. RISK_DOCS_DIR / SARA_GRAPH_MD（checks.risk-matrix のサンドボックス。作業ツリーが
+#      無いので nix が store path を渡す）
 #   2. git のリポジトリルート基準（`nix develop` からの直接実行・CI の sara job）
 risks_dir="${RISK_DOCS_DIR:-}"
 [[ -d "$risks_dir" ]] || risks_dir="$repo_root/docs/risks"
+
+graph_md="${SARA_GRAPH_MD:-}"
+[[ -f "$graph_md" ]] || graph_md="$repo_root/docs/agents/sara-graph.md"
 
 if [[ ! -d "$risks_dir" ]]; then
   echo "risk-matrix.sh: risk item のディレクトリを解決できない（$risks_dir）" >&2
@@ -69,11 +78,69 @@ if [[ ! -d "$risks_dir" ]]; then
 fi
 
 # frontmatter（先頭の `---` から次の `---` まで）から 1 フィールドを取り出す。
-# yq を足さず sed で済ませる。本文にも `likelihood: medium — …` の形の根拠記述が
-# あるため、範囲を frontmatter に限らないと本文側を拾って判定が狂う。
+# yq を足さず sed で済ませる。範囲を frontmatter に限るのは予防措置で、現コーパスの
+# 本文に `^likelihood:` の形で当たる行は無い（根拠記述は「likelihood を medium と
+# するのは …」の形）。本文へその形の行が現れた時点で判定が狂うのを未然に防ぐ。
+#
+# 値は引用符と前後の空白を剥がす。剥がさないと `impact: "high"` のような表記ゆれが
+# 「マトリクスのセルが無い」として報告され、enum 違反と区別が付かなくなる。
 field_of() {
-  sed -n '1{/^---$/!q}; 1,/^---$/{ /^---$/d; s/^'"$2"':[[:space:]]*//p }' "$1" | head -1
+  sed -n '1{/^---$/!q}; 1,/^---$/{ /^---$/d; s/^'"$2"':[[:space:]]*//p }' "$1" |
+    head -1 |
+    sed -e 's/[[:space:]]*$//' -e 's/^"\(.*\)"$/\1/' -e "s/^'\(.*\)'$/\1/"
 }
+
+# --- 1. LEVEL_MATRIX が sara-graph.md の level 表と一致する -------------------
+#
+# 正本の表は 3 行 4 列の Markdown テーブルで、行頭が likelihood、以降が impact
+# high / medium / low の順に並ぶ:
+#
+#   | **`high`** | `high` | `high` | `medium` |
+#
+# 行頭が `| **` で始まる行だけを拾えば、上の見出し行（`| `likelihood` \ …`）と
+# 区切り行（`|---|`）を巻き込まずに 3 行が取れる。バッククォート・アスタリスク・
+# パイプ・空白を落として 4 語にすると、そのまま likelihood + 3 セルになる。
+if [[ ! -f "$graph_md" ]]; then
+  fault "level 表の正本を解決できない（$graph_md）"
+else
+  matrix_rows=0
+  matrix_ok=1
+  while read -r row_likelihood cell_high cell_medium cell_low; do
+    matrix_rows=$((matrix_rows + 1))
+    for impact_col in high medium low; do
+      case "$impact_col" in
+        high) doc_level="$cell_high" ;;
+        medium) doc_level="$cell_medium" ;;
+        low) doc_level="$cell_low" ;;
+      esac
+      script_level="${LEVEL_MATRIX[$row_likelihood:$impact_col]:-}"
+      if [[ "$script_level" != "$doc_level" ]]; then
+        fault "マトリクスが正本とずれている（likelihood=$row_likelihood impact=$impact_col: sara-graph.md=$doc_level スクリプト=$script_level）"
+        matrix_ok=0
+      fi
+    done
+  done < <(
+    awk '
+      /^### `level`/ { in_section = 1; next }
+      in_section && /^## / { in_section = 0 }
+      !in_section        { next }
+      /^\| \*\*/ {
+        gsub(/[`*|]/, " ")
+        print $1, $2, $3, $4
+      }
+    ' "$graph_md"
+  )
+
+  # 抽出が壊れた状態で突合すると、ループが 0 周回って全て緑に見える。
+  # 表の形（3 行）を先に固定する。
+  if [[ "$matrix_rows" -ne 3 ]]; then
+    fault "sara-graph.md の level 表から 3 行を抽出できない（実際: $matrix_rows 行）"
+  elif [[ "$matrix_ok" -eq 1 ]]; then
+    pass "LEVEL_MATRIX の 9 セルが sara-graph.md の level 表と一致する"
+  fi
+fi
+
+# --- 2. 全 risk item の level が導出と一致する --------------------------------
 
 # ファイル一覧は改行区切りで受ける（この corpus のファイル名は日付 + UUID8 + slug で
 # 空白・改行を含まない → CLAUDE.md の ID 規約）。
@@ -100,7 +167,9 @@ for f in "${risk_files[@]}"; do
 
   want="${LEVEL_MATRIX[$likelihood:$impact]:-}"
   if [[ -z "$want" ]]; then
-    fault "$name: likelihood=$likelihood impact=$impact に対応するマトリクスのセルが無い"
+    # 生値を引用符で囲んで出す。enum 外の値と、剥がしきれなかった表記ゆれ
+    # （全角空白・内側の引用符など）を目視で区別できるようにする。
+    fault "$name: likelihood='$likelihood' impact='$impact' に対応するマトリクスのセルが無い（enum 外の値か表記ゆれ）"
     continue
   fi
 

--- a/dev/tests/risk-matrix.sh
+++ b/dev/tests/risk-matrix.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# risk の level 導出マトリクス整合の契約テスト（→ Issue #303）。
+#
+# 実行:
+#   nix develop '.?dir=dev#sara' -c dev/tests/risk-matrix.sh   # devShell / CI から直接
+#   nix flake check ./dev                                       # checks.risk-matrix 経由
+#
+# 検証対象は 1 つだけ:
+#   docs/risks/*.md 全件で、frontmatter の level が likelihood × impact の
+#   マトリクス導出（下の LEVEL_MATRIX）と一致する。
+#
+# フィールドの存在・enum 妥当性（high / medium / low のいずれか）は docs/model.yaml が
+# 宣言し `sara check` が検証する担当なので、ここでは重複させない。ここが見るのは
+# 3 フィールドの「関係」だけで、値が enum 外・欠損のときはマトリクスを引けないため
+# その旨を FAIL として報告する（sara check の代替をするのではなく、判定不能を黙って
+# 素通りさせないための扱い）。
+#
+# ## なぜ機械化するか
+#
+# level 導出は `docs/agents/sara-graph.md` の規約のうち唯一「散文の解釈を伴わない
+# 純粋な写像」で、スクリプトが判定しきれる。目視レビューはこの検査の最も弱い形。
+
+# -e は使わない（sara-id.sh・test-doc-map.sh と同じ理由）。このテストは「1 回の実行で
+# 全失敗を報告する」集計方式で、-e があると最初の非ゼロ終了で以降のアサーションが
+# 走らず、退行時の診断が先頭 1 件で切れる。
+set -uo pipefail
+
+fail=0
+pass() { printf 'ok   - %s\n' "$1"; }
+fault() {
+  printf 'FAIL - %s\n' "$1"
+  fail=1
+}
+
+# level 導出マトリクス。正本は docs/agents/sara-graph.md「How a risk is scored」節の
+# `level` 表で、ここはその 9 セルを機械可読に写したもの。表を変えるときは両方を同じ
+# コミットで揃える（9 セル固定・共用する消費者もいないため TSV 等へ外出ししない）。
+#
+#   likelihood \ impact | high   | medium | low
+#   high                | high   | high   | medium
+#   medium              | high   | medium | low
+#   low                 | medium | low    | low
+declare -A LEVEL_MATRIX=(
+  [high:high]=high
+  [high:medium]=high
+  [high:low]=medium
+  [medium:high]=high
+  [medium:medium]=medium
+  [medium:low]=low
+  [low:high]=medium
+  [low:medium]=low
+  [low:low]=low
+)
+
+# 走査基点をリポジトリルートへ解決する。git 管理外ではカレント基準へフォールバックする
+# （checks 派生のサンドボックスは作業ツリーを持たないためこの経路を通る）。
+repo_root=$(git rev-parse --show-toplevel 2>/dev/null || printf '.')
+
+# docs/risks の在り処は 2 経路ある（sara-id.sh §6b と同じ扱い）:
+#   1. RISK_DOCS_DIR（checks.risk-matrix のサンドボックス。作業ツリーが無いので
+#      nix が store path を渡す）
+#   2. git のリポジトリルート基準（`nix develop` からの直接実行・CI の sara job）
+risks_dir="${RISK_DOCS_DIR:-}"
+[[ -d "$risks_dir" ]] || risks_dir="$repo_root/docs/risks"
+
+if [[ ! -d "$risks_dir" ]]; then
+  echo "risk-matrix.sh: risk item のディレクトリを解決できない（$risks_dir）" >&2
+  exit 1
+fi
+
+# frontmatter（先頭の `---` から次の `---` まで）から 1 フィールドを取り出す。
+# yq を足さず sed で済ませる。本文にも `likelihood: medium — …` の形の根拠記述が
+# あるため、範囲を frontmatter に限らないと本文側を拾って判定が狂う。
+field_of() {
+  sed -n '1{/^---$/!q}; 1,/^---$/{ /^---$/d; s/^'"$2"':[[:space:]]*//p }' "$1" | head -1
+}
+
+# ファイル一覧は改行区切りで受ける（この corpus のファイル名は日付 + UUID8 + slug で
+# 空白・改行を含まない → CLAUDE.md の ID 規約）。
+mapfile -t risk_files < <(find "$risks_dir" -maxdepth 1 -type f -name '*.md' | LC_ALL=C sort)
+
+# 対象 0 件を緑にしない。走査先の解決を誤ったとき（ディレクトリ移動・環境変数の
+# 誤配線）、件数を見ないと「全件合格」と報告してしまう。
+if [[ "${#risk_files[@]}" -eq 0 ]]; then
+  fault "docs/risks に risk item が 1 件も無い（走査先: $risks_dir）"
+  exit "$fail"
+fi
+
+checked=0
+for f in "${risk_files[@]}"; do
+  name="$(basename "$f")"
+  likelihood="$(field_of "$f" likelihood)"
+  impact="$(field_of "$f" impact)"
+  level="$(field_of "$f" level)"
+
+  if [[ -z "$likelihood" || -z "$impact" || -z "$level" ]]; then
+    fault "$name: frontmatter から 3 フィールドを読めない（likelihood=$likelihood impact=$impact level=$level）"
+    continue
+  fi
+
+  want="${LEVEL_MATRIX[$likelihood:$impact]:-}"
+  if [[ -z "$want" ]]; then
+    fault "$name: likelihood=$likelihood impact=$impact に対応するマトリクスのセルが無い"
+    continue
+  fi
+
+  if [[ "$level" != "$want" ]]; then
+    fault "$name: level が導出と食い違う（likelihood=$likelihood impact=$impact → $want、実際: $level）"
+    continue
+  fi
+
+  checked=$((checked + 1))
+done
+
+if [[ "$checked" -eq "${#risk_files[@]}" ]]; then
+  pass "risk $checked 件の level が likelihood × impact の導出と一致する"
+fi
+
+exit "$fail"

--- a/dev/tests/risk-matrix.sh
+++ b/dev/tests/risk-matrix.sh
@@ -5,15 +5,15 @@
 #   nix develop '.?dir=dev#sara' -c dev/tests/risk-matrix.sh   # devShell / CI から直接
 #   nix flake check ./dev                                       # checks.risk-matrix 経由
 #
-# 検証対象。番号は下の節見出しに対応する:
-#   1.  下の LEVEL_MATRIX が docs/agents/sara-graph.md の level 表と一致する（契約テスト）
-#   2.  docs/risks/*.md 全件で、frontmatter の level が likelihood × impact の
-#       マトリクス導出と一致する
+# 検証対象:
+#   docs/risks/*.md 全件で、frontmatter の level が likelihood × impact の
+#   マトリクス導出（dev/tests/risk-matrix.tsv）と一致する。
 #
-# §1 が要るのは、コーパスが 9 セルのうち一部しか踏まないため。実測（2026-08-13）で
-# 32 件が踏むのは 5 セルだけで、残り 4 セルの転記を誤っても §2 は全件緑のまま通る。
-# 表の正本は散文側にあるので、その 3 行を読んで突き合わせる（sara-id.sh §6b が
-# docs/model.yaml と dev/flake.nix を突合するのと同じ構図）。
+# マトリクスの正本は dev/tests/risk-matrix.tsv（機械可読）。docs/agents/sara-graph.md の
+# level 表は読み物としての要約で、規範は TSV 側にある（test-categories.tsv と CLAUDE.md の
+# 8 区分表と同じ構図）。当初は 9 セルをスクリプトへ直書きし、sara-graph.md の Markdown
+# テーブルを awk で解析して突き合わせていたが、その処理がスクリプトの複雑さの大半を
+# 占めたため正本を TSV へ移して廃止した（→ PR #352）。
 #
 # フィールドの存在・enum 妥当性（high / medium / low のいずれか）は docs/model.yaml が
 # 宣言し `sara check` が検証する担当なので、ここでは重複させない。ここが見るのは
@@ -50,147 +50,68 @@ fault() {
 require_commands "risk-matrix.sh（nix develop '.?dir=dev#sara' から実行する）" yq || exit 1
 require_yq_go risk-matrix.sh || exit 1
 
-# level 導出マトリクス。正本は docs/agents/sara-graph.md「How a risk is scored」節の
-# `level` 表で、ここはその 9 セルを機械可読に写したもの。写しが正本とずれていないことは
-# §1 が機械的に突き合わせる（9 セル固定・共用する消費者もいないため TSV 等へ外出ししない）。
-#
-#   likelihood \ impact | high   | medium | low
-#   high                | high   | high   | medium
-#   medium              | high   | medium | low
-#   low                 | medium | low    | low
-declare -A LEVEL_MATRIX=(
-  [high:high]=high
-  [high:medium]=high
-  [high:low]=medium
-  [medium:high]=high
-  [medium:medium]=medium
-  [medium:low]=low
-  [low:high]=medium
-  [low:medium]=low
-  [low:low]=low
-)
-
 # 走査基点をリポジトリルートへ解決する。git 管理外ではカレント基準へフォールバックする
 # （checks 派生のサンドボックスは作業ツリーを持たないためこの経路を通る）。
 repo_root=$(git rev-parse --show-toplevel 2>/dev/null || printf '.')
 
-# 読む正本 2 つの在り処は 2 経路ある（sara-id.sh §6b と同じ扱い）:
-#   1. RISK_DOCS_DIR / SARA_GRAPH_MD（checks.risk-matrix のサンドボックス。作業ツリーが
-#      無いので nix が store path を渡す）
+# 走査対象 docs/risks の在り処は 2 経路ある（sara-id.sh §6b と同じ扱い）:
+#   1. RISK_DOCS_DIR（checks.risk-matrix のサンドボックス。作業ツリーが無いので
+#      nix が store path を渡す）
 #   2. git のリポジトリルート基準（`nix develop` からの直接実行・CI の sara job）
 risks_dir="${RISK_DOCS_DIR:-}"
 [[ -d "$risks_dir" ]] || risks_dir="$repo_root/docs/risks"
-
-graph_md="${SARA_GRAPH_MD:-}"
-[[ -f "$graph_md" ]] || graph_md="$repo_root/docs/agents/sara-graph.md"
 
 if [[ ! -d "$risks_dir" ]]; then
   echo "risk-matrix.sh: risk item のディレクトリを解決できない（$risks_dir）" >&2
   exit 1
 fi
 
-# --- 1. LEVEL_MATRIX が sara-graph.md の level 表と一致する -------------------
+# --- level 導出マトリクスを正本の TSV から読む -------------------------------
 #
-# 正本の表は Markdown テーブルで、見出しが impact の列順を、以降の各行が likelihood
-# ごとのセルを持つ:
-#
-#   | `likelihood` \ `impact` | `high` | `medium` | `low` |
-#   | **`high`** | `high` | `high` | `medium` |
-#
-# 見出し行が impact の列順を宣言し、行頭が `| **` の 3 行が likelihood ごとのセルを
-# 持つ。列順は見出しから読む（決め打ちにすると、見出しとデータ行を揃えて列を入れ替えた
-# 表が素通りする）。行ラベルも読み取って、照合したセルの集合が LEVEL_MATRIX の 9 キーと
-# 過不足なく一致することまで確かめる（行の重複・欠落・列の増減はここで落ちる）。
-#
-# awk はタグ付きで出す: 見出しは `H <impact> …`、データ行は `R <likelihood> <cell> …`。
-# バッククォート・アスタリスク・パイプを落とすと語に割れる。見出しの第 1 セルは
-# `likelihood \ impact` なのでラベルではなく、`\` の後ろまで含めて捨てる。
-if [[ ! -f "$graph_md" ]]; then
-  fault "level 表の正本を解決できない（$graph_md）"
-else
-  impact_cols=()
-  matrix_rows=0
-  matrix_ok=1
-  declare -A compared=()
+# TSV はこのスクリプトと同じディレクトリに置く（checks 派生も dev/ の木ごと配置するので
+# スクリプト基準で解決できる。docs/risks のように環境変数の受け口は要らない）。
+matrix_tsv="$(dirname "$0")/risk-matrix.tsv"
 
-  while read -r kind rest; do
-    case "$kind" in
-      H)
-        # shellcheck disable=SC2206 # 語分割で列名の配列にする（値は英小文字のみ）
-        impact_cols=($rest)
-        ;;
-      R)
-        matrix_rows=$((matrix_rows + 1))
-        # shellcheck disable=SC2206
-        row=($rest)
-        row_label="${row[0]}"
-        cells=("${row[@]:1}")
-        if [[ "${#cells[@]}" -ne "${#impact_cols[@]}" ]]; then
-          fault "level 表の行 $row_label のセル数が見出しと違う（見出し ${#impact_cols[@]} 列・行 ${#cells[@]} 列）"
-          matrix_ok=0
-          continue
-        fi
-        for i in "${!impact_cols[@]}"; do
-          key="$row_label:${impact_cols[$i]}"
-          if [[ -n "${compared[$key]:-}" ]]; then
-            fault "level 表でセル $key が 2 回現れる（行ラベルか列名が重複している）"
-            matrix_ok=0
-            continue
-          fi
-          compared["$key"]=1
-          script_level="${LEVEL_MATRIX[$key]:-}"
-          if [[ "$script_level" != "${cells[$i]}" ]]; then
-            fault "マトリクスが正本とずれている（$key: sara-graph.md=${cells[$i]} スクリプト=${script_level:-（キー無し）}）"
-            matrix_ok=0
-          fi
-        done
-        ;;
-    esac
-  done < <(
-    awk '
-      /^### `level`/ { in_section = 1; next }
-      in_section && /^## / { in_section = 0 }
-      !in_section        { next }
-      # 見出し行。第 1 セルの `likelihood \ impact` を捨てて impact の列名だけ出す。
-      /^\| `likelihood`/ {
-        sub(/^[^\\]*\\/, "")
-        gsub(/[`|]/, " ")
-        line = "H"
-        for (i = 2; i <= NF; i++) { line = line " " $i }
-        print line
-        next
-      }
-      # データ行。第 1 セルが likelihood のラベル。
-      /^\| \*\*/ {
-        gsub(/[`*|]/, " ")
-        line = "R"
-        for (i = 1; i <= NF; i++) { line = line " " $i }
-        print line
-      }
-    ' "$graph_md"
-  )
-
-  # 抽出が壊れた状態で突合すると、ループが 0 周回って全て緑に見える。
-  # 「照合したセルの集合 == LEVEL_MATRIX のキー集合」を最後に確かめれば、
-  # 行数・列数・ラベルの取り違えが 1 つの判定に畳まれる。
-  if [[ "${#impact_cols[@]}" -eq 0 || "$matrix_rows" -eq 0 ]]; then
-    fault "sara-graph.md の level 表を抽出できない（見出し ${#impact_cols[@]} 列・データ $matrix_rows 行）"
-  elif [[ "${#compared[@]}" -ne "${#LEVEL_MATRIX[@]}" ]]; then
-    fault "level 表と照合したセルが LEVEL_MATRIX の全キーを覆っていない（照合 ${#compared[@]} セル・LEVEL_MATRIX ${#LEVEL_MATRIX[@]} セル）"
-  else
-    for key in "${!LEVEL_MATRIX[@]}"; do
-      if [[ -z "${compared[$key]:-}" ]]; then
-        fault "LEVEL_MATRIX の $key に対応するセルが level 表に無い"
-        matrix_ok=0
-      fi
-    done
-    if [[ "$matrix_ok" -eq 1 ]]; then
-      pass "LEVEL_MATRIX の ${#LEVEL_MATRIX[@]} セルが sara-graph.md の level 表と一致する"
-    fi
-  fi
+if [[ ! -f "$matrix_tsv" ]]; then
+  echo "risk-matrix.sh: マトリクスの正本が無い（$matrix_tsv）" >&2
+  exit 1
 fi
 
-# --- 2. 全 risk item の level が導出と一致する --------------------------------
+declare -A LEVEL_MATRIX=()
+tsv_rows=0
+tsv_ok=1
+while IFS=$'\t' read -r likelihood impact level; do
+  tsv_rows=$((tsv_rows + 1))
+  if [[ -z "$likelihood" || -z "$impact" || -z "$level" ]]; then
+    fault "risk-matrix.tsv の $tsv_rows 行目に空の列がある（likelihood='$likelihood' impact='$impact' level='$level'）"
+    tsv_ok=0
+    continue
+  fi
+  key="$likelihood:$impact"
+  if [[ -n "${LEVEL_MATRIX[$key]:-}" ]]; then
+    fault "risk-matrix.tsv で $key が 2 回現れる（既出: ${LEVEL_MATRIX[$key]}・再出: $level）"
+    tsv_ok=0
+    continue
+  fi
+  LEVEL_MATRIX["$key"]="$level"
+done < <(read_tsv "$matrix_tsv")
+
+# 9 セルが揃っていることを確かめる。TSV が空・行が削れた状態で本体の走査を回すと、
+# 該当セルを持つ risk が「セルが無い」で落ちるだけで、TSV 側の欠損だと分からないまま
+# 調査先を誤る。3 値（high / medium / low）の直積なので 9 が期待値。
+if [[ "${#LEVEL_MATRIX[@]}" -ne 9 ]]; then
+  fault "risk-matrix.tsv のセルが 9 件ではない（実際: ${#LEVEL_MATRIX[@]} 件・データ行 $tsv_rows 行）"
+  tsv_ok=0
+fi
+
+# マトリクスを引けない状態で走査を回しても全件 FAIL するだけで診断の役に立たない。
+if [[ "$tsv_ok" -eq 0 ]]; then
+  exit 1
+fi
+
+pass "risk-matrix.tsv から ${#LEVEL_MATRIX[@]} セルのマトリクスを読んだ"
+
+# --- 全 risk item の level が導出と一致する -----------------------------------
 
 # ファイル一覧は改行区切りで受ける（この corpus のファイル名は日付 + UUID8 + slug で
 # 空白・改行を含まない → CLAUDE.md の ID 規約）。

--- a/dev/tests/risk-matrix.tsv
+++ b/dev/tests/risk-matrix.tsv
@@ -1,0 +1,25 @@
+# risk の level 導出マトリクス（likelihood × impact → level）の正本。
+#
+# この表が「どの組み合わせがどの level になるか」の SSOT（→ Issue #303）。
+# docs/agents/sara-graph.md「How a risk is scored」節の level 表は読み物としての
+# 要約で、規範はこちら。セルを変えるときはここと sara-graph.md の表を揃える。
+#
+# 当初は 9 セルをスクリプト内へ直書きし、sara-graph.md の Markdown テーブルを awk で
+# 解析して突き合わせていた（Issue #303 の確定判断）。その突合処理がスクリプトの
+# 複雑さの大半（約 80 行）を占め、Markdown の表記ゆれ（列順・行ラベル・列数）を
+# 自前で扱う分だけテストしづらいコードが増えていたため、機械可読な正本をここへ
+# 移して解析処理ごと廃止した（判断の撤回・PR #352）。
+#
+# 形式: <likelihood>\t<impact>\t<level>
+# 行頭 # はコメント、空行は無視。列の区切りはタブ 1 個。
+# likelihood / impact の組は 9 通りを過不足なく列挙する（dev/tests/risk-matrix.sh が
+# 件数と重複を検査する）。
+high	high	high
+high	medium	high
+high	low	medium
+medium	high	high
+medium	medium	medium
+medium	low	low
+low	high	medium
+low	medium	low
+low	low	low

--- a/dev/tests/test-doc-exclusions.tsv
+++ b/dev/tests/test-doc-exclusions.tsv
@@ -21,5 +21,6 @@ checks.nput	buildGoModule のビルド + go test 実行。個々の *_test.go �
 checks.treefmt	フォーマッタ検査（treefmt-nix が自動生成）。quality の担当
 checks.namaka	namaka アグリゲータ。leaf の tests/namaka/<name>/ を CASE が持つ
 checks.nix-unit	nix-unit アグリゲータ。leaf の tests/nix-unit/*.nix を CASE が持ち、固有ロジック（重複検査）は tests/nix-unit/aggregator-merge.nix の CASE が検証する
+dev:checks.risk-matrix	risk の level 導出マトリクス整合の契約テスト。検査対象は nput の振る舞いではなく docs のスコアリング規約なので TC / CASE へ展開しない
 dev:checks.sara-id	sara-id の採番契約。TP-d7da4065 のみを持ち TC / CASE へ展開しない
 dev:checks.test-doc-map	CASE ⇔ テストコード対応の契約テスト自身。自分を CASE で覆うと循環する

--- a/docs/agents/sara-graph.md
+++ b/docs/agents/sara-graph.md
@@ -227,6 +227,12 @@ supply the announcement.
 
 ### `level` — derived from the two, never judged by hand
 
+**The source of truth is `dev/tests/risk-matrix.tsv`**, which lists the nine cells in
+machine-readable form. The table below is a reading aid — the same relationship the data
+file holds, laid out for the eye. A change to the derivation edits the TSV and this table in
+the same commit (the same arrangement `dev/tests/test-categories.tsv` has with the
+eight-category table in `CLAUDE.md`).
+
 | `likelihood` \ `impact` | `high` | `medium` | `low` |
 |---|---|---|---|
 | **`high`** | `high` | `high` | `medium` |
@@ -234,13 +240,11 @@ supply the announcement.
 | **`low`** | `medium` | `low` | `low` |
 
 Unlike the rest of this file, this rule is not upheld by review: `dev/tests/risk-matrix.sh`
-checks it mechanically over every item in `docs/risks/`, wired into `checks.risk-matrix`
-for `nix flake check ./dev` and into the CI `sara` job (→ #303). `sara check` validates the
-enum of each field but never the relation between the three, which is the gap that test
-fills. It is the one convention here a script can decide outright — a pure mapping over
-three frontmatter fields with no prose to interpret. The matrix above is the source of
-truth and the test transcribes its nine cells, so a change to the table updates both in the
-same commit.
+reads the TSV and checks every item in `docs/risks/` against it, wired into
+`checks.risk-matrix` for `nix flake check ./dev` and into the CI `sara` job (→ #303).
+`sara check` validates the enum of each field but never the relation between the three,
+which is the gap that test fills. It is the one convention here a script can decide
+outright — a pure mapping over three frontmatter fields with no prose to interpret.
 
 A `level` that does not match the cell is a defect in the item, not a considered override:
 if the matrix feels wrong for an item, the mis-scored field is `likelihood` or `impact`.

--- a/docs/agents/sara-graph.md
+++ b/docs/agents/sara-graph.md
@@ -233,13 +233,14 @@ supply the announcement.
 | **`medium`** | `high` | `medium` | `low` |
 | **`low`** | `medium` | `low` | `low` |
 
-Nothing mechanical checks the derivation today — `sara check` validates the enum, not the
-relation between the three fields — so it is upheld by review like the rest of this file.
-Unlike the rest of this file, though, it need not stay that way: the rule is a pure mapping
-over three frontmatter fields with no prose to interpret, so it is the one convention here
-that a script can decide outright. Reviewing it by eye is the weakest form of the check,
-and a repository-level check in the shape of `dev/tests/sara-id.sh` would replace it
-wholesale. Until such a check exists, verify the cell when touching any of the three fields.
+Unlike the rest of this file, this rule is not upheld by review: `dev/tests/risk-matrix.sh`
+checks it mechanically over every item in `docs/risks/`, wired into `checks.risk-matrix`
+for `nix flake check ./dev` and into the CI `sara` job (→ #303). `sara check` validates the
+enum of each field but never the relation between the three, which is the gap that test
+fills. It is the one convention here a script can decide outright — a pure mapping over
+three frontmatter fields with no prose to interpret. The matrix above is the source of
+truth and the test transcribes its nine cells, so a change to the table updates both in the
+same commit.
 
 A `level` that does not match the cell is a defect in the item, not a considered override:
 if the matrix feels wrong for an item, the mis-scored field is `likelihood` or `impact`.


### PR DESCRIPTION
## 概要

`docs/agents/sara-graph.md` の risk スコアリング規約は `level` を `likelihood` × `impact` の
マトリクスから導出すると定めているが、`sara check` は各フィールドの enum しか検証せず、
3 つの関係は目視レビュー任せだった。規約自身も「スクリプトが判定しきれる唯一の規約」と
述べており、その機械化を行う（Issue #303 の PR 計画 PR-1）。

構成は以下:

- `dev/tests/risk-matrix.tsv` — マトリクス 9 セルの機械可読な正本
- `dev/tests/risk-matrix.sh` — TSV を読み、`docs/risks/*.md` 全件で `level` が
  `likelihood` × `impact` の導出と一致することを検査する
- `docs/agents/sara-graph.md` の level 表 — 読み物としての要約（規範は TSV 側）

`dev/tests/test-categories.tsv` と `CLAUDE.md` の 8 区分表の関係と同じ構図で、機械可読な
正本をデータファイルが持ち、散文側は通読用の要約に留める。

配線は既存 2 つの契約テストと同じ二重化: ローカルの `nix flake check ./dev` 用に
`checks.risk-matrix`、PR での退行検知用に CI の `sara` job のステップ。

**Issue #303 の確定判断から外した 2 点**（いずれもユーザー承認済み）:

1. **「マトリクス 9 セルはスクリプト内に直書きし、TSV 等の外部データファイル化はしない」**
   → 撤回。当初は 9 セルを直書きし、`sara-graph.md` の Markdown テーブルを awk で解析して
   突き合わせる構成にしていたが、その突合処理だけで約 80 行とスクリプトの複雑さの大半を
   占めていた。列順・行ラベル・列数といった Markdown の表記ゆれを自前で扱う必要があり、
   テストしづらいコードが増えていた。正本を TSV へ移して解析処理ごと廃止した結果、awk が
   スクリプトから消えて 249 行 → 170 行になった
2. **「frontmatter 抽出は sed/awk で行い、yq 等の依存を足さない」** → 前提が事実誤認だった。
   `yq-go` は `devShells.sara`（本テストが走る CI 経路そのもの）に既に載っており、`docs/` の
   frontmatter を読む既存スクリプト 2 本（`test-doc-map.sh` / `test-doc-matrix.sh`）も yq を
   使っている。依存は増えず独自パーサだけが流儀から外れる形だったため、`test-doc-matrix.sh`
   と同じ「1 ファイル 1 回の yq で複数フィールドを `@tsv` で採り、yq の失敗と値が空を
   区別する」形へ揃えた

Issue #303 本文にも訂正を反映済み（確定判断 5 の該当項目 + 経緯のコメント）。

「フィールドの存在と enum 妥当性は `sara check` の担当なので重複させない」は変更していない。

**スコープ外の追随**: `checks.risk-matrix` を足したことで、既存の `test-doc-map` 契約テスト
（§5 静的リストの突合）が `dev/scripts/test-inventory.sh` の `FLAKE_CHECKS` への追加を要求して
落ちる。1 行の追加と、対応する `dev/tests/test-doc-exclusions.tsv` への除外行をコミット 1 に
含めた。検査対象が nput の振る舞いではなく docs の規約であるため TC / CASE へは展開しない
（既存の `dev:checks.sara-id` / `dev:checks.test-doc-map` と同じ扱い）。

**動作確認**:

- `nix develop ./dev -c dev/tests/risk-matrix.sh` → pass（TSV 9 セル / risk 32 件）
- `nix build ./dev#checks.x86_64-linux.risk-matrix` → sandbox 経路でも同じ 2 アサーション pass
- `nix flake check ./dev` → `all checks passed!`（`checks.risk-matrix` 含む）
- `nix develop ./dev --command sara check` → pass（strict_mode / warning 0 を維持）
- `nix develop '.?dir=dev#sara' -c dev/tests/test-doc-map.sh` → pass（TSV 新設の影響なし）
- 破壊検証（いずれもローカルの一時変更でコミットしない）。TSV 側:
  - 行を 1 つ削る → 「セルが 9 件ではない（実際: 8 件）」で FAIL
  - `level` を崩す（`medium:high` を `medium` へ）→ 該当セルを持つ risk 21 件が FAIL
  - 重複行を足す → 「`high:high` が 2 回現れる」で FAIL
  - 列が欠ける → 「空の列がある」+ セル数不一致で FAIL
  - データ行を全部消す（コメントのみ）→ 「セルが 9 件ではない（実際: 0 件）」で FAIL
- 破壊検証。risk 側:
  - `level` 不整合 → 該当 1 件のみ FAIL
  - enum 外の値（`impact: critical`）→ 生値付きで FAIL
  - フィールド欠損 → 欠けたフィールドを特定して FAIL
  - YAML 構文エラー → 「yq で読めなかった」として FAIL（欠損とは別経路）
  - `impact: "high"` の引用符・行末空白 → yq が正規化して pass
  - `docs/risks` が 0 件 → FAIL（空走査の偽緑防止）
- `shellcheck dev/tests/risk-matrix.sh` → clean

## 関連 issue

Refs #303

issue は規約改訂と再採点を行う PR-2 で閉じる。本 PR はマトリクスの「関係」だけを見るため
現 corpus で pass し、規約改訂と独立して先行マージできる。

## docs / ADR 影響

- `docs/agents/sara-graph.md` — 2 点変更した。(1) level 導出節末尾の「Nothing mechanical
  checks the derivation today ...」段落を、契約テストが存在する事実へ書き換えた。
  (2) level 表を読み物としての要約へ格下げし、正本が `dev/tests/risk-matrix.tsv` であることを
  明記した（`test-categories.tsv` と `CLAUDE.md` の 8 区分表と同じ構図）。
  「A `level` that does not match the cell is a defect ...」の段落は変更していない
- concept / design / spec の更新 — なし。配置動作・API・方針には触れず、検査手段の追加のみ
- ADR — なし。Issue #303 で ADR を起こすのは impact スケールの再定義（PR-2 の ADR-0052）で、
  本 PR の契約テスト機械化は既存規約の実施手段であり方針転換を伴わない。マトリクス正本の
  配置（スクリプト直書き → TSV）は同 issue の確定判断の撤回にあたるが、規約そのものの
  変更ではなく実装手段の選択なので ADR は起こさず、issue 本文と PR 本文への記録に留める
