### PR TITLE
feat(dev): sara init を包む item 起票ラッパー sara-new を新設する

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -105,9 +105,9 @@ jobs:
 
   sara:
     # Knowledge-graph validation of docs/ (broken references, duplicate IDs,
-    # cycles) plus four contract tests: sara-id's numbering, test-doc-map's
-    # test-code ⇔ CASE mapping, risk-matrix's level derivation, and sara-gap's
-    # gap enumeration. Non-required
+    # cycles) plus five contract tests: sara-id's numbering, test-doc-map's
+    # test-code ⇔ CASE mapping, risk-matrix's level derivation, sara-gap's
+    # gap enumeration, and sara-new's item creation. Non-required
     # check with no threshold gate, same policy as go-coverage: it is NOT
     # registered as a required status check and is NOT part of the DoD, so a
     # failure reports on the PR without blocking merge. The check itself runs
@@ -210,6 +210,17 @@ jobs:
       - name: Run sara-gap contract test
         if: steps.filter.outputs.relevant != 'false'
         run: nix develop '.?dir=dev#sara' -c dev/tests/sara-gap.sh
+
+      # The item-creation contract for sara-new, the wrapper around `sara init`
+      # that enforces the <YYYYMMDD>-<full UUID>-<slug>.md filename convention
+      # (→ #367, ADR-0053). The wrapper is the structural guarantee behind that
+      # convention, so a regression here silently degrades every item raised
+      # afterwards. Wired the same way as the four above — also exposed as
+      # `checks.sara-new` for local `nix flake check ./dev`, which CI's
+      # root-flake flake-check never reaches.
+      - name: Run sara-new contract test
+        if: steps.filter.outputs.relevant != 'false'
+        run: nix develop '.?dir=dev#sara' -c dev/tests/sara-new.sh
 
   e2e:
     needs: changes

--- a/dev/flake.nix
+++ b/dev/flake.nix
@@ -191,6 +191,25 @@
             '';
           };
 
+          # sara init を包む item 起票ラッパー（→ Issue #367・epic #364）。
+          #
+          #   sara-new <型> <slug> <配置ディレクトリ> [-- <sara init のオプション>...]
+          #
+          # 実体は dev/scripts/sara-new.sh。他の dev ツール（sara-id / sara-gap）と違い
+          # 本体を flake.nix へインラインしないのは、このドキュメント管理基盤を他
+          # プロジェクトへ横展開する方針で、ファイル 1 つで持ち出せる形に保つため。
+          # ここは PATH に載せるための薄い wrapper（runtimeInputs で依存を固定する）。
+          sara-new = pkgs.writeShellApplication {
+            name = "sara-new";
+            runtimeInputs = [
+              inputs'.nur.packages.sara
+              pkgs.coreutils
+            ];
+            text = ''
+              exec bash ${./scripts/sara-new.sh} "$@"
+            '';
+          };
+
           # sara ドキュメントグラフの未カバーを 3 段で列挙する決定論コマンド。
           #
           #   sara-gap [--json]
@@ -338,6 +357,9 @@
               # uuidgen -r の供給元（util-linux）は sara-id の runtimeInputs で
               # wrapper の PATH に前置されるため、devShell 側には載せない。
               sara-id
+              # item 起票ラッパー（sara init + 規約どおりの rename）。定義は上の
+              # let 束縛を参照。sara は runtimeInputs で wrapper の PATH に前置される。
+              sara-new
               # グラフ未カバー 3 段の列挙。定義は上の let 束縛を参照。sara / jq は
               # runtimeInputs で wrapper の PATH に前置される。
               sara-gap
@@ -554,6 +576,7 @@
             packages = [
               inputs'.nur.packages.sara
               sara-id
+              sara-new
               sara-gap
               # 以下は dev/tests/sara-id.sh が使う。stdenv 既定や runner の system
               # PATH でも引けるが、checks.sara-id と揃えて明示する。

--- a/dev/flake.nix
+++ b/dev/flake.nix
@@ -203,7 +203,13 @@
             name = "sara-new";
             runtimeInputs = [
               inputs'.nur.packages.sara
+              # date / mkdir / mv / rm / tr。
               pkgs.coreutils
+              # ID 行の抽出に使う。ambient PATH 任せにすると最小環境で
+              # `sed: command not found` になる。
+              pkgs.gnused
+              # 下の text が exec するインタプリタ自身。
+              pkgs.bash
             ];
             text = ''
               exec bash ${./scripts/sara-new.sh} "$@"

--- a/dev/flake.nix
+++ b/dev/flake.nix
@@ -566,12 +566,49 @@
                 touch "$out"
               '';
 
+          # sara-new の起票契約を固定するテスト（dev/tests/sara-new.sh）。
+          # checks.sara-id と同じ二重化の意図で 2 経路から走らせる:
+          #
+          # - この checks 派生: ローカルの `nix flake check ./dev` に載せる
+          # - CI: .github/workflows/test.yml の sara job が devShells.sara 経由で実行し、
+          #   PR での退行検知を担保する（flake-check job はルート flake が対象なので
+          #   この派生は CI では回らない）
+          checks.sara-new =
+            pkgs.runCommandLocal "sara-new-test"
+              {
+                # テストが fixture リポジトリへ重ねる実物のモデル。サンドボックスには
+                # リポジトリの作業ツリーが無く、テスト側の git ルート解決も効かないため
+                # nix から store path を渡す（checks.sara-gap と同じ手法）。
+                SARA_NEW_MODEL_YAML = ../docs/model.yaml;
+                nativeBuildInputs = [
+                  sara-new
+                  # 偽 sara を作る §7 / §9 以外の経路で実 sara を使う。sara-new の
+                  # runtimeInputs で wrapper の PATH には載るが、テストは fixture の
+                  # 検証にも sara を前提とするため明示する。
+                  inputs'.nur.packages.sara
+                  pkgs.coreutils
+                  pkgs.findutils
+                  pkgs.gnugrep
+                  # テストが sara-new の出力から id / file を抜くのに使う。
+                  pkgs.gnused
+                  # 走査基点の解決に使う（SARA_NEW_MODEL_YAML が先に解決するので
+                  # 実際には使われないが、無いと `git rev-parse` が command not found
+                  # となり診断が濁る）。
+                  pkgs.git
+                ];
+              }
+              ''
+                bash ${./tests/sara-new.sh}
+                touch "$out"
+              '';
+
           # CI の sara check 専用シェル。default devShell は nput のビルドと
           # dogfood の shellHook（nput apply skills）を伴うため、docs 変更だけの PR で
           # それらを走らせないよう sara 単体に絞る。NUR 由来の store path を
           # yasunori0418.cachix.org から引くだけで済む。
-          # CI からは sara check・dev/tests/sara-id.sh・dev/tests/test-doc-map.sh・
-          # dev/tests/risk-matrix.sh・dev/tests/sara-gap.sh をこのシェルで実行する。
+          # CI からは sara check・dev/tests/sara-id.sh・dev/tests/sara-new.sh・
+          # dev/tests/test-doc-map.sh・dev/tests/risk-matrix.sh・dev/tests/sara-gap.sh を
+          # このシェルで実行する。
           devShells.sara = pkgs.mkShell {
             packages = [
               inputs'.nur.packages.sara
@@ -584,6 +621,10 @@
               pkgs.git
               pkgs.gnused
               pkgs.coreutils
+              # dev/tests/sara-new.sh が fixture の残存ファイルを数えるのに使う
+              # （runner の system PATH でも引けるが、checks.sara-new と揃えて明示する）。
+              pkgs.findutils
+              pkgs.gnugrep
               # dev/tests/test-doc-map.sh が CASE frontmatter の target を読むのに使う。
               # yq-go（mikefarah/yq v4）。nixpkgs の `yq` は python-yq（別実装・別構文）
               # なので取り違えないこと。テスト側も実装を確認して落とす。

--- a/dev/scripts/sara-new.sh
+++ b/dev/scripts/sara-new.sh
@@ -29,7 +29,7 @@ usage: sara-new <type> <slug> <dir> [-- <sara init options>...]
 
   type   sara の型名（requirement / test_case / test-case …）。ADR は対象外
   slug   ファイル名に使う短い識別子（英小文字・数字・ハイフン）
-  dir    配置ディレクトリ（リポジトリルートからの相対。無ければ作る）
+  dir    配置ディレクトリ（カレントからの相対。無ければ作る）
   --     以降を sara init へそのまま渡す（--name / --specification …）
 
 例:
@@ -101,11 +101,21 @@ mkdir -p "$dir"
 # sara 呼び出しの seam（契約テストが失敗経路を決定論的に再現するため）。
 sara_cmd=${SARA_NEW_SARA:-sara}
 
-# 採番前の仮ファイル。sara init はパスを先に要求するので避けられない。プロセス ID を
-# 混ぜて並列起動でも衝突させない。以降のどの失敗経路でも残さない（trap で回収する）。
-tmp_file="$dir/.sara-new-$$.md"
-cleanup() { rm -f "$tmp_file"; }
+# 採番前の仮ファイル。sara init はパスを先に要求するので避けられない。
+#
+# 仮ファイルの stem を slug にするのは見た目の問題ではなく必須。sara init は --name を
+# 渡さないとき**ファイル名の stem から item の name を導出する**ため、`.sara-new-<pid>.md`
+# のような名前で作ると frontmatter へ name: ".sara-new-12345" が焼き付き、rename しても
+# 直らない（sara check はこの値を検証しないので機械検出にも載らない）。stem を slug に
+# しておけば、--name を渡さない既定経路でも意味のある name が入る。
+#
+# 並列起動どうしの衝突回避は stem ではなく、プロセス ID を持つ隠しディレクトリで担う。
+tmp_dir="$dir/.sara-new-$$"
+tmp_file="$tmp_dir/$slug.md"
+cleanup() { rm -rf "$tmp_dir"; }
 trap cleanup EXIT
+
+mkdir -p "$tmp_dir"
 
 # 装飾（色・絵文字）を落として ID 行を安定させる。sara は診断も stdout へ出すため
 # stderr は素通しにして、失敗時の診断を握り潰さない。
@@ -124,6 +134,19 @@ fi
 # ファイル名は正式 ID の UUID 部（prefix を除いた全体）を使う。8 文字の省略形は
 # 使わない（→ ADR-0053）。prefix は型ごとに違うので `<PREFIX>-` を前方から落とす。
 uuid=${id#*-}
+
+# 剥がした残りが UUID の形をしているか検査する。最初のハイフンで切る以上、prefix 自体が
+# ハイフンを含む（TEST-CASE 等）と UUID 部が `CASE-<uuid>` に化けるが、それを黙って
+# ファイル名にすると規約違反の item が静かに生まれる。横展開先で prefix 規約が違っても
+# 気付けるよう、ここで落とす（型ごとの prefix 一覧は持たない方針なので、形で見る）。
+case "$uuid" in
+  [0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]-[0-9a-f][0-9a-f][0-9a-f][0-9a-f]-[0-9a-f][0-9a-f][0-9a-f][0-9a-f]-[0-9a-f][0-9a-f][0-9a-f][0-9a-f]-[0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]) ;;
+  *)
+    echo "sara-new: 採番 ID から UUID 部を取り出せなかった: $id" >&2
+    echo "sara-new: prefix がハイフンを含む型は本ラッパーの対象外（ID 形式を確認すること）" >&2
+    exit 1
+    ;;
+esac
 
 target="$dir/$(date +%Y%m%d)-$uuid-$slug.md"
 

--- a/dev/scripts/sara-new.sh
+++ b/dev/scripts/sara-new.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# sara init を包む item 起票ラッパー（→ Issue #367・epic #364）。
+#
+#   sara-new <型> <slug> <配置ディレクトリ> [-- <sara init のオプション>...]
+#
+# sara init はファイルパスを先に渡す設計なので、素で使うと「仮の名前で init →
+# 採番された ID を見てファイル名を組み立て直す」工程が毎回発生する。本スクリプトは
+# それを 1 コマンドに畳み、ファイル名規約 `<YYYYMMDD>-<フル UUID>-<slug>.md`
+# （→ ADR-0053）を機械的に守らせる。8 文字省略形をファイル名に混ぜる事故は、CI の
+# 検査ではなくこの生成の機械化で構造的に防ぐ。
+#
+# ID は一切生成しない。UUID の採番・重複可否は sara init（model.yaml の id_format）
+# の領分で、ここは `sara init` の出力から採番済み ID を読むだけ。型 → prefix の
+# 対応表も持たない（model.yaml との二重管理を作らないため）。
+#
+# ADR は対象外。id_format が {prefix}-{seq:04} で連番を維持する唯一の型であり
+# （→ ADR-0053）、`sara init adr <パス>` の直呼びに委ねる。
+#
+# 他プロジェクトへ横展開する前提でこのファイル 1 つに閉じている。依存は POSIX の
+# 範囲 + sara 本体のみで、リポジトリ固有の知識（型ごとの配置先など）は持たない
+# （配置ディレクトリを引数で受けるのはそのため。docs/test/<対象>/ のように型から
+# 導けない配置があり、対応表を持てば必ず実体とずれる）。
+
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'EOF'
+usage: sara-new <type> <slug> <dir> [-- <sara init options>...]
+
+  type   sara の型名（requirement / test_case / test-case …）。ADR は対象外
+  slug   ファイル名に使う短い識別子（英小文字・数字・ハイフン）
+  dir    配置ディレクトリ（リポジトリルートからの相対。無ければ作る）
+  --     以降を sara init へそのまま渡す（--name / --specification …）
+
+例:
+  sara-new requirement lock-ordering docs/requirements
+  sara-new test-case engine-lock docs/test/atomicity -- --name "engine の lock"
+
+出力（機械可読の 2 行）:
+  id:   採番された正式 ID
+  file: 起票したファイルのパス
+
+注: ADR は連番を維持するため対象外（sara init adr <パス> を直接使う）
+EOF
+}
+
+# help は引数個数に先立って処理する（`sara-new --help extra` も help になる）。
+case "${1-}" in
+  -h | --help)
+    usage
+    exit 0
+    ;;
+esac
+
+if [ "$#" -lt 3 ]; then
+  usage
+  exit 2
+fi
+
+type=$1
+slug=$2
+dir=$3
+shift 3
+
+# `--` 以降は sara init への透過オプション。区切りが無ければ余分な引数は受け付けない
+# （タイポした引数が黙って捨てられるより、使い方を出して落とす）。
+if [ "$#" -gt 0 ]; then
+  if [ "$1" != "--" ]; then
+    usage
+    exit 2
+  fi
+  shift
+fi
+
+# ADR は連番を維持する（→ ADR-0053）。ここで UUID 名のファイルを作ると
+# docs/adr/README.md の運用・既存 ADR の相互参照が壊れる。
+case "$type" in
+  adr | ADR)
+    echo "sara-new: ADR は連番を維持する（sara init adr <パス> を直接使う）" >&2
+    exit 2
+    ;;
+esac
+
+# slug はファイル名へそのまま入る。`../` やスペースを通すと配置先が黙ってずれるため、
+# 起票の前に弾く（弾いた時点でファイルは 1 つも作られていない）。
+case "$slug" in
+  "" | *[!a-z0-9-]*)
+    echo "sara-new: slug は英小文字・数字・ハイフンのみ（実際: '$slug'）" >&2
+    exit 2
+    ;;
+esac
+
+# sara init のサブコマンド名はハイフン（test-case）だが、model.yaml の型名は
+# アンダースコア（test_case）で、規約文書も後者で書かれている。どちらで呼んでも
+# 通るよう `_` を `-` へ寄せる。型の一覧は持たない（未知の名前は sara init が
+# 「unrecognized subcommand」で弾く）ので、model.yaml との二重管理にはならない。
+init_subcommand=$(printf '%s' "$type" | tr '_' '-')
+
+mkdir -p "$dir"
+
+# sara 呼び出しの seam（契約テストが失敗経路を決定論的に再現するため）。
+sara_cmd=${SARA_NEW_SARA:-sara}
+
+# 採番前の仮ファイル。sara init はパスを先に要求するので避けられない。プロセス ID を
+# 混ぜて並列起動でも衝突させない。以降のどの失敗経路でも残さない（trap で回収する）。
+tmp_file="$dir/.sara-new-$$.md"
+cleanup() { rm -f "$tmp_file"; }
+trap cleanup EXIT
+
+# 装飾（色・絵文字）を落として ID 行を安定させる。sara は診断も stdout へ出すため
+# stderr は素通しにして、失敗時の診断を握り潰さない。
+init_out=$("$sara_cmd" --no-color --no-emoji init "$init_subcommand" "$tmp_file" "$@")
+
+# `  ID:   <ID>` 行から採番結果を採る。読めなければ rename せず落とす
+# （sara の出力形式が変わったとき、UUID 部が空のファイル名を黙って作らせない）。
+id=$(printf '%s\n' "$init_out" | sed -n 's/^[[:space:]]*ID:[[:space:]]*\([^[:space:]]*\).*/\1/p' | head -n 1)
+
+if [ -z "$id" ]; then
+  echo "sara-new: sara init の出力から ID を読めなかった（sara の出力形式が変わった可能性）" >&2
+  printf '%s\n' "$init_out" >&2
+  exit 1
+fi
+
+# ファイル名は正式 ID の UUID 部（prefix を除いた全体）を使う。8 文字の省略形は
+# 使わない（→ ADR-0053）。prefix は型ごとに違うので `<PREFIX>-` を前方から落とす。
+uuid=${id#*-}
+
+target="$dir/$(date +%Y%m%d)-$uuid-$slug.md"
+
+# 起票済み item を潰さない。UUID が違えば通常は衝突しないが、衝突したときに
+# 黙って上書きするより失敗させる。
+if [ -e "$target" ]; then
+  echo "sara-new: 出力先が既に存在する: $target" >&2
+  exit 1
+fi
+
+mv "$tmp_file" "$target"
+
+printf 'id: %s\n' "$id"
+printf 'file: %s\n' "$target"

--- a/dev/scripts/test-inventory.sh
+++ b/dev/scripts/test-inventory.sh
@@ -92,6 +92,7 @@ FLAKE_CHECKS=(
   dev:checks.risk-matrix
   dev:checks.sara-gap
   dev:checks.sara-id
+  dev:checks.sara-new
   dev:checks.test-doc-map
 )
 

--- a/dev/tests/sara-new.sh
+++ b/dev/tests/sara-new.sh
@@ -16,10 +16,12 @@
 #   4b. 型名はアンダースコア表記（model.yaml・規約文書）とハイフン表記
 #       （sara init のサブコマンド名）の両方を受ける
 #   5.  slug の検査（空・不正文字は exit 2 で、ファイルを残さない）
-#   5b. 英小文字・数字・ハイフンの slug は受理する（境界の有効側）
+#   5b. 英小文字・数字・ハイフンの slug を受理し、ファイル名へ入れる（境界の有効側）
 #   6.  ADR は連番維持のため exit 2 で拒否する
 #   7.  sara init の失敗（exit 3）をそのまま伝播し、一時ファイルを残さない（seam で再現）
 #   8.  sara init の出力から ID を読めなければ exit 1 で落ち、一時ファイルを残さない（seam）
+#   8b. 採番 ID から UUID 部を取り出せなければ exit 1 で落ちる（prefix がハイフンを
+#       含む型。正常系では踏まない経路なので seam で押さえる）
 #   9.  出力先が既存なら上書きせず exit 1（起票済み item を潰さない）
 #   10. 引数の異常系（引数不足 = 2 / -- 区切り無しの余分引数 = 2 / --help = 0）
 #
@@ -94,7 +96,10 @@ status_capture=0
 run_sara_new() {
   local root="$1"
   shift
+  # 固定パスを毎回切って使い回す。stderr_capture が保持するのは常に「直前の 1 回分」
+  # で、呼び出しは全て逐次（並列化していない）。
   local err_file="$work/stderr"
+  : >"$err_file"
   stdout_capture="$(cd "$root" && "$@" 2>"$err_file")" && status_capture=0 || status_capture=$?
   stderr_capture="$(cat "$err_file" 2>/dev/null)"
 }
@@ -258,11 +263,14 @@ for bad in "" "has space" "../escape" "a/b" "UPPER" "under_score" "dot.ted"; do
 done
 
 # 有効側（英小数字とハイフン）は通す。境界の両側を押さえる。
+# 受理するだけでなく、その slug がファイル名へ入ることまで見る（exit 0 だけだと
+# slug がファイル名から欠落・変形する退行を通してしまう）。
 run_sara_new "$repo5" sara-new requirement a1-b2 docs/requirements
-if [[ "$status_capture" -eq 0 ]]; then
-  pass "英小文字・数字・ハイフンの slug は受理する（境界の有効側）"
+valid_slug_file="$(field file)"
+if [[ "$status_capture" -eq 0 && "$valid_slug_file" == *-a1-b2.md ]]; then
+  pass "英小文字・数字・ハイフンの slug を受理し、ファイル名へ入れる（境界の有効側）"
 else
-  fault "英小文字・数字・ハイフンの slug は受理する（実際: exit=$status_capture）"
+  fault "英小文字・数字・ハイフンの slug を受理し、ファイル名へ入れる（exit=$status_capture file=$valid_slug_file）"
 fi
 
 # --- 6. ADR は連番維持のため拒否する ------------------------------------------
@@ -297,9 +305,14 @@ fake_sara="$work/fake-sara"
 # exit 126 になる（sara-id.sh の偽 uuidgen と同じ事情）。
 #
 # 偽 sara は「SUT がどう呼んだか」も検査する。ここを素通しにすると、SUT が
-# --no-color を落とす・型名の `_` → `-` 変換を壊す・仮ファイルのパス組み立てを
-# 変えるといった退行を偽 sara が吸収して緑のまま通してしまう（実 sara を使う
-# §1〜§4 は装飾なしの環境だと --no-color の欠落を検知できない）。
+# --no-color を落とす・仮ファイルの stem を slug 以外にするといった退行を偽 sara が
+# 吸収して緑のまま通してしまう（実 sara を使う §1〜§4 は、装飾を出さない環境だと
+# --no-color の欠落を検知できない）。
+#
+# 仮ファイルの stem を検査するのは、それが name の由来だから。stem == slug は
+# 「--name 未指定でも意味のある name が入る」の前提だが、§1b の name アサーションは
+# 「sara が stem から name を導出する」という sara 側の挙動に依存している。sara が
+# その導出をやめると §1b は緑のまま検知力だけ失うので、ここで stem 自体も固定する。
 #
 # 加えて、失敗する前に必ず仮ファイルを作る。作らないと「一時ファイルを残さない」の
 # アサーションは SUT の trap cleanup が壊れていても自明に成立する（空振りする）。
@@ -323,6 +336,15 @@ if [ -z "$tmp_path" ]; then
   echo "fake sara: 仮ファイルのパスが渡っていない" >&2
   exit 92
 fi
+
+# stem が slug と一致すること（name の由来なので規約の一部）。
+tmp_stem=${tmp_path##*/}
+tmp_stem=${tmp_stem%.md}
+if [ "$tmp_stem" != "$SARA_NEW_FAKE_WANT_STEM" ]; then
+  echo "fake sara: 仮ファイルの stem が想定と違う（期待 $SARA_NEW_FAKE_WANT_STEM 実際 $tmp_stem）" >&2
+  exit 94
+fi
+
 : >"$tmp_path"
 
 case "${SARA_NEW_FAKE_MODE:-}" in
@@ -352,7 +374,7 @@ chmod +x "$fake_sara"
 repo7="$work/initfail"
 make_repo "$repo7"
 run_sara_new "$repo7" env SARA_NEW_SARA="$fake_sara" SARA_NEW_FAKE_MODE=fail \
-  SARA_NEW_FAKE_WANT_TYPE=requirement \
+  SARA_NEW_FAKE_WANT_TYPE=requirement SARA_NEW_FAKE_WANT_STEM=boom \
   sara-new requirement boom docs/requirements
 initfail_status="$status_capture"
 initfail_files="$(find "$repo7/docs" -name '*.md' -type f | wc -l)"
@@ -379,7 +401,7 @@ fi
 repo8="$work/noid"
 make_repo "$repo8"
 run_sara_new "$repo8" env SARA_NEW_SARA="$fake_sara" SARA_NEW_FAKE_MODE=no-id \
-  SARA_NEW_FAKE_WANT_TYPE=requirement \
+  SARA_NEW_FAKE_WANT_TYPE=requirement SARA_NEW_FAKE_WANT_STEM=noid \
   sara-new requirement noid docs/requirements
 noid_status="$status_capture"
 noid_files="$(find "$repo8/docs" -name '*.md' -type f | wc -l)"
@@ -394,6 +416,34 @@ if [[ "$noid_files" -eq 0 && "$noid_tmp" -eq 0 ]]; then
   pass "ID 読み取り失敗時に一時ファイル・一時ディレクトリを残さない"
 else
   fault "ID 読み取り失敗時に一時ファイル・一時ディレクトリを残さない（md $noid_files 件 / tmp $noid_tmp 件）"
+fi
+
+# --- 8b. UUID 部を取り出せなければ失敗する ------------------------------------
+#
+# SUT は正式 ID の最初のハイフンで切って UUID 部を得る。prefix 自体がハイフンを
+# 含む型（横展開先で TEST-CASE のような prefix を定義した場合）では残りが
+# `CASE-<uuid>` に化けるので、UUID の形をしているか検査して落とす。この分岐が
+# 無いと規約違反のファイル名が黙って生まれる（本ラッパーの存在意義そのものが
+# 崩れる）ため、正常系では踏まない経路だが seam で押さえる。
+
+repo8b="$work/badprefix"
+make_repo "$repo8b"
+run_sara_new "$repo8b" env SARA_NEW_SARA="$fake_sara" SARA_NEW_FAKE_MODE=id \
+  SARA_NEW_FAKE_ID='TEST-CASE-11111111-2222-4333-8444-555555555555' \
+  SARA_NEW_FAKE_WANT_TYPE=requirement SARA_NEW_FAKE_WANT_STEM=badprefix \
+  sara-new requirement badprefix docs/requirements
+badprefix_status="$status_capture"
+badprefix_files="$(find "$repo8b/docs" -name '*.md' -type f | wc -l)"
+badprefix_tmp="$(find "$repo8b/docs" -name '.sara-new-*' | wc -l)"
+if [[ "$badprefix_status" -eq 1 ]]; then
+  pass "UUID 部を取り出せない ID なら exit 1 で落ちる"
+else
+  fault "UUID 部を取り出せない ID なら exit 1 で落ちる（実際: exit=$badprefix_status stderr: $stderr_capture）"
+fi
+if [[ "$badprefix_files" -eq 0 && "$badprefix_tmp" -eq 0 ]]; then
+  pass "UUID 部の検査で落ちたときにファイル・一時ディレクトリを残さない"
+else
+  fault "UUID 部の検査で落ちたときにファイル・一時ディレクトリを残さない（md $badprefix_files 件 / tmp $badprefix_tmp 件）"
 fi
 
 # --- 9. 既存ファイルを上書きしない --------------------------------------------
@@ -415,19 +465,29 @@ else
   first_id="$(sed -n 's/^id: "\(.*\)"$/\1/p' "$repo9/$first_file")"
   run_sara_new "$repo9" env SARA_NEW_SARA="$fake_sara" SARA_NEW_FAKE_MODE=id \
     SARA_NEW_FAKE_ID="$first_id" SARA_NEW_FAKE_WANT_TYPE=requirement \
+    SARA_NEW_FAKE_WANT_STEM=dup \
     sara-new requirement dup docs/requirements
   clobber_status="$status_capture"
   clobber_files="$(find "$repo9/docs/requirements" -name '*.md' -type f | wc -l)"
   clobber_tmp="$(find "$repo9/docs" -name '.sara-new-*' | wc -l)"
-  if [[ "$clobber_status" -eq 1 ]]; then
+
+  # 衝突は「日付 + UUID + slug」が揃って初めて成立する。1 件目と 2 件目の間で
+  # 日付が変わると rename 先が別名になり、衝突しないのが正しい挙動になる。
+  # §1 と同じ日付境界の配慮だが、こちらは前提が崩れるので判定自体を見送る
+  # （偽陽性で赤くするより、成立しなかったことを明示する）。
+  first_date="${first_file##*/}"
+  first_date="${first_date%%-*}"
+  if [[ "$first_date" != "$(date +%Y%m%d)" ]]; then
+    pass "§9 は日付が跨いだため判定を見送る（衝突の前提が崩れる）"
+  elif [[ "$clobber_status" -eq 1 ]]; then
     pass "rename 先が既存なら exit 1 で拒否する"
+    if [[ "$clobber_files" -eq 1 && "$clobber_tmp" -eq 0 ]]; then
+      pass "既存ファイルを上書きせず、一時ファイル・一時ディレクトリも残さない"
+    else
+      fault "既存ファイルを上書きせず、一時ファイル・一時ディレクトリも残さない（md $clobber_files 件 / tmp $clobber_tmp 件）"
+    fi
   else
-    fault "rename 先が既存なら exit 1 で拒否する（実際: exit=$clobber_status）"
-  fi
-  if [[ "$clobber_files" -eq 1 && "$clobber_tmp" -eq 0 ]]; then
-    pass "既存ファイルを上書きせず、一時ファイル・一時ディレクトリも残さない"
-  else
-    fault "既存ファイルを上書きせず、一時ファイル・一時ディレクトリも残さない（md $clobber_files 件 / tmp $clobber_tmp 件）"
+    fault "rename 先が既存なら exit 1 で拒否する（実際: exit=$clobber_status stderr: $stderr_capture）"
   fi
 fi
 

--- a/dev/tests/sara-new.sh
+++ b/dev/tests/sara-new.sh
@@ -1,0 +1,375 @@
+#!/usr/bin/env bash
+# sara-new（sara init を包む item 起票ラッパー）の検証。
+#
+# 実行:
+#   nix develop ./dev -c dev/tests/sara-new.sh   # devShell から直接
+#   nix flake check ./dev                         # checks.sara-new 経由
+#
+# 検証対象（→ Issue #367・epic #364）。番号は下の節見出しに対応する:
+#   1.  item を起票し `<YYYYMMDD>-<フル UUID>-<slug>.md` へ rename する。
+#       frontmatter の id と、ファイル名の UUID 部が一致する
+#   2.  採番 ID とファイルパスを機械可読な 2 行（id: / file:）で出力する
+#   3.  sara init へオプションを透過する（-- 以降）
+#   4.  配置ディレクトリを作る（無ければ mkdir -p）。型名はアンダースコア表記
+#       （model.yaml・規約文書）とハイフン表記（sara init のサブコマンド名）の両方を受ける
+#   5.  slug の検査（空・不正文字は exit 2 で、ファイルを残さない）
+#   6.  ADR は連番維持のため exit 2 で拒否する
+#   7.  sara init が失敗したら非ゼロで落ち、一時ファイルを残さない（seam で再現）
+#   8.  sara init の出力から ID を読めなければ失敗し、一時ファイルを残さない（seam）
+#   9.  出力先が既存なら上書きせず exit 1（起票済み item を潰さない）
+#   10. 引数の異常系（引数不足 = 2 / --help = 0）
+#
+# 担保できる範囲: ラッパーの責務（パス組み立て・rename・ID 読み取り・異常系の後片付け）。
+# UUID の採番そのもの・8 文字 prefix の重複可否は検証しない（sara init の領分であり、
+# ラッパーは採番を持たない設計 → Issue #367）。
+#
+# fixture は実物の docs/model.yaml を重ねて作る（sara-gap.sh と同じく写しを持たない。
+# 型や必須フィールドが変わって fixture が実モデルに合わなくなれば、このテストが落ちて
+# 追随を要求する）。
+#
+# -e は使わない。sara-id.sh / sara-gap.sh と同じく「1 回の実行で全失敗を報告する」
+# 集計方式のため（-e があると最初の非ゼロ終了で以降のアサーションが走らない）。
+set -uo pipefail
+
+fail=0
+pass() { printf 'ok   - %s\n' "$1"; }
+fault() {
+  printf 'FAIL - %s\n' "$1"
+  fail=1
+}
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+# モデルの正本は実リポジトリの docs/model.yaml。解決は 2 経路: checks.sara-new の
+# サンドボックスは作業ツリーが無いので nix が SARA_NEW_MODEL_YAML で store path を
+# 渡す。devShell / CI 経路は git ルート基準。どちらでも解決できなければ skip せず
+# 失敗させる（黙って素通りさせない）。
+model_yaml="${SARA_NEW_MODEL_YAML:-}"
+contract_root="$(git rev-parse --show-toplevel 2>/dev/null || printf '.')"
+[[ -f "$model_yaml" ]] || model_yaml="$contract_root/docs/model.yaml"
+if [[ ! -f "$model_yaml" ]]; then
+  fault "docs/model.yaml を解決できない（model.yaml=$model_yaml）"
+  exit 1
+fi
+
+# sara が動くリポジトリの最小形（sara.toml + model.yaml + 空の docs/）を作る。
+# 各節が互いの残骸に依存しないよう、節ごとに作り直せる関数にしておく。
+make_repo() {
+  local root="$1"
+  mkdir -p "$root/docs"
+  cp "$model_yaml" "$root/docs/model.yaml"
+  cat >"$root/sara.toml" <<'EOF'
+model_schema = "docs/model.yaml"
+
+[repositories]
+paths = ["./docs"]
+EOF
+}
+
+uuid_re='[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}'
+
+# SUT を repo のルートで呼ぶ（sara.toml を既定パスで引かせるため）。
+# 非ゼロ終了でもここでは落とさない（判定は各アサーションが行う）。
+stdout_capture=""
+status_capture=0
+run_sara_new() {
+  local root="$1"
+  shift
+  stdout_capture="$(cd "$root" && "$@" 2>/dev/null)" && status_capture=0 || status_capture=$?
+}
+
+field() { printf '%s\n' "$stdout_capture" | sed -n "s/^$1:[[:space:]]*//p"; }
+
+# --- 1. 起票と rename ---------------------------------------------------------
+
+repo="$work/basic"
+make_repo "$repo"
+run_sara_new "$repo" sara-new requirement lock-ordering docs/requirements
+
+created="$(field file)"
+created_id="$(field id)"
+
+if [[ "$status_capture" -eq 0 ]]; then
+  pass "起票に成功して exit 0"
+else
+  fault "起票に成功して exit 0（実際: exit=$status_capture 出力: $stdout_capture）"
+fi
+
+if [[ "$created_id" =~ ^REQ-${uuid_re}$ ]]; then
+  pass "採番 ID が <PREFIX>-<フル UUIDv4> 形式"
+else
+  fault "採番 ID が <PREFIX>-<フル UUIDv4> 形式（実際: $created_id）"
+fi
+
+uuid="${created_id#REQ-}"
+today="$(date +%Y%m%d)"
+want_name="$today-$uuid-lock-ordering.md"
+
+if [[ "$created" == "docs/requirements/$want_name" ]]; then
+  pass "ファイル名が <YYYYMMDD>-<フル UUID>-<slug>.md で、出力の file: と一致する"
+else
+  fault "ファイル名が <YYYYMMDD>-<フル UUID>-<slug>.md（期待: docs/requirements/$want_name 実際: $created）"
+fi
+
+if [[ -f "$repo/docs/requirements/$want_name" ]]; then
+  pass "その名前のファイルが実在する"
+else
+  fault "その名前のファイルが実在する（$repo/docs/requirements/$want_name が無い）"
+fi
+
+# frontmatter の id と、ファイル名に埋めた UUID が一致する（rename 先の組み立てに
+# 別の UUID を混ぜていないことを固定する）。
+if grep -q "id: \"$created_id\"" "$repo/docs/requirements/$want_name" 2>/dev/null; then
+  pass "frontmatter の id とファイル名の UUID が同じ item を指す"
+else
+  fault "frontmatter の id とファイル名の UUID が同じ item を指す（id=$created_id）"
+fi
+
+# 一時ファイル名が残っていない（rename であって copy ではない）。
+leftovers="$(find "$repo/docs/requirements" -name '*.md' -type f | wc -l)"
+if [[ "$leftovers" -eq 1 ]]; then
+  pass "生成物は 1 ファイルだけ（一時ファイルを残さない）"
+else
+  fault "生成物は 1 ファイルだけ（実際: $leftovers 件）"
+fi
+
+# --- 2. 出力形式 --------------------------------------------------------------
+#
+# 呼び出し側（人・エージェント）が採番結果を機械的に拾えることを固定する。
+# sara init の装飾付き出力をそのまま流すと、後続の自動処理が壊れる。
+
+if [[ "$(printf '%s\n' "$stdout_capture" | grep -c '^id: \|^file: ')" -eq 2 ]]; then
+  pass "id: / file: の 2 行を出力する"
+else
+  fault "id: / file: の 2 行を出力する（実際: $stdout_capture）"
+fi
+
+# --- 3. sara init へのオプション透過 ------------------------------------------
+#
+# ラッパーが sara init のオプション面を塞ぐと、起票のたびに手で frontmatter を
+# 埋め直すことになる（--name / --specification 等）。`--` 以降を透過する。
+
+repo3="$work/passthru"
+make_repo "$repo3"
+run_sara_new "$repo3" sara-new requirement passthru docs/requirements -- --name "透過テスト"
+passthru_file="$(field file)"
+if [[ "$status_capture" -eq 0 ]] && grep -q 'name: "透過テスト"' "$repo3/$passthru_file" 2>/dev/null; then
+  pass "-- 以降のオプションを sara init へ透過する"
+else
+  fault "-- 以降のオプションを sara init へ透過する（exit=$status_capture file=$passthru_file）"
+fi
+
+# --- 4. 配置ディレクトリの自動作成と型名の表記ゆれ ----------------------------
+#
+# 新しい区分（docs/test/<対象>/ 等）を起こすとき、mkdir を別途踏ませない。
+# あわせて型名のアンダースコア表記（model.yaml・規約文書の書き方）を受けることを
+# 固定する。sara init のサブコマンドはハイフン（test-case）なので、素通しにすると
+# 規約文書どおりに叩いた呼び出しが unrecognized subcommand で落ちる。
+
+repo4="$work/mkdir"
+make_repo "$repo4"
+run_sara_new "$repo4" sara-new test_case first-case docs/test/new-area
+mkdir_file="$(field file)"
+if [[ "$status_capture" -eq 0 && -f "$repo4/$mkdir_file" && "$mkdir_file" == docs/test/new-area/* ]]; then
+  pass "存在しない配置ディレクトリを作って起票する（型名はアンダースコア表記）"
+else
+  fault "存在しない配置ディレクトリを作って起票する（exit=$status_capture file=$mkdir_file）"
+fi
+
+# ハイフン表記（sara init のサブコマンド名そのもの）も同じ型として通る。
+run_sara_new "$repo4" sara-new test-case second-case docs/test/new-area
+hyphen_file="$(field file)"
+hyphen_id="$(field id)"
+if [[ "$status_capture" -eq 0 && "$hyphen_id" == CASE-* ]]; then
+  pass "型名のハイフン表記も同じ型として通る（test-case → CASE）"
+else
+  fault "型名のハイフン表記も同じ型として通る（exit=$status_capture id=$hyphen_id file=$hyphen_file）"
+fi
+
+# --- 5. slug の検査 -----------------------------------------------------------
+#
+# slug はファイル名へそのまま入る。`../` やスペースを通すと配置先が黙ってずれる。
+# 検査は起票の前に行い、失敗時にファイルを残さない。
+
+repo5="$work/slug"
+make_repo "$repo5"
+for bad in "" "has space" "../escape" "UPPER" "under_score"; do
+  run_sara_new "$repo5" sara-new requirement "$bad" docs/requirements
+  bad_status="$status_capture"
+  bad_files="$(find "$repo5/docs" -name '*.md' -type f ! -name 'model.yaml' | wc -l)"
+  if [[ "$bad_status" -eq 2 && "$bad_files" -eq 0 ]]; then
+    pass "不正な slug '$bad' を exit 2 で拒否し、ファイルを残さない"
+  else
+    fault "不正な slug '$bad' を exit 2 で拒否し、ファイルを残さない（exit=$bad_status 残 $bad_files 件）"
+  fi
+done
+
+# 有効側（英小数字とハイフン）は通す。境界の両側を押さえる。
+run_sara_new "$repo5" sara-new requirement a1-b2 docs/requirements
+if [[ "$status_capture" -eq 0 ]]; then
+  pass "英小文字・数字・ハイフンの slug は受理する（境界の有効側）"
+else
+  fault "英小文字・数字・ハイフンの slug は受理する（実際: exit=$status_capture）"
+fi
+
+# --- 6. ADR は連番維持のため拒否する ------------------------------------------
+#
+# ADR だけ id_format が {prefix}-{seq:04} で、ファイル名規約も別（→ ADR-0053）。
+# ラッパーは UUID 採番の 10 型だけを担い、ADR は `sara init adr` 直呼びへ委ねる。
+
+repo6="$work/adr"
+make_repo "$repo6"
+run_sara_new "$repo6" sara-new adr some-decision docs/adr
+adr_status="$status_capture"
+adr_files="$(find "$repo6/docs" -name '*.md' -type f ! -name 'model.yaml' | wc -l)"
+if [[ "$adr_status" -eq 2 ]]; then
+  pass "ADR は exit 2 で拒否する（連番維持）"
+else
+  fault "ADR は exit 2 で拒否する（実際: exit=$adr_status）"
+fi
+if [[ "$adr_files" -eq 0 ]]; then
+  pass "ADR 拒否時はファイルを作らない"
+else
+  fault "ADR 拒否時はファイルを作らない（実際: $adr_files 件）"
+fi
+
+# --- 7. sara init の失敗を伝播する --------------------------------------------
+#
+# sara 呼び出しは seam（SARA_NEW_SARA）経由。失敗を握り潰して 0 を返すと、
+# 起票できていないのに成功したと誤認する。
+
+fake_sara="$work/fake-sara"
+# shebang は実行中の bash の絶対パスを埋め込む。`#!/usr/bin/env bash` だと
+# nix のビルドサンドボックス（checks.sara-new 経由）に /usr/bin/env が無く
+# exit 126 になる（sara-id.sh の偽 uuidgen と同じ事情）。
+{
+  printf '#!%s\n' "$BASH"
+  cat <<'FAKE'
+# 引数末尾がファイルパスとは限らないので、`init` の次の次を拾わず、
+# SARA_NEW_FAKE_MODE に応じた振る舞いだけを行う。
+case "$SARA_NEW_FAKE_MODE" in
+  fail)
+    echo "fake sara: boom" >&2
+    exit 3
+    ;;
+  no-id)
+    echo "[OK] Created something with Requirement template"
+    exit 0
+    ;;
+esac
+FAKE
+} >"$fake_sara"
+chmod +x "$fake_sara"
+
+repo7="$work/initfail"
+make_repo "$repo7"
+run_sara_new "$repo7" env SARA_NEW_SARA="$fake_sara" SARA_NEW_FAKE_MODE=fail \
+  sara-new requirement boom docs/requirements
+initfail_status="$status_capture"
+initfail_files="$(find "$repo7/docs" -name '*.md' -type f ! -name 'model.yaml' | wc -l)"
+if [[ "$initfail_status" -ne 0 ]]; then
+  pass "sara init が失敗したら非ゼロで落ちる"
+else
+  fault "sara init が失敗したら非ゼロで落ちる（実際: exit=$initfail_status）"
+fi
+if [[ "$initfail_files" -eq 0 ]]; then
+  pass "sara init 失敗時に一時ファイルを残さない"
+else
+  fault "sara init 失敗時に一時ファイルを残さない（実際: $initfail_files 件）"
+fi
+
+# --- 8. ID を読めなければ失敗する ---------------------------------------------
+#
+# sara の出力形式が変わった場合。ID 無しで rename を続行すると、規約に反した
+# ファイル名（UUID 部が空）の item が黙って生まれる。
+
+repo8="$work/noid"
+make_repo "$repo8"
+run_sara_new "$repo8" env SARA_NEW_SARA="$fake_sara" SARA_NEW_FAKE_MODE=no-id \
+  sara-new requirement noid docs/requirements
+noid_status="$status_capture"
+noid_files="$(find "$repo8/docs" -name '*.md' -type f ! -name 'model.yaml' | wc -l)"
+if [[ "$noid_status" -ne 0 ]]; then
+  pass "sara init の出力から ID を読めなければ非ゼロで落ちる"
+else
+  fault "sara init の出力から ID を読めなければ非ゼロで落ちる（実際: exit=$noid_status）"
+fi
+if [[ "$noid_files" -eq 0 ]]; then
+  pass "ID 読み取り失敗時に一時ファイルを残さない"
+else
+  fault "ID 読み取り失敗時に一時ファイルを残さない（実際: $noid_files 件）"
+fi
+
+# --- 9. 既存ファイルを上書きしない --------------------------------------------
+#
+# 同じ日・同じ slug で 2 度叩いても UUID が違うので通常は衝突しないが、
+# rename 先が既存なら潰さず落とす（起票済み item の消失を構造的に避ける）。
+
+repo9="$work/clobber"
+make_repo "$repo9"
+run_sara_new "$repo9" sara-new requirement dup docs/requirements
+first_file="$(field file)"
+if [[ -z "$first_file" ]]; then
+  fault "§9 の前提（1 件目の起票）が失敗した（$stdout_capture）"
+else
+  # 2 件目の rename 先を 1 件目と同じにするため、SARA_NEW_SARA で 1 件目と
+  # 同じ ID を返す偽 sara を使う（実 sara は毎回別の UUID を採るため衝突を作れない）。
+  clobber_sara="$work/clobber-sara"
+  {
+    printf '#!%s\n' "$BASH"
+    cat <<'FAKE'
+# 最終引数を初期化対象のファイルとみなして空ファイルを作り、既定の ID を返す。
+for target; do :; done
+: >"$target"
+printf '  ID:   %s\n' "$SARA_NEW_FAKE_ID"
+FAKE
+  } >"$clobber_sara"
+  chmod +x "$clobber_sara"
+
+  first_id="$(sed -n 's/^id: "\(.*\)"$/\1/p' "$repo9/$first_file")"
+  run_sara_new "$repo9" env SARA_NEW_SARA="$clobber_sara" SARA_NEW_FAKE_ID="$first_id" \
+    sara-new requirement dup docs/requirements
+  clobber_status="$status_capture"
+  clobber_files="$(find "$repo9/docs/requirements" -name '*.md' -type f | wc -l)"
+  if [[ "$clobber_status" -eq 1 ]]; then
+    pass "rename 先が既存なら exit 1 で拒否する"
+  else
+    fault "rename 先が既存なら exit 1 で拒否する（実際: exit=$clobber_status）"
+  fi
+  if [[ "$clobber_files" -eq 1 ]]; then
+    pass "既存ファイルを上書きせず、一時ファイルも残さない"
+  else
+    fault "既存ファイルを上書きせず、一時ファイルも残さない（実際: $clobber_files 件）"
+  fi
+fi
+
+# --- 10. 引数の異常系 ---------------------------------------------------------
+
+repo10="$work/args"
+make_repo "$repo10"
+
+run_sara_new "$repo10" sara-new
+if [[ "$status_capture" -eq 2 ]]; then
+  pass "引数なしは exit 2"
+else
+  fault "引数なしは exit 2（実際: exit=$status_capture）"
+fi
+
+# 境界は 2/3 の間（型・slug・dir の 3 個が必須）。無効側を押さえる
+# （有効側は §1 が押さえている）。
+run_sara_new "$repo10" sara-new requirement only-slug
+if [[ "$status_capture" -eq 2 ]]; then
+  pass "配置ディレクトリを省くと exit 2（境界の無効側）"
+else
+  fault "配置ディレクトリを省くと exit 2（実際: exit=$status_capture）"
+fi
+
+run_sara_new "$repo10" sara-new --help
+if [[ "$status_capture" -eq 0 ]]; then
+  pass "--help は exit 0"
+else
+  fault "--help は exit 0（実際: exit=$status_capture）"
+fi
+
+exit "$fail"

--- a/dev/tests/sara-new.sh
+++ b/dev/tests/sara-new.sh
@@ -8,16 +8,23 @@
 # 検証対象（→ Issue #367・epic #364）。番号は下の節見出しに対応する:
 #   1.  item を起票し `<YYYYMMDD>-<フル UUID>-<slug>.md` へ rename する。
 #       frontmatter の id と、ファイル名の UUID 部が一致する
+#   1b. --name 未指定の既定経路でも name が slug 由来になる（仮ファイル名が漏れない）
+#   1c. 一時ファイル・一時ディレクトリ（.sara-new-*）を残さない
 #   2.  採番 ID とファイルパスを機械可読な 2 行（id: / file:）で出力する
 #   3.  sara init へオプションを透過する（-- 以降）
-#   4.  配置ディレクトリを作る（無ければ mkdir -p）。型名はアンダースコア表記
-#       （model.yaml・規約文書）とハイフン表記（sara init のサブコマンド名）の両方を受ける
+#   4.  配置ディレクトリを作る（無ければ mkdir -p）
+#   4b. 型名はアンダースコア表記（model.yaml・規約文書）とハイフン表記
+#       （sara init のサブコマンド名）の両方を受ける
 #   5.  slug の検査（空・不正文字は exit 2 で、ファイルを残さない）
+#   5b. 英小文字・数字・ハイフンの slug は受理する（境界の有効側）
 #   6.  ADR は連番維持のため exit 2 で拒否する
-#   7.  sara init が失敗したら非ゼロで落ち、一時ファイルを残さない（seam で再現）
-#   8.  sara init の出力から ID を読めなければ失敗し、一時ファイルを残さない（seam）
+#   7.  sara init の失敗（exit 3）をそのまま伝播し、一時ファイルを残さない（seam で再現）
+#   8.  sara init の出力から ID を読めなければ exit 1 で落ち、一時ファイルを残さない（seam）
 #   9.  出力先が既存なら上書きせず exit 1（起票済み item を潰さない）
-#   10. 引数の異常系（引数不足 = 2 / --help = 0）
+#   10. 引数の異常系（引数不足 = 2 / -- 区切り無しの余分引数 = 2 / --help = 0）
+#
+# 偽 sara（seam）は SUT の呼び出し形（--no-color --no-emoji init <型> <仮パス>）も
+# 検査する。素通しの偽物にすると、SUT がその形を崩す退行を吸収して緑のまま通る。
 #
 # 担保できる範囲: ラッパーの責務（パス組み立て・rename・ID 読み取り・異常系の後片付け）。
 # UUID の採番そのもの・8 文字 prefix の重複可否は検証しない（sara init の領分であり、
@@ -69,14 +76,27 @@ EOF
 
 uuid_re='[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}'
 
+# SUT が PATH に無いまま走ると、異常系の節（§5〜§10）は「非ゼロで落ちる」「ファイルを
+# 残さない」がどちらも自明に成立して緑になる。全節の前提としてここで存在を確かめ、
+# 無ければ以降のアサーションを回さず落とす（偽の緑を構造的に防ぐ）。
+if ! command -v sara-new >/dev/null 2>&1; then
+  fault "SUT（sara-new）が PATH に無い。devShell 経由で実行すること"
+  exit 1
+fi
+
 # SUT を repo のルートで呼ぶ（sara.toml を既定パスで引かせるため）。
 # 非ゼロ終了でもここでは落とさない（判定は各アサーションが行う）。
+# stderr は捨てずに拾う（失敗時の fault メッセージに SUT の診断を載せるため。
+# 捨てると CI ログに終了コードしか残らず原因追跡がリポジトリ外から不可能になる）。
 stdout_capture=""
+stderr_capture=""
 status_capture=0
 run_sara_new() {
   local root="$1"
   shift
-  stdout_capture="$(cd "$root" && "$@" 2>/dev/null)" && status_capture=0 || status_capture=$?
+  local err_file="$work/stderr"
+  stdout_capture="$(cd "$root" && "$@" 2>"$err_file")" && status_capture=0 || status_capture=$?
+  stderr_capture="$(cat "$err_file" 2>/dev/null)"
 }
 
 field() { printf '%s\n' "$stdout_capture" | sed -n "s/^$1:[[:space:]]*//p"; }
@@ -85,7 +105,11 @@ field() { printf '%s\n' "$stdout_capture" | sed -n "s/^$1:[[:space:]]*//p"; }
 
 repo="$work/basic"
 make_repo "$repo"
+# 日付は SUT 実行の前後で採る。実行中に日付が変わる（深夜 0 時跨ぎ）と、後だけで
+# 採った期待値が実際のファイル名と食い違って偽陽性になる。
+date_before="$(date +%Y%m%d)"
 run_sara_new "$repo" sara-new requirement lock-ordering docs/requirements
+date_after="$(date +%Y%m%d)"
 
 created="$(field file)"
 created_id="$(field id)"
@@ -93,7 +117,7 @@ created_id="$(field id)"
 if [[ "$status_capture" -eq 0 ]]; then
   pass "起票に成功して exit 0"
 else
-  fault "起票に成功して exit 0（実際: exit=$status_capture 出力: $stdout_capture）"
+  fault "起票に成功して exit 0（実際: exit=$status_capture 出力: $stdout_capture stderr: $stderr_capture）"
 fi
 
 if [[ "$created_id" =~ ^REQ-${uuid_re}$ ]]; then
@@ -103,30 +127,46 @@ else
 fi
 
 uuid="${created_id#REQ-}"
-today="$(date +%Y%m%d)"
-want_name="$today-$uuid-lock-ordering.md"
+want_before="docs/requirements/$date_before-$uuid-lock-ordering.md"
+want_after="docs/requirements/$date_after-$uuid-lock-ordering.md"
 
-if [[ "$created" == "docs/requirements/$want_name" ]]; then
+if [[ "$created" == "$want_before" || "$created" == "$want_after" ]]; then
   pass "ファイル名が <YYYYMMDD>-<フル UUID>-<slug>.md で、出力の file: と一致する"
 else
-  fault "ファイル名が <YYYYMMDD>-<フル UUID>-<slug>.md（期待: docs/requirements/$want_name 実際: $created）"
+  fault "ファイル名が <YYYYMMDD>-<フル UUID>-<slug>.md（期待: $want_before 実際: $created）"
 fi
 
-if [[ -f "$repo/docs/requirements/$want_name" ]]; then
+if [[ -n "$created" && -f "$repo/$created" ]]; then
   pass "その名前のファイルが実在する"
 else
-  fault "その名前のファイルが実在する（$repo/docs/requirements/$want_name が無い）"
+  fault "その名前のファイルが実在する（$repo/$created が無い）"
 fi
 
 # frontmatter の id と、ファイル名に埋めた UUID が一致する（rename 先の組み立てに
 # 別の UUID を混ぜていないことを固定する）。
-if grep -q "id: \"$created_id\"" "$repo/docs/requirements/$want_name" 2>/dev/null; then
+if grep -q "id: \"$created_id\"" "$repo/$created" 2>/dev/null; then
   pass "frontmatter の id とファイル名の UUID が同じ item を指す"
 else
   fault "frontmatter の id とファイル名の UUID が同じ item を指す（id=$created_id）"
 fi
 
-# 一時ファイル名が残っていない（rename であって copy ではない）。
+# --name を渡さない既定経路で、item の name が意味のある値になる。
+#
+# sara init は --name 未指定のときファイル名の stem から name を導出するため、
+# ラッパーが仮ファイルを `.sara-new-<pid>.md` のような名前で作ると
+# name: ".sara-new-12345" が frontmatter へ焼き付き、rename しても直らない
+# （sara check はこの値を検証しないので機械検出にも載らない）。実運用の主経路が
+# これなので、§3 の --name 透過とは別に固定する。
+actual_name="$(sed -n 's/^name: "\(.*\)"$/\1/p' "$repo/$created" 2>/dev/null)"
+if [[ "$actual_name" == "lock-ordering" ]]; then
+  pass "--name 未指定でも name が slug 由来になる（仮ファイル名が漏れない）"
+else
+  fault "--name 未指定でも name が slug 由来になる（期待: lock-ordering 実際: $actual_name）"
+fi
+
+# 一時ファイル・一時ディレクトリが残っていない（rename であって copy ではない）。
+# 件数だけでなく名指しでも見る（件数だけだと「tmp が残る」と「rename 先が増える」を
+# 区別できず、失敗時の診断が数字しか出ない）。
 leftovers="$(find "$repo/docs/requirements" -name '*.md' -type f | wc -l)"
 if [[ "$leftovers" -eq 1 ]]; then
   pass "生成物は 1 ファイルだけ（一時ファイルを残さない）"
@@ -134,15 +174,25 @@ else
   fault "生成物は 1 ファイルだけ（実際: $leftovers 件）"
 fi
 
+tmp_left="$(find "$repo/docs" -name '.sara-new-*' | wc -l)"
+if [[ "$tmp_left" -eq 0 ]]; then
+  pass "一時ファイル・一時ディレクトリ（.sara-new-*）を残さない"
+else
+  fault "一時ファイル・一時ディレクトリ（.sara-new-*）を残さない（実際: $tmp_left 件）"
+fi
+
 # --- 2. 出力形式 --------------------------------------------------------------
 #
 # 呼び出し側（人・エージェント）が採番結果を機械的に拾えることを固定する。
 # sara init の装飾付き出力をそのまま流すと、後続の自動処理が壊れる。
 
-if [[ "$(printf '%s\n' "$stdout_capture" | grep -c '^id: \|^file: ')" -eq 2 ]]; then
-  pass "id: / file: の 2 行を出力する"
+# 2 行を合計で数えると、id: が 2 行出て file: が 0 行でも通ってしまう。個別に見る。
+id_lines="$(printf '%s\n' "$stdout_capture" | grep -c '^id: ')"
+file_lines="$(printf '%s\n' "$stdout_capture" | grep -c '^file: ')"
+if [[ "$id_lines" -eq 1 && "$file_lines" -eq 1 ]]; then
+  pass "id: / file: をそれぞれ 1 行ずつ出力する"
 else
-  fault "id: / file: の 2 行を出力する（実際: $stdout_capture）"
+  fault "id: / file: をそれぞれ 1 行ずつ出力する（id: $id_lines 行 file: $file_lines 行）"
 fi
 
 # --- 3. sara init へのオプション透過 ------------------------------------------
@@ -192,12 +242,14 @@ fi
 # slug はファイル名へそのまま入る。`../` やスペースを通すと配置先が黙ってずれる。
 # 検査は起票の前に行い、失敗時にファイルを残さない。
 
+# 無効側の同値クラスは、実装の文字集合検査のどれが効いたか切り分けられるよう分ける
+# （`../escape` は `.` と `/` を同時に含むので、単独では切り分けにならない）。
 repo5="$work/slug"
 make_repo "$repo5"
-for bad in "" "has space" "../escape" "UPPER" "under_score"; do
+for bad in "" "has space" "../escape" "a/b" "UPPER" "under_score" "dot.ted"; do
   run_sara_new "$repo5" sara-new requirement "$bad" docs/requirements
   bad_status="$status_capture"
-  bad_files="$(find "$repo5/docs" -name '*.md' -type f ! -name 'model.yaml' | wc -l)"
+  bad_files="$(find "$repo5/docs" -name '*.md' -type f | wc -l)"
   if [[ "$bad_status" -eq 2 && "$bad_files" -eq 0 ]]; then
     pass "不正な slug '$bad' を exit 2 で拒否し、ファイルを残さない"
   else
@@ -222,7 +274,7 @@ repo6="$work/adr"
 make_repo "$repo6"
 run_sara_new "$repo6" sara-new adr some-decision docs/adr
 adr_status="$status_capture"
-adr_files="$(find "$repo6/docs" -name '*.md' -type f ! -name 'model.yaml' | wc -l)"
+adr_files="$(find "$repo6/docs" -name '*.md' -type f | wc -l)"
 if [[ "$adr_status" -eq 2 ]]; then
   pass "ADR は exit 2 で拒否する（連番維持）"
 else
@@ -243,12 +295,37 @@ fake_sara="$work/fake-sara"
 # shebang は実行中の bash の絶対パスを埋め込む。`#!/usr/bin/env bash` だと
 # nix のビルドサンドボックス（checks.sara-new 経由）に /usr/bin/env が無く
 # exit 126 になる（sara-id.sh の偽 uuidgen と同じ事情）。
+#
+# 偽 sara は「SUT がどう呼んだか」も検査する。ここを素通しにすると、SUT が
+# --no-color を落とす・型名の `_` → `-` 変換を壊す・仮ファイルのパス組み立てを
+# 変えるといった退行を偽 sara が吸収して緑のまま通してしまう（実 sara を使う
+# §1〜§4 は装飾なしの環境だと --no-color の欠落を検知できない）。
+#
+# 加えて、失敗する前に必ず仮ファイルを作る。作らないと「一時ファイルを残さない」の
+# アサーションは SUT の trap cleanup が壊れていても自明に成立する（空振りする）。
 {
   printf '#!%s\n' "$BASH"
   cat <<'FAKE'
-# 引数末尾がファイルパスとは限らないので、`init` の次の次を拾わず、
-# SARA_NEW_FAKE_MODE に応じた振る舞いだけを行う。
-case "$SARA_NEW_FAKE_MODE" in
+# 引数契約: sara-new は必ず `--no-color --no-emoji init <型> <仮パス> [透過分...]`
+# の順で呼ぶ。違えば偽 sara 自身が非ゼロで落ちて、テスト側の期待コードと食い違う。
+if [ "$1" != "--no-color" ] || [ "$2" != "--no-emoji" ] || [ "$3" != "init" ]; then
+  echo "fake sara: 想定外の呼ばれ方: $*" >&2
+  exit 90
+fi
+if [ "$4" != "$SARA_NEW_FAKE_WANT_TYPE" ]; then
+  echo "fake sara: 型が想定と違う（期待 $SARA_NEW_FAKE_WANT_TYPE 実際 $4）" >&2
+  exit 91
+fi
+
+# 仮ファイル（第 5 引数）を実際に作る。SUT の後片付けを検証可能にするため。
+tmp_path=$5
+if [ -z "$tmp_path" ]; then
+  echo "fake sara: 仮ファイルのパスが渡っていない" >&2
+  exit 92
+fi
+: >"$tmp_path"
+
+case "${SARA_NEW_FAKE_MODE:-}" in
   fail)
     echo "fake sara: boom" >&2
     exit 3
@@ -256,6 +333,16 @@ case "$SARA_NEW_FAKE_MODE" in
   no-id)
     echo "[OK] Created something with Requirement template"
     exit 0
+    ;;
+  id)
+    printf '  ID:   %s\n' "$SARA_NEW_FAKE_ID"
+    exit 0
+    ;;
+  *)
+    # モード指定漏れを成功扱いにしない（この偽 sara を別の節から流用したとき、
+    # 指定漏れが黙って exit 0 になると偽の緑になる）。
+    echo "fake sara: 未知のモード: ${SARA_NEW_FAKE_MODE:-（未設定）}" >&2
+    exit 93
     ;;
 esac
 FAKE
@@ -265,18 +352,23 @@ chmod +x "$fake_sara"
 repo7="$work/initfail"
 make_repo "$repo7"
 run_sara_new "$repo7" env SARA_NEW_SARA="$fake_sara" SARA_NEW_FAKE_MODE=fail \
+  SARA_NEW_FAKE_WANT_TYPE=requirement \
   sara-new requirement boom docs/requirements
 initfail_status="$status_capture"
-initfail_files="$(find "$repo7/docs" -name '*.md' -type f ! -name 'model.yaml' | wc -l)"
-if [[ "$initfail_status" -ne 0 ]]; then
-  pass "sara init が失敗したら非ゼロで落ちる"
+initfail_files="$(find "$repo7/docs" -name '*.md' -type f | wc -l)"
+initfail_tmp="$(find "$repo7/docs" -name '.sara-new-*' | wc -l)"
+# 期待コードは具体値で押さえる。`-ne 0` だと SUT 不在（127）・偽 sara の引数契約違反
+# （90 番台）まで pass してしまう。SUT は set -e 配下で sara の非ゼロをそのまま伝播する
+# ので、偽 sara の exit 3 がそのまま出る。
+if [[ "$initfail_status" -eq 3 ]]; then
+  pass "sara init の失敗（exit 3）をそのまま伝播する"
 else
-  fault "sara init が失敗したら非ゼロで落ちる（実際: exit=$initfail_status）"
+  fault "sara init の失敗（exit 3）をそのまま伝播する（実際: exit=$initfail_status stderr: $stderr_capture）"
 fi
-if [[ "$initfail_files" -eq 0 ]]; then
-  pass "sara init 失敗時に一時ファイルを残さない"
+if [[ "$initfail_files" -eq 0 && "$initfail_tmp" -eq 0 ]]; then
+  pass "sara init 失敗時に一時ファイル・一時ディレクトリを残さない"
 else
-  fault "sara init 失敗時に一時ファイルを残さない（実際: $initfail_files 件）"
+  fault "sara init 失敗時に一時ファイル・一時ディレクトリを残さない（md $initfail_files 件 / tmp $initfail_tmp 件）"
 fi
 
 # --- 8. ID を読めなければ失敗する ---------------------------------------------
@@ -287,18 +379,21 @@ fi
 repo8="$work/noid"
 make_repo "$repo8"
 run_sara_new "$repo8" env SARA_NEW_SARA="$fake_sara" SARA_NEW_FAKE_MODE=no-id \
+  SARA_NEW_FAKE_WANT_TYPE=requirement \
   sara-new requirement noid docs/requirements
 noid_status="$status_capture"
-noid_files="$(find "$repo8/docs" -name '*.md' -type f ! -name 'model.yaml' | wc -l)"
-if [[ "$noid_status" -ne 0 ]]; then
-  pass "sara init の出力から ID を読めなければ非ゼロで落ちる"
+noid_files="$(find "$repo8/docs" -name '*.md' -type f | wc -l)"
+noid_tmp="$(find "$repo8/docs" -name '.sara-new-*' | wc -l)"
+# ID を読めない経路は SUT 自身の判断で落ちるので exit 1（具体値で押さえる）。
+if [[ "$noid_status" -eq 1 ]]; then
+  pass "sara init の出力から ID を読めなければ exit 1 で落ちる"
 else
-  fault "sara init の出力から ID を読めなければ非ゼロで落ちる（実際: exit=$noid_status）"
+  fault "sara init の出力から ID を読めなければ exit 1 で落ちる（実際: exit=$noid_status stderr: $stderr_capture）"
 fi
-if [[ "$noid_files" -eq 0 ]]; then
-  pass "ID 読み取り失敗時に一時ファイルを残さない"
+if [[ "$noid_files" -eq 0 && "$noid_tmp" -eq 0 ]]; then
+  pass "ID 読み取り失敗時に一時ファイル・一時ディレクトリを残さない"
 else
-  fault "ID 読み取り失敗時に一時ファイルを残さない（実際: $noid_files 件）"
+  fault "ID 読み取り失敗時に一時ファイル・一時ディレクトリを残さない（md $noid_files 件 / tmp $noid_tmp 件）"
 fi
 
 # --- 9. 既存ファイルを上書きしない --------------------------------------------
@@ -315,32 +410,24 @@ if [[ -z "$first_file" ]]; then
 else
   # 2 件目の rename 先を 1 件目と同じにするため、SARA_NEW_SARA で 1 件目と
   # 同じ ID を返す偽 sara を使う（実 sara は毎回別の UUID を採るため衝突を作れない）。
-  clobber_sara="$work/clobber-sara"
-  {
-    printf '#!%s\n' "$BASH"
-    cat <<'FAKE'
-# 最終引数を初期化対象のファイルとみなして空ファイルを作り、既定の ID を返す。
-for target; do :; done
-: >"$target"
-printf '  ID:   %s\n' "$SARA_NEW_FAKE_ID"
-FAKE
-  } >"$clobber_sara"
-  chmod +x "$clobber_sara"
-
+  # 引数契約を持つ共通の偽 sara を id モードで使い回す（専用の緩い偽物を別に置くと、
+  # そちらだけ SUT の呼び出し形の退行を吸収してしまう）。
   first_id="$(sed -n 's/^id: "\(.*\)"$/\1/p' "$repo9/$first_file")"
-  run_sara_new "$repo9" env SARA_NEW_SARA="$clobber_sara" SARA_NEW_FAKE_ID="$first_id" \
+  run_sara_new "$repo9" env SARA_NEW_SARA="$fake_sara" SARA_NEW_FAKE_MODE=id \
+    SARA_NEW_FAKE_ID="$first_id" SARA_NEW_FAKE_WANT_TYPE=requirement \
     sara-new requirement dup docs/requirements
   clobber_status="$status_capture"
   clobber_files="$(find "$repo9/docs/requirements" -name '*.md' -type f | wc -l)"
+  clobber_tmp="$(find "$repo9/docs" -name '.sara-new-*' | wc -l)"
   if [[ "$clobber_status" -eq 1 ]]; then
     pass "rename 先が既存なら exit 1 で拒否する"
   else
     fault "rename 先が既存なら exit 1 で拒否する（実際: exit=$clobber_status）"
   fi
-  if [[ "$clobber_files" -eq 1 ]]; then
-    pass "既存ファイルを上書きせず、一時ファイルも残さない"
+  if [[ "$clobber_files" -eq 1 && "$clobber_tmp" -eq 0 ]]; then
+    pass "既存ファイルを上書きせず、一時ファイル・一時ディレクトリも残さない"
   else
-    fault "既存ファイルを上書きせず、一時ファイルも残さない（実際: $clobber_files 件）"
+    fault "既存ファイルを上書きせず、一時ファイル・一時ディレクトリも残さない（md $clobber_files 件 / tmp $clobber_tmp 件）"
   fi
 fi
 
@@ -363,6 +450,17 @@ if [[ "$status_capture" -eq 2 ]]; then
   pass "配置ディレクトリを省くと exit 2（境界の無効側）"
 else
   fault "配置ディレクトリを省くと exit 2（実際: exit=$status_capture）"
+fi
+
+# `--` 区切り無しの余分な引数は受け付けない（タイポした引数が黙って捨てられるより、
+# 使い方を出して落とす設計）。この分岐を削っても §3 の正常系は通るので個別に押さえる。
+run_sara_new "$repo10" sara-new requirement stray-arg docs/requirements extra
+stray_status="$status_capture"
+stray_files="$(find "$repo10/docs" -name '*.md' -type f | wc -l)"
+if [[ "$stray_status" -eq 2 && "$stray_files" -eq 0 ]]; then
+  pass "-- 区切り無しの余分な引数は exit 2 で拒否し、ファイルを残さない"
+else
+  fault "-- 区切り無しの余分な引数は exit 2 で拒否し、ファイルを残さない（exit=$stray_status 残 $stray_files 件）"
 fi
 
 run_sara_new "$repo10" sara-new --help

--- a/dev/tests/test-doc-exclusions.tsv
+++ b/dev/tests/test-doc-exclusions.tsv
@@ -24,4 +24,5 @@ checks.nix-unit	nix-unit アグリゲータ。leaf の tests/nix-unit/*.nix を 
 dev:checks.risk-matrix	risk の level 導出マトリクス整合の契約テスト。検査対象は nput の振る舞いではなく docs のスコアリング規約なので TC / CASE へ展開しない
 dev:checks.sara-gap	sara-gap のギャップ列挙契約。検査対象は nput の振る舞いではなくドキュメントグラフ運用の道具なので TC / CASE へ展開しない（sara-id と同じ扱い）
 dev:checks.sara-id	sara-id の採番契約。TP-d7da4065 のみを持ち TC / CASE へ展開しない
+dev:checks.sara-new	sara-new の起票契約。他プロジェクトへ横展開する基盤ツールで nput の振る舞いを検査しないため test_plan も TC / CASE も持たない（→ Issue #367）
 dev:checks.test-doc-map	CASE ⇔ テストコード対応の契約テスト自身。自分を CASE で覆うと循環する


### PR DESCRIPTION
## 概要

`sara init` を包む item 起票ラッパー `sara-new` を新設する。

`sara init` はファイルパスを先に渡す設計なので、素で使うと「仮の名前で init → 採番された
ID を見てファイル名を組み立て直す」工程が起票のたびに発生する。本ラッパーはそれを 1
コマンドに畳み、ファイル名規約 `<YYYYMMDD>-<フル UUID>-<slug>.md`（→ ADR-0053）を機械的に
守らせる。8 文字省略形の混入は CI 検査ではなく**この生成の機械化で構造的に防ぐ**方針
（epic #364 の grilling Q8）で、本ラッパーがその構造保証の実体になる。

設計上の要点:

- **ID を一切生成しない**。UUID の採番・重複可否は `sara init`（model.yaml の `id_format`）の
  領分で、ラッパーは出力の `ID:` 行を読むだけ。型 → prefix の対応表も持たないため
  model.yaml との二重管理を作らない（`sara-id` との最大の違い）
- **配置ディレクトリは引数で受ける**。型から導けない配置（`docs/test/<対象>/`）があり、
  対応表を持てば必ず実体とずれるため
- **ADR は対象外**。連番を維持する唯一の型なので `sara init adr` の直呼びへ委ねる
- **本体は `dev/scripts/sara-new.sh` の独立ファイル**。他プロジェクトへ横展開する方針
  （issue 記載）のため flake.nix へインラインせず、`dev/flake.nix` 側は PATH に載せる薄い
  wrapper に留める

型名は `test_case`（model.yaml・規約文書の表記）と `test-case`（`sara init` のサブコマンド名）の
両方を受ける。素通しにすると規約文書どおりに叩いた呼び出しが `unrecognized subcommand` で
落ちるため。

レビューで見つけて直した欠陥が 2 件ある。

- **仮ファイル名が item の `name` へ焼き付く**: `sara init` は `--name` 未指定のときファイル名の
  stem から `name` を導出するため、`.sara-new-<pid>.md` で作ると frontmatter に
  `name: ".sara-new-12345"` が残り、rename しても直らなかった。`sara check` はこの値を検証
  しないので機械検出にも載らない。仮ファイルの stem を slug にし、並列起動の衝突回避は
  プロセス ID を持つ隠しディレクトリへ移した
- **wrapper の `runtimeInputs` に `sed`(gnused) と `bash` が無い**: ambient PATH に依存しており、
  最小 PATH では ID 行の抽出が `sed: command not found` で落ちた

## 関連 issue

Closes #367
Refs #364

## docs / ADR 影響

**なし**（新規 ADR・concept / design / spec の更新とも不要）。

本 PR は ADR-0053（先行 PR #370 = #366 で起票）で決まった方針の実装で、新たな方針転換や
trade-off は含まない。規約文書（CLAUDE.md・`docs/adr/README.md`）へ `sara-new` の使い方を
書き込むのは後続の #368（全面移行）の担当で、本 PR がラッパー名を `sara-new` に確定させる
ことがその前提になる。

test_plan item も起こさない（issue 記載・grilling Q9）。他プロジェクトへ横展開する基盤
ツールであり nput の振る舞いを検査しないため、`dev/tests/test-doc-exclusions.tsv` へ理由付きで
登録し、`dev/scripts/test-inventory.sh` の `FLAKE_CHECKS` にも `dev:checks.sara-new` を足して
`test-doc-map.sh` §5 の突合へ載せている。

動作確認:

- `dev/tests/sara-new.sh` — 34 アサーション green（devShell 経路 / `checks.sara-new` の nix
  サンドボックス経路の両方）
- `dev/tests/test-doc-map.sh` — green（除外表・静的リストの整合）
- **変異テスト 5 種**でテストの検知力を実証: `--no-color` 削除 → 3 件 FAIL / `trap cleanup`
  削除 → 4 件 FAIL / 仮ファイル stem 変更 → 5 件 FAIL / UUID 形状ガード削除 → 2 件 FAIL
- 最小 PATH（wrapper の bin のみ）での実機起動 green
- 実機で 1 件起票し、ファイル名・`name` とも規約どおりに組み上がることを確認（probe は削除済み）

CI の sara job へも実行ステップを追加した（`checks.sara-new` は `nix flake check ./dev` 用で、
CI の flake-check job はルート flake を対象にするため回らない）。
