### PR TITLE
docs(infrastructure): INF-d1230e1f / INF-af33c5a1 の記述を CI の実態へ追随させる

### DIFF
--- a/docs/infrastructure/20260802-af33c5a1-binary-cache.md
+++ b/docs/infrastructure/20260802-af33c5a1-binary-cache.md
@@ -16,7 +16,9 @@ consumer の CI / ローカルが「最新 main の `nput` を実ビルドせず
 
 - 構成は CI パイプライン（INF-d1230e1f）と同じ os×system の 3 環境マトリクス
   （`ubuntu-latest`=x86_64-linux / `ubuntu-24.04-arm`=aarch64-linux /
-  `macos-latest`=aarch64-darwin）で `nix build .#packages.<system>.nput` をネイティブ実行する
+  `macos-latest`=aarch64-darwin）で `nix build .#packages.<system>.nput` をネイティブ実行する。
+  ただし**同じ値を持つ別々の定義**で、この workflow 自身の `strategy.matrix` に直書きしてある
+  （下の「CI パイプラインへの依存」を参照）
 - 投入は `.github/actions/setup-nix` が内包する `cachix-action` が authToken 指定で生成パスを
   自動 push する経路に任せる。明示の push ステップは置かない
 - 単一パッケージのため、未キャッシュのものだけを選別する plan / collect の多段構成は採らない
@@ -41,7 +43,14 @@ main への push 後に走るため、トリガ段の `paths` フィルタをそ
 乗っている**。この workflow は自前の nix セットアップを持たず、`.github/actions/setup-nix`
 （`install-nix-action` + cachix 認証込みの `cachix-action`）へ丸ごと委ねる。投入経路そのものが
 その composite action の中にあるため、`setup-nix` の構成が変われば投入も直接影響を受ける。
-os×system マトリクスの定義も CI パイプラインと同一のものを踏襲する。
+
+os×system マトリクスも CI パイプラインと同一の内容を踏襲するが、こちらは共有部品ではない。
+`setup-nix` と違って reusable workflow / composite action のような共有機構は挟んでおらず、
+**同じ 3 組をこの workflow の `strategy.matrix` へ独立にハードコードした写し**である。したがって
+**片方を変えたらもう片方の追従が要る** — CI パイプライン側で環境を増減しても、この workflow は
+黙って旧構成のままビルドし続ける（キャッシュに載る system が CI の検証対象とずれる）。
+INF-8b97573f が「ジョブ名 / matrix を変えると check 名も変わる。ruleset 側の追従が要る」と
+言うのと同じ種類の追従点で、マトリクスの変更はこの 2 箇所へ同時に波及する。
 
 ## 出典
 

--- a/docs/infrastructure/20260802-af33c5a1-binary-cache.md
+++ b/docs/infrastructure/20260802-af33c5a1-binary-cache.md
@@ -16,9 +16,7 @@ consumer の CI / ローカルが「最新 main の `nput` を実ビルドせず
 
 - 構成は CI パイプライン（INF-d1230e1f）と同じ os×system の 3 環境マトリクス
   （`ubuntu-latest`=x86_64-linux / `ubuntu-24.04-arm`=aarch64-linux /
-  `macos-latest`=aarch64-darwin）で `nix build .#packages.<system>.nput` をネイティブ実行する。
-  ただし**同じ値を持つ別々の定義**で、この workflow 自身の `strategy.matrix` に直書きしてある
-  （下の「CI パイプラインへの依存」を参照）
+  `macos-latest`=aarch64-darwin）で `nix build .#packages.<system>.nput` をネイティブ実行する
 - 投入は `.github/actions/setup-nix` が内包する `cachix-action` が authToken 指定で生成パスを
   自動 push する経路に任せる。明示の push ステップは置かない
 - 単一パッケージのため、未キャッシュのものだけを選別する plan / collect の多段構成は採らない
@@ -46,11 +44,11 @@ main への push 後に走るため、トリガ段の `paths` フィルタをそ
 
 os×system マトリクスも CI パイプラインと同一の内容を踏襲するが、こちらは共有部品ではない。
 `setup-nix` と違って reusable workflow / composite action のような共有機構は挟んでおらず、
-**同じ 3 組をこの workflow の `strategy.matrix` へ独立にハードコードした写し**である。したがって
-**片方を変えたらもう片方の追従が要る** — CI パイプライン側で環境を増減しても、この workflow は
-黙って旧構成のままビルドし続ける（キャッシュに載る system が CI の検証対象とずれる）。
-INF-8b97573f が「ジョブ名 / matrix を変えると check 名も変わる。ruleset 側の追従が要る」と
-言うのと同じ種類の追従点で、マトリクスの変更はこの 2 箇所へ同時に波及する。
+同じ 3 組をこの workflow の `strategy.matrix` へ独立にハードコードした写しになっている。
+したがって **マトリクスを変えるときは 2 箇所を揃えて直す**。CI パイプライン側だけで環境を
+増減しても、この workflow は黙って旧構成のままビルドし続け、キャッシュに載る system が CI の
+検証対象とずれる。INF-8b97573f が ruleset 側について挙げる追従点と同じ種類のものが、
+マトリクスの定義にもある。
 
 ## 出典
 

--- a/docs/infrastructure/20260802-d1230e1f-ci-pipeline.md
+++ b/docs/infrastructure/20260802-d1230e1f-ci-pipeline.md
@@ -36,8 +36,9 @@ GitHub Actions 上の `test.yml` のうち、**flake check と E2E の系統**�
 最後の `test-doc-matrix` だけはテストを走らせるジョブではなく、テスト資産とテスト文書
 （→ Issue #304）の対応を読み物として出す生成ジョブ。生成物はリポジトリへコミットせず artifact
 に留める — 生成元と併走する生成物はずれるうえ、その diff を読んでも対応の崩れは別途契約テスト
-（→ INF-659b139d）が機械で強制している以上のことは分からない。Job Summary への出力は
-そのついでの表示手段で、サイズ上限に触れる場合は artifact への誘導へ退避する。
+（`dev/tests/test-doc-map.sh`。担当は INF-659b139d）が機械で強制している以上のことは分からない。
+Job Summary への出力はそのついでの表示手段で、サイズ上限に触れる場合は artifact への誘導へ
+退避する。
 
 マトリクスは `ubuntu-latest`=x86_64-linux / `ubuntu-24.04-arm`=aarch64-linux /
 `macos-latest`=aarch64-darwin の 3 環境。x86_64-darwin は GitHub ホストの標準ランナーが
@@ -72,17 +73,19 @@ main への push を消費するのは対応表生成（`test-doc-matrix`）だ�
 
 対応表の生成は `--full` のインベントリ（モジュール全体の `go test -json` と nix-unit 各ファイルの
 評価）を要して PR ごとに払うには重く、マージ後の状態から作れば足りるため、main push と
-`workflow_dispatch` に負担させる。例外は生成側（`dev/scripts/**` とその入力・データファイル）を
-触る PR で、そのときはステップ段の filter が効いて当該 PR 上でも走る。
+`workflow_dispatch` に負担させる。例外は生成の元と入力一式（スクリプトとそのデータファイル、
+生成対象のテスト資産・テスト文書）を触る PR で、そのときはステップ段の filter が効いて当該
+PR 上でも走る。
 
 そのため **`test-doc-matrix` 以外の全ジョブが `github.event_name != 'push'` のジョブ段ガードを
 各自持つ**。変更検出（`changes`）は pull_request 以外のイベントを「実行する」と扱う設計なので、
-ガードが無いと main push で `flake-check` / `go-coverage` / `e2e` / `sara` が新たに走り出す
-（`changes` 自身も、消費者が全て抜ける以上ランナーを取る意味がないので同じガードを持つ）。
-トリガ段で `push` の対象ジョブを絞る手段が GitHub Actions に無い以上、除外はジョブ段で書く
-しかない。`flake-check` も例外ではなくジョブ段に置く — required context の生成が要求されるのは
-pull_request のときだけなので、push で 3 環境のランナーを確保して即終了させる無駄の方を避ける。
-以降で述べる変更検出のゲートがステップ段を採るのはあくまで pull_request 内の話で、
+ガードが無いと main push で `flake-check` / `go-coverage` / `e2e` / `sara` が新たに走り出し、
+その `changes` 自身も消費者が全て抜ける以上ランナーを取る意味がない。トリガ段で `push` の
+対象ジョブを絞る手段が GitHub Actions に無い以上、除外はジョブ段で書くしかない。
+
+`flake-check` もこのガードだけは例外にせずジョブ段へ置く。required context の生成が要求される
+のは pull_request のときだけなので、push で 3 環境のランナーを確保して即終了させる無駄の方を
+避ける。以降で述べる変更検出のゲートがステップ段を採るのはあくまで pull_request 内の話で、
 この push ガードとは別の判断になる。
 
 docs のみの変更で 3 環境マトリクスを回すのは無駄だが、**トリガ段の `paths` フィルタは使わない**。

--- a/docs/infrastructure/20260802-d1230e1f-ci-pipeline.md
+++ b/docs/infrastructure/20260802-d1230e1f-ci-pipeline.md
@@ -55,8 +55,14 @@ SHA pin）に閉じる。`changes` は checkout と変更検出 action だけで
 
 ## トリガと変更検出
 
-`pull_request` + `workflow_dispatch`。`push`（branches-ignore: main）は採らない — PR 経由運用
-（main へ直 push しない）が前提で、push トリガは PR チェックと重複するため。
+`pull_request` + `workflow_dispatch` + `push: main`。テスト系のジョブを駆動するのは前 2 つで、
+main への push を消費するのは対応表生成（`test-doc-matrix`）だけ。PR 経由運用（main へ直 push
+しない）が前提であり、テスト系のジョブを main push で回しても PR チェックと重複するため。
+
+そのため **push を受けないジョブは `github.event_name != 'push'` のジョブ段ガードを各自持つ**。
+変更検出（`changes`）は pull_request 以外のイベントを「実行する」と扱う設計なので、ガードが
+無いと main push で `flake-check` / `go-coverage` / `e2e` / `sara` が新たに走り出す。トリガ段で
+`push` の対象ジョブを絞る手段が GitHub Actions に無い以上、除外はジョブ段で書くしかない。
 
 docs のみの変更で 3 環境マトリクスを回すのは無駄だが、**トリガ段の `paths` フィルタは使わない**。
 required status check（→ INF-8b97573f）は生成されない check を `Expected` のままブロックするため、
@@ -70,6 +76,10 @@ action（`.github/actions/changes`）を `changes` ジョブが呼び、後続�
 |---|---|---|
 | `flake-check` | **ステップ段**（`Setup Nix` / `Run nix flake check` の `if:`） | ジョブ段の `if:` だと matrix が展開されず、ruleset が要求する `flake-check (os, system)` の 3 context が生成されない。`Expected` のまま永久にマージがブロックされる |
 | `e2e` / `go-coverage` | ジョブ段の `if:` | skip → "Skipped" = 成功扱いになるので required check でも成立する |
+
+この区別は変更検出のゲートに限る。前述の push ガードは `flake-check` でもジョブ段に置く —
+required context の生成が要求されるのは pull_request のときだけなので、push では 3 環境の
+ランナーを確保して即終了させる無駄の方を避ける。
 
 ADR-0030 §2 はこの区別を持たず「各 job を `needs` + `if:` でゲートする」と書いているが、
 matrix 展開の問題は実装で判明したもので、`flake-check` のステップ段ゲートが現行の形。

--- a/docs/infrastructure/20260802-d1230e1f-ci-pipeline.md
+++ b/docs/infrastructure/20260802-d1230e1f-ci-pipeline.md
@@ -79,14 +79,15 @@ PR 上でも走る。
 
 そのため **`test-doc-matrix` 以外の全ジョブが `github.event_name != 'push'` のジョブ段ガードを
 各自持つ**。変更検出（`changes`）は pull_request 以外のイベントを「実行する」と扱う設計なので、
-ガードが無いと main push で `flake-check` / `go-coverage` / `e2e` / `sara` が新たに走り出し、
-その `changes` 自身も消費者が全て抜ける以上ランナーを取る意味がない。トリガ段で `push` の
-対象ジョブを絞る手段が GitHub Actions に無い以上、除外はジョブ段で書くしかない。
+ガードが無いと main push で `flake-check` / `go-coverage` / `e2e` / `sara` が新たに走り出す。
+`changes` 自身も同じガードを持つ。消費者が全て抜ける以上、検出だけ走らせてもランナーを取る
+意味がないため。トリガ段で `push` の対象ジョブを絞る手段が GitHub Actions に無い以上、
+除外はジョブ段で書くしかない。
 
 `flake-check` もこのガードだけは例外にせずジョブ段へ置く。required context の生成が要求される
 のは pull_request のときだけなので、push で 3 環境のランナーを確保して即終了させる無駄の方を
-避ける。以降で述べる変更検出のゲートがステップ段を採るのはあくまで pull_request 内の話で、
-この push ガードとは別の判断になる。
+避ける。以降で述べる `changes` によるゲートがステップ段を採るのはあくまで pull_request 内の
+話で、この push ガードとは別の判断になる。
 
 docs のみの変更で 3 環境マトリクスを回すのは無駄だが、**トリガ段の `paths` フィルタは使わない**。
 required status check（→ INF-8b97573f）は生成されない check を `Expected` のままブロックするため、
@@ -94,7 +95,8 @@ required status check（→ INF-8b97573f）は生成されない check を `Expe
 action（`.github/actions/changes`）を `changes` ジョブが呼び、後続ジョブがその outputs でゲートする。
 「docs-only で nix を実走させない」意図は保ったまま、実現手段だけを移してある。
 
-ゲートの段は required かどうかで分かれる。
+この `changes` の outputs を消費する側では、ゲートの段が required かどうかで分かれる
+（`test-doc-matrix` は `changes` を使わずジョブローカルの filter を持つので、この分岐の外）。
 
 | ジョブ | ゲートの段 | 理由 |
 |---|---|---|

--- a/docs/infrastructure/20260802-d1230e1f-ci-pipeline.md
+++ b/docs/infrastructure/20260802-d1230e1f-ci-pipeline.md
@@ -16,9 +16,9 @@ satisfies:
 
 ## 範囲
 
-GitHub Actions 上の `test.yml` のうち、**flake check と E2E の系統**、およびそれらと同じ
-workflow に同居する対応表生成（`test-doc-matrix`）。同じ `test.yml` に同居する `sara` ジョブ
-だけはトレーサビリティ検証基盤（INF-659b139d）の担当で、本 item には入らない。
+GitHub Actions 上の `test.yml` のうち、**flake check と E2E の系統**と、テストを走らせないが
+同じ workflow が抱える対応表生成（`test-doc-matrix`）。同居する `sara` ジョブだけは
+トレーサビリティ検証基盤（INF-659b139d）の担当で、本 item には入らない。
 
 ## 構成
 
@@ -34,13 +34,10 @@ workflow に同居する対応表生成（`test-doc-matrix`）。同じ `test.ym
 | `test-doc-matrix` | `dev/scripts/test-doc-matrix.sh` でテスト資産 ⇔ CASE ⇔ TC ⇔ RISK の対応表を生成し、Job Summary へ出力 + artifact へアップロードする | `ubuntu-latest` |
 
 最後の `test-doc-matrix` だけはテストを走らせるジョブではなく、テスト資産とテスト文書
-（→ Issue #304）の対応を読み物として出す生成ジョブで、**main push トリガの唯一の消費者**でも
-ある。生成には `--full` のインベントリ（モジュール全体の `go test -json` と nix-unit 各ファイルの
-評価）が要り PR ごとに払うには重いため、通常は main push と `workflow_dispatch` が負担する。
-例外は生成側（`dev/scripts/**` とその入力・データファイル）を触る PR で、そのときはステップ段の
-filter が効いて当該 PR 上で走る。生成物はリポジトリへコミットしない — 生成元と併走する生成物は
-ずれるうえ、その diff を読んでも `sara` ジョブの契約テストが既に機械で強制している以上のことは
-分からない。1 MiB を超えて Job Summary が丸ごと捨てられる場合は、artifact への誘導文へ落とす。
+（→ Issue #304）の対応を読み物として出す生成ジョブ。生成物はリポジトリへコミットせず artifact
+に留める — 生成元と併走する生成物はずれるうえ、その diff を読んでも対応の崩れは別途契約テスト
+（→ INF-659b139d）が機械で強制している以上のことは分からない。Job Summary への出力は
+そのついでの表示手段で、サイズ上限に触れる場合は artifact への誘導へ退避する。
 
 マトリクスは `ubuntu-latest`=x86_64-linux / `ubuntu-24.04-arm`=aarch64-linux /
 `macos-latest`=aarch64-darwin の 3 環境。x86_64-darwin は GitHub ホストの標準ランナーが
@@ -49,9 +46,10 @@ filter が効いて当該 PR 上で走る。生成物はリポジトリへコミ
 Go の check（go-vet / golangci-lint）は `CGO_ENABLED=0` のピュア Go で実行する。nput は
 cgo 未使用のため、サンドボックスに C コンパイラを持ち込まずに検査できる。
 
-nix を使う `flake-check` / `go-coverage` / `e2e` / `test-doc-matrix` では、セットアップを composite action
-`.github/actions/setup-nix`（`cachix/install-nix-action` + `cachix/cachix-action`・各 action は
-SHA pin）に閉じる。`changes` は checkout と変更検出 action だけで完結し、nix を入れない。
+nix を使う `flake-check` / `go-coverage` / `e2e` / `test-doc-matrix` では、セットアップを
+composite action `.github/actions/setup-nix`（`cachix/install-nix-action` +
+`cachix/cachix-action`・各 action は SHA pin）に閉じる。`changes` は checkout と変更検出
+action だけで完結し、nix を入れない。
 
 本パイプラインが参照する外部 action は、`setup-nix` の中もジョブの直書きも**コミット SHA で
 固定し、可読性のための版名（`# v7.0.0` 等）をコメントで併記する**。版タグは同じ名前のまま
@@ -72,10 +70,20 @@ yq-go と sara が同時に要り、`sara` ジョブが使う軽量な `sara` de
 main への push を消費するのは対応表生成（`test-doc-matrix`）だけ。PR 経由運用（main へ直 push
 しない）が前提であり、テスト系のジョブを main push で回しても PR チェックと重複するため。
 
-そのため **push を受けないジョブは `github.event_name != 'push'` のジョブ段ガードを各自持つ**。
-変更検出（`changes`）は pull_request 以外のイベントを「実行する」と扱う設計なので、ガードが
-無いと main push で `flake-check` / `go-coverage` / `e2e` / `sara` が新たに走り出す。トリガ段で
-`push` の対象ジョブを絞る手段が GitHub Actions に無い以上、除外はジョブ段で書くしかない。
+対応表の生成は `--full` のインベントリ（モジュール全体の `go test -json` と nix-unit 各ファイルの
+評価）を要して PR ごとに払うには重く、マージ後の状態から作れば足りるため、main push と
+`workflow_dispatch` に負担させる。例外は生成側（`dev/scripts/**` とその入力・データファイル）を
+触る PR で、そのときはステップ段の filter が効いて当該 PR 上でも走る。
+
+そのため **`test-doc-matrix` 以外の全ジョブが `github.event_name != 'push'` のジョブ段ガードを
+各自持つ**。変更検出（`changes`）は pull_request 以外のイベントを「実行する」と扱う設計なので、
+ガードが無いと main push で `flake-check` / `go-coverage` / `e2e` / `sara` が新たに走り出す
+（`changes` 自身も、消費者が全て抜ける以上ランナーを取る意味がないので同じガードを持つ）。
+トリガ段で `push` の対象ジョブを絞る手段が GitHub Actions に無い以上、除外はジョブ段で書く
+しかない。`flake-check` も例外ではなくジョブ段に置く — required context の生成が要求されるのは
+pull_request のときだけなので、push で 3 環境のランナーを確保して即終了させる無駄の方を避ける。
+以降で述べる変更検出のゲートがステップ段を採るのはあくまで pull_request 内の話で、
+この push ガードとは別の判断になる。
 
 docs のみの変更で 3 環境マトリクスを回すのは無駄だが、**トリガ段の `paths` フィルタは使わない**。
 required status check（→ INF-8b97573f）は生成されない check を `Expected` のままブロックするため、
@@ -89,10 +97,6 @@ action（`.github/actions/changes`）を `changes` ジョブが呼び、後続�
 |---|---|---|
 | `flake-check` | **ステップ段**（`Setup Nix` / `Run nix flake check` の `if:`） | ジョブ段の `if:` だと matrix が展開されず、ruleset が要求する `flake-check (os, system)` の 3 context が生成されない。`Expected` のまま永久にマージがブロックされる |
 | `e2e` / `go-coverage` | ジョブ段の `if:` | skip → "Skipped" = 成功扱いになるので required check でも成立する |
-
-この区別は変更検出のゲートに限る。前述の push ガードは `flake-check` でもジョブ段に置く —
-required context の生成が要求されるのは pull_request のときだけなので、push では 3 環境の
-ランナーを確保して即終了させる無駄の方を避ける。
 
 ADR-0030 §2 はこの区別を持たず「各 job を `needs` + `if:` でゲートする」と書いているが、
 matrix 展開の問題は実装で判明したもので、`flake-check` のステップ段ゲートが現行の形。

--- a/docs/infrastructure/20260802-d1230e1f-ci-pipeline.md
+++ b/docs/infrastructure/20260802-d1230e1f-ci-pipeline.md
@@ -16,8 +16,9 @@ satisfies:
 
 ## 範囲
 
-GitHub Actions 上の `test.yml` のうち、**flake check と E2E の系統**。同じ `test.yml` に同居する
-`sara` ジョブだけはトレーサビリティ検証基盤（INF-659b139d）の担当で、本 item には入らない。
+GitHub Actions 上の `test.yml` のうち、**flake check と E2E の系統**、およびそれらと同じ
+workflow に同居する対応表生成（`test-doc-matrix`）。同じ `test.yml` に同居する `sara` ジョブ
+だけはトレーサビリティ検証基盤（INF-659b139d）の担当で、本 item には入らない。
 
 ## 構成
 
@@ -30,6 +31,16 @@ GitHub Actions 上の `test.yml` のうち、**flake check と E2E の系統**�
 | `flake-check` | `nix flake check -L`（lib のテストと engine の Go check を集約） | os×system の 3 環境マトリクス |
 | `go-coverage` | `nix build` の checkPhase が出す coverprofile を Job Summary へ表示する。計測のみで閾値ゲートを持たない（他 PR とのマージ順依存を避けるため） | `ubuntu-latest` |
 | `e2e` | CI 用 devShell から E2E ハーネスを走らせ、フィクスチャへ `nput apply` して FS / nix profile / rollback をアサートする | `ubuntu-latest` |
+| `test-doc-matrix` | `dev/scripts/test-doc-matrix.sh` でテスト資産 ⇔ CASE ⇔ TC ⇔ RISK の対応表を生成し、Job Summary へ出力 + artifact へアップロードする | `ubuntu-latest` |
+
+最後の `test-doc-matrix` だけはテストを走らせるジョブではなく、テスト資産とテスト文書
+（→ Issue #304）の対応を読み物として出す生成ジョブで、**main push トリガの唯一の消費者**でも
+ある。生成には `--full` のインベントリ（モジュール全体の `go test -json` と nix-unit 各ファイルの
+評価）が要り PR ごとに払うには重いため、通常は main push と `workflow_dispatch` が負担する。
+例外は生成側（`dev/scripts/**` とその入力・データファイル）を触る PR で、そのときはステップ段の
+filter が効いて当該 PR 上で走る。生成物はリポジトリへコミットしない — 生成元と併走する生成物は
+ずれるうえ、その diff を読んでも `sara` ジョブの契約テストが既に機械で強制している以上のことは
+分からない。1 MiB を超えて Job Summary が丸ごと捨てられる場合は、artifact への誘導文へ落とす。
 
 マトリクスは `ubuntu-latest`=x86_64-linux / `ubuntu-24.04-arm`=aarch64-linux /
 `macos-latest`=aarch64-darwin の 3 環境。x86_64-darwin は GitHub ホストの標準ランナーが
@@ -38,7 +49,7 @@ GitHub Actions 上の `test.yml` のうち、**flake check と E2E の系統**�
 Go の check（go-vet / golangci-lint）は `CGO_ENABLED=0` のピュア Go で実行する。nput は
 cgo 未使用のため、サンドボックスに C コンパイラを持ち込まずに検査できる。
 
-nix を使う `flake-check` / `go-coverage` / `e2e` では、セットアップを composite action
+nix を使う `flake-check` / `go-coverage` / `e2e` / `test-doc-matrix` では、セットアップを composite action
 `.github/actions/setup-nix`（`cachix/install-nix-action` + `cachix/cachix-action`・各 action は
 SHA pin）に閉じる。`changes` は checkout と変更検出 action だけで完結し、nix を入れない。
 
@@ -49,9 +60,11 @@ SHA pin）に閉じる。`changes` は checkout と変更検出 action だけで
 引き受ける「不変な識別子での固定」の実体になる（→ QA-d028e302）。
 
 その先のコマンド実行は 2 通りに分かれる。`flake-check` と `go-coverage` は `nix flake check -L` /
-`nix build` を素で叩き、`e2e` は `nix develop '.?dir=dev#ci' -c tests/e2e/run.sh` と CI 用 devShell
-経由でハーネスを走らせる。ハーネスは `nput` / `git` / `jq` / `niface-validate` など複数のツールと
-検証用の環境変数を必要とするため、それらを揃える CI 用 devShell を挟む。
+`nix build` を素で叩き、`e2e` と `test-doc-matrix` は devShell 経由でスクリプトを走らせる。
+`e2e` は `nix develop '.?dir=dev#ci' -c tests/e2e/run.sh`。ハーネスは `nput` / `git` / `jq` /
+`niface-validate` など複数のツールと検証用の環境変数を必要とするため、それらを揃える CI 用
+devShell を挟む。`test-doc-matrix` は `nix develop ./dev` の既定 devShell — 生成に go と jq /
+yq-go と sara が同時に要り、`sara` ジョブが使う軽量な `sara` devShell では足りない。
 
 ## トリガと変更検出
 


### PR DESCRIPTION
## 概要

`docs/infrastructure/` の横断監査（2026-08-13 の grilling）で見つかった CI 実態との乖離のうち、
INF-d1230e1f（CI パイプライン）と INF-af33c5a1（バイナリキャッシュ）の 3 件を item 側へ反映する。
**ドキュメント修正であり CI の挙動は変えていない**。`.github/workflows/**` は読むだけで、
実態が正しく item の記述が古いので item を実態へ揃えた。

1. **トリガ記述の事実誤り**（INF-d1230e1f）。従来は「`push`（branches-ignore: main）は採らない」と
   書いていたが、`test.yml` は `pull_request` + `workflow_dispatch` に加えて `push: branches: [main]`
   を持つ。このトリガを消費するのは `test-doc-matrix` ジョブだけで、他ジョブは
   `github.event_name != 'push'` のジョブ段ガードで抜ける。この push ガードという仕組み自体が
   item に一切現れていなかったため、`changes` が非 pull_request を「実行する」と扱う設計との
   関係、`flake-check` でもこのガードだけはジョブ段に置く理由を含めて書き直した。
2. **`test-doc-matrix` ジョブの記載漏れ**（INF-d1230e1f）。構成表が 4 ジョブしか挙げていなかった。
   本 item は範囲節で「`sara` ジョブだけは INF-659b139d の担当」と宣言して `test.yml` の残りを
   自分の担当としているため、担当の空白ではなく記述漏れ。表へ 1 行足し、テストを走らせない
   生成ジョブであること・生成物を artifact に留める判断・PR 上で走る例外を添えた。
3. **マトリクス共有の粒度ずれ**（INF-af33c5a1）。従来は「CI パイプラインと同一のものを踏襲する」
   とだけ書き、`setup-nix` を「丸ごと委ねる」記述と並置されるとマトリクスも共有部品に読めた。
   実態は `cachix-push.yml` へ独立にハードコードされた写しで共有機構は無いため、重複定義である
   ことと「変えるときは 2 箇所を揃える」追従点を明記した。

検証は `nix develop ./dev --command sara check` の pass（strict / warning 0）と、`test.yml` /
`cachix-push.yml` の該当行を開いての突き合わせで行った。`sara check` はグラフの整合しか見ず
散文と CI 実態のずれは検出できないため、後者を必須の確認として実施している。

## 関連 issue

Closes #356
Refs #354（同じ監査で見つかった INF-659b139d 側の乖離。並列レーンで別 PR）

## docs / ADR 影響

- concept / design / spec: 更新なし。本 PR は `docs/infrastructure/` の 2 item のみを触り、
  requirement / design / quality の内容には触れていない（risk / TC / CASE と同様、infrastructure は
  `docs/spec.md` のリンク集の対象外）。両 item の frontmatter（`id` / `type` / `depends_on` /
  `satisfies`）も変更していない。
- ADR: 追加なし。CI の挙動・方針は一切変えておらず、既存の決定を item の記述へ反映しただけ。

なお、本 PR の範囲外だが監査で次の追随漏れが残っている（いずれもタスク境界外のため未対応）:

- ADR-0027 §2 が「push トリガ削除。PR ゲートで十分」と書いたまま、`push: main` を採った現行実装と
  矛盾している。実態を追認する改訂注記が要る
- INF-659b139d の部品表が `sara` ジョブの契約テストを 3 件中 1 件しか挙げておらず、
  「検証の強度」節も `strict_mode = false` から開始のまま。これは #354 の対応範囲
