### PR TITLE
docs(agents): epic / task ラベルの定義と運用を追記

### DIFF
--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -13,6 +13,22 @@ Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all op
 
 Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
 
+## Epics
+
+An epic bundles sub-issues under a milestone-level tracking issue (#147). Epics are
+plain issues — there is no separate issue type — distinguished by convention:
+
+- **Title prefix** `epic:` (e.g. `epic: sara によるドキュメントのグラフ構造化`).
+- **Label** `epic`, plus a topical label (`enhancement` / `documentation`).
+- **Registered** in the tracking issue's epic table. That table is the index; the label
+  makes the same set queryable with `gh issue list --label epic --state all`.
+
+Apply `epic` when creating an issue that the tracking issue will list as an epic. Keep it
+on the issue after it closes — the label is how completed epics stay discoverable.
+
+An epic row in the tracking table may exist before its issue does (the table can name a
+planned epic with "issue は未起票"). Such a row has nothing to label until it is filed.
+
 ## When a skill says "publish to the issue tracker"
 
 Create a GitHub issue.

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -29,6 +29,25 @@ on the issue after it closes — the label is how completed epics stay discovera
 An epic row in the tracking table may exist before its issue does (the table can name a
 planned epic with "issue は未起票"). Such a row has nothing to label until it is filed.
 
+Epics may nest: an epic can be filed under another epic rather than directly under the
+tracking issue (#283 under #203, for example). Label it `epic` all the same — depth is
+expressed by which issue lists it, not by the label.
+
+## Tasks
+
+A task is a sub-issue under an epic or tracking issue — the unit actual work and PRs are
+scoped to. Label it `task`.
+
+- **Apply** `task` when decomposing an epic into sub-issues. This is required, not
+  optional: `label:task` is how the work units stay enumerable.
+- **Do not apply** it to a standalone issue that belongs to no epic (a one-off bug report
+  or docs fix). Those carry only topical and triage labels.
+- **Keep** it after the issue closes, same as `epic`.
+
+`tracking` / `epic` / `task` are mutually exclusive — an issue is at most one of them.
+
+PRs reference both levels: `Closes #<task>` + `Refs #<epic>`.
+
 ## When a skill says "publish to the issue tracker"
 
 Create a GitHub issue.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -13,3 +13,16 @@ The skills speak in terms of five canonical triage roles. This file maps those r
 When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
 
 Edit the right-hand column to match whatever vocabulary you actually use.
+
+## Structural labels (not triage roles)
+
+These are orthogonal to the triage roles above — they describe what an issue *is*, not
+what it needs next. An issue carries both (e.g. `epic` + `needs-triage`).
+
+| Label      | Color     | Meaning                                                        |
+| ---------- | --------- | -------------------------------------------------------------- |
+| `tracking` | (default) | Milestone-level issue aggregating epics (e.g. #147)            |
+| `epic`     | `#6f42c1` | An epic reachable from a tracking issue; bundles sub-issues    |
+
+`epic` is applied to closed epics as well, so `label:epic --state all` lists every epic
+the project has had. See `issue-tracker.md` for when to apply it.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -19,10 +19,15 @@ Edit the right-hand column to match whatever vocabulary you actually use.
 These are orthogonal to the triage roles above — they describe what an issue *is*, not
 what it needs next. An issue carries both (e.g. `epic` + `needs-triage`).
 
-| Label      | Color     | Meaning                                                        |
-| ---------- | --------- | -------------------------------------------------------------- |
-| `tracking` | (default) | Milestone-level issue aggregating epics (e.g. #147)            |
-| `epic`     | `#6f42c1` | An epic reachable from a tracking issue; bundles sub-issues    |
+| Label      | Color     | Meaning                                                     |
+| ---------- | --------- | ----------------------------------------------------------- |
+| `tracking` | (default) | Milestone-level issue aggregating epics (e.g. #147)         |
+| `epic`     | `#6f42c1` | Bundles sub-issues under a tracking issue                   |
+| `task`     | `#0e8a16` | A sub-issue under an epic or tracking issue — the work unit |
 
-`epic` is applied to closed epics as well, so `label:epic --state all` lists every epic
-the project has had. See `issue-tracker.md` for when to apply it.
+The three are mutually exclusive: an issue is at most one of them. A standalone issue
+(a one-off bug or docs fix belonging to no epic) carries none.
+
+All three are kept on closed issues, so `--state all` queries list the project's full
+history: `label:epic` for every epic it has had, `label:task` for every work unit. See
+`issue-tracker.md` for when to apply them.


### PR DESCRIPTION
## 概要

issue の階層（tracking → epic → task）をラベルで明示できるようにし、その運用を
ドキュメント化する。

これまで epic / sub-issue は「タイトルの `epic:` prefix」と「tracking 表・epic 本文への記載」
だけで表現されており、ラベルでの一覧取得ができなかった。`epic` / `task` を足したことで
`gh issue list --label <name> --state all` が索引として機能する（表は順序・依存・進捗を持つ
読み物、ラベルは機械的な絞り込み用という分担）。

closed にもラベルを残すため、完了した epic / task も後から辿れる。

**付与結果**（全 187 issue）:

| ラベル | 色 | 件数 | 内訳 |
|---|---|---|---|
| `tracking` | 既存 | 5 | #8 / #27 / #61 / #91 / #147 |
| `epic` | `#6f42c1` | 18 | OPEN 12 / CLOSED 6 |
| `task` | `#0e8a16` | 153 | OPEN 20 / CLOSED 133 |
| （なし）| — | 11 | epic に属さない単発 issue |

3 つは相互排他で、重複が無いことを確認済み。

**抽出方法**: tracking 5 件と epic 各件の本文から `#N` 参照を機械抽出し、実在する issue と
突き合わせて tracking / epic 自身を除いたものを task とした。PR 番号・ADR 番号などの
非 issue 参照は実在チェックで落ちる。

**epic ラベルの追加付与**: tracking #147 の表から辿れない epic が 2 件あったため追加した。

- **#283**（テストの欠落と検出力不備の解消）— epic #203 配下の入れ子 epic
- **#362**（src 側のプロジェクトルート実行時解決）— PR #363 の作業中に起票

**残る 11 件**（ラベルなし）は、どの tracking / epic からも参照されていない単発 issue
（#2 / #3 / #4 / #50 / #162 / #204 / #276 / #303 / #354 / #356 / #358）。規約上
`task` を付けない対象なので意図的に未付与。

**動作確認**: `--limit 300` 付きで各ラベルの件数を確認し、`task` を持つ issue に
`epic` / `tracking` が同居していないことを検証済み（既定の `--limit 30` では件数が
頭打ちになるので注意）。

## 関連 issue

なし（ラベル運用の追記のみ。epic #364 の起票時に `epic` ラベルを使ったのが発端）

## docs / ADR 影響

あり（docs のみ。配置動作・API・方針は変えていないため concept / design / spec の更新と
新規 ADR はなし）。

- `docs/agents/triage-labels.md` — 「Structural labels (not triage roles)」節を新設し、
  `tracking` / `epic` / `task` を定義。既存のトリアージ 5 役割とは**直交する**（1 つの issue に
  両方付く）ことと、3 つの構造ラベルが相互排他であることを明示した。既存の表・記述は変更していない
- `docs/agents/issue-tracker.md` — 「Epics」「Tasks」節を新設。epic の判別規約（title prefix /
  ラベル / tracking 表への登録）、epic が入れ子になりうること、task の付与必須・単発には
  付けない・close 後も残すという規約、`Closes #<task>` + `Refs #<epic>` の対応を記載した

両ファイルとも既存記述が英語のため、追記も英語で統一している。
